### PR TITLE
Switch to lib names exported from ClangConfig.cmake

### DIFF
--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -1411,14 +1411,21 @@ llvm_map_components_to_libnames(LLVM_LIBS
   support
 )
 
-set(CLANG_LIBS
-  clangAST
-  clangBasic
-  clangFrontend
-  clangParse
-  clangLex
-  clangRewrite
-)
+if (${LLVM_LINK_LLVM_DYLIB})
+  set(CLANG_LIBS
+    clang-cpp
+    LLVM
+  )
+else()
+  set(CLANG_LIBS
+    clangAST
+    clangBasic
+    clangFrontend
+    clangParse
+    clangLex
+    clangRewrite
+  )
+endif()
 
 add_executable(clang_delta
   ${CMAKE_BINARY_DIR}/config.h

--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -1412,8 +1412,12 @@ llvm_map_components_to_libnames(LLVM_LIBS
 )
 
 set(CLANG_LIBS
-  clang-cpp
-  LLVM
+  clangAST
+  clangBasic
+  clangFrontend
+  clangParse
+  clangLex
+  clangRewrite
 )
 
 add_executable(clang_delta


### PR DESCRIPTION
It is not always the case that there exits a unified libLLVM-file, if you build
clang yourself it may be split into multiple libraries. Thus it is better to
import the clang dependencies using the names exported from ClangConfig.cmake
than refering to the archive file names explicitly.