### PR TITLE
When backing-up original file, do not strip original file extension (`creduce` compatibility)

### DIFF
--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -180,7 +180,7 @@ class TestManager:
 
     def backup_test_cases(self):
         for f in self.test_cases:
-            orig_file = "{}.orig".format(os.path.splitext(f)[0])
+            orig_file = "{}.orig".format(f)
 
             if not os.path.exists(orig_file):
                 # Copy file and preserve attributes


### PR DESCRIPTION
## Issue

When creating a back-up file, `cvise` creates the back-up file called:

```
orig_file = "{}.orig".format(os.path.splitext(f)[0])
```

while `creduce` would do this:

```
orig_file = "{}.orig".format(f)
```

## Summary of changes

This PR ensures that `cvise` creates back-up files in the same location as `creduce` would.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>