### PR TITLE
INSTALL: add delta and unifdef debian packages

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,7 +27,7 @@ like this:
 
 ```
 sudo apt-get install \
-  flex build-essential
+  flex build-essential unifdef delta
 ```
 
 On FreeBSD 12.1, the prerequisites can be installed like this:


### PR DESCRIPTION
Debian packages these, so they can be added to the recommended
dependency install script.

Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>