### PR TITLE
clang_delta: fix build for ToT LLVM

### DIFF
--- a/clang_delta/CommonRenameClassRewriteVisitor.h
+++ b/clang_delta/CommonRenameClassRewriteVisitor.h
@@ -98,7 +98,7 @@ bool CommonRenameClassRewriteVisitor<T>::VisitUsingDecl(UsingDecl *D)
     return true;
 
   IdentifierInfo *IdInfo = DeclName.getAsIdentifierInfo();
-  std::string IdName = IdInfo->getName();
+  std::string IdName = IdInfo->getName().str();
   std::string Name;
   if (getNewNameByName(IdName, Name)) {
     SourceLocation LocStart = NameInfo.getBeginLoc();
@@ -337,7 +337,7 @@ template<typename T> bool CommonRenameClassRewriteVisitor<T>::
   TransAssert(DTST && "Bad DependentTemplateSpecializationType!");
 
   const IdentifierInfo *IdInfo = DTST->getIdentifier();
-  std::string IdName = IdInfo->getName();
+  std::string IdName = IdInfo->getName().str();
   std::string Name;
   if (getNewNameByName(IdName, Name)) {
     SourceLocation LocStart = DTSLoc.getTemplateNameLoc();

--- a/clang_delta/RemoveNamespace.cpp
+++ b/clang_delta/RemoveNamespace.cpp
@@ -458,7 +458,7 @@ bool RemoveNamespaceRewriteVisitor::VisitDependentTemplateSpecializationTypeLoc(
   TransAssert(DTST && "Bad DependentTemplateSpecializationType!");
 
   const IdentifierInfo *IdInfo = DTST->getIdentifier();
-  std::string IdName = IdInfo->getName();
+  std::string IdName = IdInfo->getName().str();
   std::string Name;
 
   // FIXME:

--- a/clang_delta/RewriteUtils.cpp
+++ b/clang_delta/RewriteUtils.cpp
@@ -748,7 +748,7 @@ std::string RewriteUtils::getStmtIndentString(Stmt *S,
     ++I;
   indentSpace = MB.substr(lineOffs, I-lineOffs);
 
-  return indentSpace;
+  return indentSpace.str();
 }
 
 bool RewriteUtils::addLocalVarToFunc(const std::string &VarStr,

--- a/clang_delta/Transformation.cpp
+++ b/clang_delta/Transformation.cpp
@@ -357,7 +357,7 @@ unsigned int Transformation::getConstArraySize(
   llvm::SmallString<8> IntStr;
   Result.toStringUnsigned(IntStr);
 
-  std::stringstream TmpSS(IntStr.str());
+  std::stringstream TmpSS(IntStr.str().str());
 
   if (!(TmpSS >> Sz)) {
     TransAssert(0 && "Non-integer value!");

--- a/clang_delta/TransformationManager.cpp
+++ b/clang_delta/TransformationManager.cpp
@@ -18,6 +18,7 @@
 
 #include "clang/Basic/Builtins.h"
 #include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/FileManager.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Frontend/CompilerInstance.h"


### PR DESCRIPTION
It seems StringRef is no longer convertible to std::string, and
clang::FileManager moved since llvm-9.

Note: ToT LLVM is currently post-llvm-10 (i.e. llvm-11).

Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>