### PR TITLE
Use GNUInstallDirs for configurable install locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,9 @@ add_test(NAME all COMMAND pytest)
 
 ###############################################################################
 
+# Needs to be sourced after we have a compiler tested
+include(GNUInstallDirs)
+
 add_subdirectory(clang_delta)
 add_subdirectory(clex)
 add_subdirectory(cvise)
@@ -168,11 +171,11 @@ add_subdirectory(delta)
 configure_file(
   "${PROJECT_SOURCE_DIR}/cvise.py"
   "${PROJECT_BINARY_DIR}/cvise.py"
-  COPYONLY
+  @ONLY
 )
 
 install(PROGRAMS "${PROJECT_BINARY_DIR}/cvise.py"
-  DESTINATION "bin"
+  DESTINATION "${CMAKE_INSTALL_BINDIR}"
   RENAME "cvise"
 )
 

--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -512,7 +512,7 @@ set(CMAKE_CXX_FLAGS_ASAN
     FORCE)
 
 install(TARGETS clang_delta
-  RUNTIME DESTINATION
+  DESTINATION "${CMAKE_INSTALL_BINDIR}"
 )
 # If binary is read-only, then installing may fail with an error:
 # CMake Error at cmake_install.cmake:45 (FILE):

--- a/clex/CMakeLists.txt
+++ b/clex/CMakeLists.txt
@@ -55,7 +55,7 @@ set_source_files_properties(strlex.c PROPERTIES COMPILE_FLAGS -Wno-unused-functi
 ###############################################################################
 
 install(TARGETS clex strlex
-  RUNTIME DESTINATION
+  DESTINATION "${CMAKE_INSTALL_BINDIR}"
   )
 
 ###############################################################################

--- a/cvise.py
+++ b/cvise.py
@@ -15,8 +15,8 @@ import importlib.util
 # If the cvise modules cannot be found
 # add the known install location to the path
 if importlib.util.find_spec("cvise") is None:
-    script_path = os.path.dirname(os.path.realpath(__file__))
-    sys.path.append(os.path.join(script_path, "..", "share"))
+    sharedir = "@CMAKE_INSTALL_FULL_DATADIR@/@cvise_PACKAGE@"
+    sys.path.append(sharedir)
 
 from cvise import CVise
 from cvise.passes.abstract import AbstractPass
@@ -36,7 +36,7 @@ def get_share_dir():
 
     # Test all known locations for the cvise directory
     share_dirs = [
-            os.path.join(script_path, "..", "share", "cvise"),
+            "@CMAKE_INSTALL_FULL_DATADIR@/@cvise_PACKAGE@",
             os.path.join(script_path, "cvise")
             ]
 

--- a/cvise/CMakeLists.txt
+++ b/cvise/CMakeLists.txt
@@ -107,7 +107,7 @@ endforeach()
 ###############################################################################
 
 install(DIRECTORY "${cvise_python_BINARY_DIR}/"
-  DESTINATION "${CMAKE_INSTALL_PREFIX}/share/${cvise_PACKAGE}"
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/${cvise_PACKAGE}"
   FILES_MATCHING
   PATTERN "*.py"
   PATTERN "*.json"


### PR DESCRIPTION
Use GNUInstallDirs to make install locations configurable rather than
hardcoding 'bin' and 'share'.  This also means allowing any relative
path between the script and share directory rather than '../share'.