### PR TITLE
passes/ifs.py: fix infinite loop in IfPass

### DIFF
--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 BUILD_TYPE=$1
 

--- a/cvise/passes/ifs.py
+++ b/cvise/passes/ifs.py
@@ -39,10 +39,12 @@ class IfPass(AbstractPass):
 
     def advance(self, test_case, state):
         if state.value == 0:
+            state = state.copy()
             state.value = 1
         else:
-            state.advance()
-            state.value = 0
+            state = state.advance()
+            if state:
+                state.value = 0
         return state
 
     def advance_on_success(self, test_case, state):
@@ -63,12 +65,11 @@ class IfPass(AbstractPass):
 
                     if self.line_regex.search(line):
                         if state.index <= i and i < state.end():
-                            tmp_file.write('#if {0}\n'.format(state.value))
+                            if self.__macro_continues(line):
+                                in_multiline = True
+                            line = '#if {0}\n'.format(state.value)
                         i += 1
-                        if self.__macro_continues(line):
-                            in_multiline = True
-                    else:
-                        tmp_file.write(line)
+                    tmp_file.write(line)
 
         cmd = [self.external_programs["unifdef"], "-B", "-x", "2", "-k", "-o", test_case, tmp_file.name]
         stdout, stderr, returncode = process_event_notifier.run_process(cmd)

--- a/cvise/tests/test_ifs.py
+++ b/cvise/tests/test_ifs.py
@@ -25,3 +25,51 @@ class LineMarkersTestCase(unittest.TestCase):
 
         os.unlink(tmp_file.name)
         self.assertEqual(variant, "int a = 2;\n")
+
+    def test_two_steps(self):
+        self.maxDiff = None
+        in_contents = (
+            "#if FOO\nint foo = 1;\n#else\nint foo = 0;\n#endif\n" +
+            "#if BAR\nint bar = 1;\n#else\nint bar = 0;\n#endif\n"
+        )
+        expected_outs = [
+            # ix val chunk contents
+            # FOO=0 BAR=0
+            (0,  0,  2,    'int foo = 0;\nint bar = 0;\n'),
+            # FOO=1 BAR=1
+            (0,  1,  2,    'int foo = 1;\nint bar = 1;\n'),
+
+            # FOO=0
+            (0,  0,  1,     ('int foo = 0;\n' +
+                             '#if BAR\nint bar = 1;\n#else\nint bar = 0;\n#endif\n')),
+            # FOO=1
+            (0,  1,  1,     ('int foo = 1;\n' +
+                             '#if BAR\nint bar = 1;\n#else\nint bar = 0;\n#endif\n')),
+            # BAR=0
+            (1,  0,  1,     ('#if FOO\nint foo = 1;\n#else\nint foo = 0;\n#endif\n' +
+                             'int bar = 0;\n')),
+            # BAR=1
+            (1,  1,  1,     ('#if FOO\nint foo = 1;\n#else\nint foo = 0;\n#endif\n' +
+                             'int bar = 1;\n')),
+        ]
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as tf:
+            tf.write(in_contents)
+
+        outs = []
+
+        # perform all iterations. They should iterate through FOO/!FOO x BAR/!BAR.
+        state = self.pass_.new(tf.name)
+        while state:
+            with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp_file:
+                tmp_file.write(in_contents)
+
+            (_, state) = self.pass_.transform(tmp_file.name, state, self.process_event_notifier)
+            with open(tmp_file.name) as variant_file:
+                variant = variant_file.read()
+                outs.append(tuple([state.index, state.value, state.chunk, variant]))
+            os.unlink(tmp_file.name)
+            state = self.pass_.advance(tmp_file.name, state)
+
+        os.unlink(tf.name)
+        self.assertEqual(expected_outs, outs)


### PR DESCRIPTION
Before the change IfPass was looping on the same fine:

```
$ cvise --timestamp --remove-pass IncludesPass,UnIfDefPass,CommentsPass \
    --print-diff --debug ./test_cvise.bash *.h *.cpp
2020-08-09 11:45:38,176 DEBUG granularity reduced to 2
2020-08-09 11:45:38,211 DEBUG granularity reduced to 2
2020-08-09 11:45:41,990 DEBUG granularity reduced to 2
2020-08-09 11:45:42,211 DEBUG granularity reduced to 2
2020-08-09 11:45:46,045 DEBUG granularity reduced to 2
...
```

This happens because due to two problems:
1. `state.advance()` is not a mutating operation in `ifs.py`.
   As a result increment was lost.

2. `IfPass` iteration was not able to make progress for either
   `#if 0` or `#if 1` cases.

This change fixes [1.].