### PR TITLE
class-template-to-class transformation was not working with out-of-line method definitions

### DIFF
--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -55,6 +55,8 @@ set(SOURCE_FILES
   "/tests/class-to-struct/class-to-struct1.C"
   "/tests/class-to-struct/class-to-struct1.output"
   "/tests/class-to-struct/class-to-struct-forward.C"
+  "/tests/class-template-to-class/test1.cc"
+  "/tests/class-template-to-class/test1.output"
   "/tests/copy-propagation/copy1.cpp"
   "/tests/copy-propagation/copy1.output"
   "/tests/copy-propagation/copy2.cpp"

--- a/clang_delta/ClassTemplateToClass.cpp
+++ b/clang_delta/ClassTemplateToClass.cpp
@@ -55,6 +55,7 @@ public:
   { }
 
   bool VisitTemplateSpecializationTypeLoc(TemplateSpecializationTypeLoc Loc);
+  bool VisitCXXMethodDecl(CXXMethodDecl* MD);
 
 private:
 
@@ -194,6 +195,21 @@ bool ClassTemplateToClassSpecializationTypeRewriteVisitor::
                                                        RAngleLoc));
   return true;
 }
+
+bool ClassTemplateToClassSpecializationTypeRewriteVisitor::VisitCXXMethodDecl(CXXMethodDecl* MD) {
+  if (auto DCT = MD->getParent()->getDescribedClassTemplate()) {
+    if (MD->isOutOfLine() && DCT->getCanonicalDecl() == ConsumerInstance->TheClassTemplateDecl) {
+      if (MD->getNumTemplateParameterLists() == 1) {
+        const TemplateParameterList* TPList = MD->getTemplateParameterList(0);
+        SourceLocation LocStart = MD->getBeginLoc();
+        ConsumerInstance->removeTemplateAndParameter(LocStart, TPList);
+      }
+    }
+  }
+
+  return true;
+}
+
 
 void ClassTemplateToClass::Initialize(ASTContext &context) 
 {

--- a/clang_delta/tests/class-template-to-class/test1.cc
+++ b/clang_delta/tests/class-template-to-class/test1.cc
@@ -1,0 +1,11 @@
+template <class> class j {
+public:
+	void func();
+	
+	template <class c>
+	void func2(c p);
+};
+
+template <class m> void j<m>::func() {
+	return *this;
+}

--- a/clang_delta/tests/class-template-to-class/test1.output
+++ b/clang_delta/tests/class-template-to-class/test1.output
@@ -1,0 +1,11 @@
+ class j {
+public:
+	void func();
+	
+	template <class c>
+	void func2(c p);
+};
+
+ void j::func() {
+	return *this;
+}

--- a/clang_delta/tests/test_clang_delta.py
+++ b/clang_delta/tests/test_clang_delta.py
@@ -550,3 +550,6 @@ class TestClangDelta(unittest.TestCase):
     def test_class_to_struct_forward(self):
         self.check_query_instances('class-to-struct/class-to-struct-forward.C', '--query-instances=class-to-struct',
                                    'Available transformation instances: 0')
+
+    def test_class_template_to_class(self):
+        self.check_clang_delta('class-template-to-class/test1.cc', '--transformation=class-template-to-class --counter=1')


### PR DESCRIPTION
The class-template-to-class transformation did not remove the template keyword from out-of-line methods.

```
template <class> class j {
public:
	void func();

	template <class c>
	void func2(c p);
};

template <class m> void j<m>::func() {
	return *this;
}
```

was translated to

```
class j {
public:
	void func();

	template <class c>
	void func2(c p);
};

template <class m> void j::func() {
	return *this;
}
```

the template specifier of `j::func` was not removed.