### PR TITLE
Added member-to-global pass that moves declarations within a record (class or struct) in front of the record

### DIFF
--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -358,6 +358,18 @@ set(SOURCE_FILES
   "/tests/union-to-struct/union3.output"
   "/tests/simple-inliner/alias-crash.c"
   "/tests/simple-inliner/alias-crash.output"
+  "/tests/member-to-global/test1.cc"
+  "/tests/member-to-global/test1.output"
+  "/tests/member-to-global/test2.cc"
+  "/tests/member-to-global/test2.output"
+  "/tests/member-to-global/test3.cc"
+  "/tests/member-to-global/test3.output"
+  "/tests/member-to-global/test4.cc"
+  "/tests/member-to-global/test4.output"
+  "/tests/member-to-global/test5.cc"
+  "/tests/member-to-global/test5.output"
+  "/tests/member-to-global/test6.cc"
+  "/tests/member-to-global/test6.output"
 )
 
 foreach(file IN LISTS SOURCE_FILES)
@@ -464,6 +476,8 @@ add_executable(clang_delta
   ParamToGlobal.h
   ParamToLocal.cpp
   ParamToLocal.h
+  MemberToGlobal.cpp
+  MemberToGlobal.h
   ReduceArrayDim.cpp
   ReduceArrayDim.h
   ReduceArraySize.cpp

--- a/clang_delta/MemberToGlobal.cpp
+++ b/clang_delta/MemberToGlobal.cpp
@@ -1,0 +1,192 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) 2012, 2013, 2014, 2015 The University of Utah
+// All rights reserved.
+//
+// This file is distributed under the University of Illinois Open Source
+// License.  See the file COPYING for details.
+//
+//===----------------------------------------------------------------------===//
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif
+
+#include "MemberToGlobal.h"
+
+#include "clang/AST/ASTContext.h"
+#include "clang/Basic/SourceManager.h"
+
+#include "TransformationManager.h"
+
+using namespace clang;
+
+static const char* DescriptionMsg =
+"Move declarations within a record (class or struct) in front of the record. \
+The pass supports functions, variables, typedefs and nested records. \n";
+
+static RegisterTransformation<MemberToGlobal>
+         Trans("member-to-global", DescriptionMsg);
+
+class MemberToGlobal::CollectionVisitor : public 
+  RecursiveASTVisitor<CollectionVisitor> {
+
+public:
+  explicit CollectionVisitor(MemberToGlobal *Instance)
+    : ConsumerInstance(Instance)
+  { }
+
+  bool VisitRecordDecl(RecordDecl* RD) {
+    for (auto* D : RD->decls())
+      if (ConsumerInstance->isValidDecl(RD, D))
+        ConsumerInstance->ValidDecls.push_back(std::make_pair(RD, D));
+
+    return true;
+  }
+
+private:
+  MemberToGlobal *ConsumerInstance;
+};
+
+class MemberToGlobal::RewriteVisitor : public RecursiveASTVisitor<RewriteVisitor> {
+
+public:
+  explicit RewriteVisitor(MemberToGlobal *Instance)
+    : ConsumerInstance(Instance)
+  { }
+
+  bool VisitMemberExpr(MemberExpr* ME) {
+    if (!ME->isImplicitAccess() && ConsumerInstance->isTheDecl(ME->getMemberDecl())) {
+      ConsumerInstance->TheRewriter.ReplaceText(ME->getOperatorLoc(), ",");
+      ConsumerInstance->TheRewriter.InsertTextBefore(ME->getSourceRange().getBegin(), "(");
+      ConsumerInstance->TheRewriter.InsertTextAfterToken(ME->getSourceRange().getEnd(), ")");
+    }
+
+    return true;
+  }
+
+  bool VisitElaboratedTypeLoc(ElaboratedTypeLoc TL) {
+    // Replace CLASS::TYPE by TYPE
+    if (auto* TT = TL.getInnerType()->getAs<TypedefType>()) {
+      if (ConsumerInstance->isTheDecl(TT->getDecl())) {
+        ConsumerInstance->removeRecordQualifier(TL.getQualifierLoc());
+      }
+    } else if (auto* TT = TL.getInnerType()->getAs<TagType>()) {
+      if (ConsumerInstance->isTheDecl(TT->getDecl())) {
+        ConsumerInstance->removeRecordQualifier(TL.getQualifierLoc());
+      }
+    }
+
+    return true;
+  }
+
+  bool VisitDeclRefExpr(DeclRefExpr* DRE) {
+    if (ConsumerInstance->isTheDecl(DRE->getDecl())) {
+      ConsumerInstance->removeRecordQualifier(DRE->getQualifierLoc());
+    }
+
+    return true;
+  }
+
+private:
+  MemberToGlobal *ConsumerInstance;
+};
+
+void MemberToGlobal::Initialize(ASTContext &context) 
+{
+  Transformation::Initialize(context);
+}
+
+StringRef MemberToGlobal::GetText(SourceRange replacementRange) {
+  std::pair<FileID, unsigned> Begin = SrcManager->getDecomposedLoc(replacementRange.getBegin());
+  std::pair<FileID, unsigned> End = SrcManager->getDecomposedLoc(replacementRange.getEnd());
+  if (Begin.first != End.first)
+    return "";
+
+  StringRef MB = SrcManager->getBufferData(Begin.first);
+  return MB.substr(Begin.second, End.second - Begin.second + 1);
+}
+
+void MemberToGlobal::removeRecordQualifier(const NestedNameSpecifierLoc& NNSLoc) {
+  if (!NNSLoc)
+    return;
+
+  if (isTheRecordDecl(NNSLoc.getNestedNameSpecifier()->getAsRecordDecl())) {
+    SourceRange SR = NNSLoc.getLocalSourceRange();
+    SR.setEnd(SR.getEnd().getLocWithOffset(1));
+
+    TheRewriter.RemoveText(SR);
+  }
+}
+
+static bool replace(std::string& str, const std::string& from, const std::string& to) {
+  size_t start_pos = str.find(from);
+  if (start_pos == std::string::npos)
+    return false;
+  str.replace(start_pos, from.length(), to);
+  return true;
+}
+
+void MemberToGlobal::HandleTranslationUnit(ASTContext &Ctx)
+{
+  CollectionVisitor(this).TraverseDecl(Ctx.getTranslationUnitDecl());
+
+  ValidInstanceNum = ValidDecls.size();
+
+  if (QueryInstanceOnly)
+    return;
+
+  if (TransformationCounter > ValidInstanceNum) {
+    TransError = TransMaxInstanceError;
+    return;
+  }
+
+  TheDecl = ValidDecls[TransformationCounter - 1].second;
+  TheRecordDecl = ValidDecls[TransformationCounter - 1].first;
+  Ctx.getDiagnostics().setSuppressAllDiagnostics(false);
+
+  auto RecordBegin = TheRecordDecl->getSourceRange().getBegin();
+  auto BeginLoc = TheDecl->getSourceRange().getBegin();
+  auto EndLoc = RewriteHelper->getEndLocationUntil(TheDecl->getSourceRange().getEnd(), ';');
+
+  std::string Text = GetText(SourceRange(BeginLoc, EndLoc)).str();
+  if (auto* VD = dyn_cast<VarDecl>(TheDecl)) {
+    if (VD->isStaticDataMember()) {
+      replace(Text, "static", "extern");
+    }
+  }
+
+  TheRewriter.InsertTextBefore(RecordBegin, Text + "\n");
+  TheRewriter.RemoveText(SourceRange(BeginLoc, EndLoc));
+
+  for (auto* Redecl : TheDecl->redecls()) {
+    if (auto* DD = dyn_cast<DeclaratorDecl>(Redecl)) {
+      removeRecordQualifier(DD->getQualifierLoc());
+    }
+  }
+
+  RewriteVisitor(this).TraverseDecl(Ctx.getTranslationUnitDecl());
+
+  if (Ctx.getDiagnostics().hasErrorOccurred() ||
+      Ctx.getDiagnostics().hasFatalErrorOccurred())
+    TransError = TransInternalError;
+}
+
+bool MemberToGlobal::isValidDecl(clang::RecordDecl* RD, clang::Decl* D) {
+  if (D->isImplicit())
+    return false;
+  // No access specifier, e.g. public:
+  if (isa<AccessSpecDecl>(D))
+    return false;
+  // No constructors or destructors
+  if (isa<CXXConstructorDecl>(D) || isa<CXXDestructorDecl>(D))
+    return false;
+  // No friend declarations
+  if (isa<FriendDecl>(D))
+    return false;
+
+  if (isInIncludedFile(D))
+    return false;
+
+  return true;
+}

--- a/clang_delta/MemberToGlobal.h
+++ b/clang_delta/MemberToGlobal.h
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) 2012, 2013 The University of Utah
+// All rights reserved.
+//
+// This file is distributed under the University of Illinois Open Source
+// License.  See the file COPYING for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MEMBER_TO_GLOBAL_H
+#define MEMBER_TO_GLOBAL_H
+
+#include <string>
+#include "llvm/ADT/SmallVector.h"
+#include "Transformation.h"
+#include "CommonParameterRewriteVisitor.h"
+
+namespace clang {
+  class DeclGroupRef;
+  class ASTContext;
+  class FunctionDecl;
+  class ReturnStmt;
+  class ParmVarDecl;
+}
+
+class ParamToGlobalASTVisitor;
+class ParamToGlobalRewriteVisitor;
+template<typename T, typename Trans> class CommonParameterRewriteVisitor;
+
+class MemberToGlobal : public Transformation {
+
+  class CollectionVisitor;
+  class RewriteVisitor;
+public:
+
+  MemberToGlobal(const char *TransName, const char *Desc)
+    : Transformation(TransName, Desc)
+  { }
+
+private:
+  
+  virtual void Initialize(clang::ASTContext &context);
+
+  virtual void HandleTranslationUnit(clang::ASTContext &Ctx);
+
+  bool isValidDecl(clang::RecordDecl* FD, clang::Decl* D);
+
+  llvm::StringRef GetText(clang::SourceRange range);
+
+  void removeRecordQualifier(const clang::NestedNameSpecifierLoc& NNSLoc);
+
+  bool isTheDecl(clang::Decl *D) {
+    return TheDecl->getCanonicalDecl() == D->getCanonicalDecl();
+  }
+
+  bool isTheRecordDecl(clang::Decl *D) {
+    return TheRecordDecl->getCanonicalDecl() == D->getCanonicalDecl();
+  }
+
+  std::vector<std::pair<clang::RecordDecl*, clang::Decl*>> ValidDecls;
+
+  clang::Decl *TheDecl = nullptr;
+  clang::RecordDecl *TheRecordDecl = nullptr;
+};
+#endif

--- a/clang_delta/tests/member-to-global/test1.cc
+++ b/clang_delta/tests/member-to-global/test1.cc
@@ -1,0 +1,12 @@
+
+namespace n {
+
+class C {
+public:
+	void f();
+};
+
+}
+
+void n::C::f() {
+}

--- a/clang_delta/tests/member-to-global/test1.output
+++ b/clang_delta/tests/member-to-global/test1.output
@@ -1,0 +1,13 @@
+
+namespace n {
+
+void f();
+class C {
+public:
+	
+};
+
+}
+
+void n::f() {
+}

--- a/clang_delta/tests/member-to-global/test2.cc
+++ b/clang_delta/tests/member-to-global/test2.cc
@@ -1,0 +1,9 @@
+
+class C {
+public:
+	int& f();
+};
+
+void func(C& c1, C& c2) {
+	c1.f() = c2.f();
+}

--- a/clang_delta/tests/member-to-global/test2.output
+++ b/clang_delta/tests/member-to-global/test2.output
@@ -1,0 +1,10 @@
+
+int& f();
+class C {
+public:
+	
+};
+
+void func(C& c1, C& c2) {
+	(c1,f)() = (c2,f)();
+}

--- a/clang_delta/tests/member-to-global/test3.cc
+++ b/clang_delta/tests/member-to-global/test3.cc
@@ -1,0 +1,9 @@
+
+class C {
+public:
+	int i;
+};
+
+int func(C& c) {
+	return c.i;
+}

--- a/clang_delta/tests/member-to-global/test3.output
+++ b/clang_delta/tests/member-to-global/test3.output
@@ -1,0 +1,10 @@
+
+int i;
+class C {
+public:
+	
+};
+
+int func(C& c) {
+	return (c,i);
+}

--- a/clang_delta/tests/member-to-global/test4.cc
+++ b/clang_delta/tests/member-to-global/test4.cc
@@ -1,0 +1,11 @@
+
+class C {
+public:
+	static int s;
+};
+
+int C::s = 5;
+
+int func() {
+	return C::s;
+}

--- a/clang_delta/tests/member-to-global/test4.output
+++ b/clang_delta/tests/member-to-global/test4.output
@@ -1,0 +1,12 @@
+
+extern int s;
+class C {
+public:
+	
+};
+
+int s = 5;
+
+int func() {
+	return s;
+}

--- a/clang_delta/tests/member-to-global/test5.cc
+++ b/clang_delta/tests/member-to-global/test5.cc
@@ -1,0 +1,9 @@
+
+class C {
+public:
+	using x = int;
+};
+
+void func() {
+	C::x v;
+}

--- a/clang_delta/tests/member-to-global/test5.output
+++ b/clang_delta/tests/member-to-global/test5.output
@@ -1,0 +1,10 @@
+
+using x = int;
+class C {
+public:
+	
+};
+
+void func() {
+	x v;
+}

--- a/clang_delta/tests/member-to-global/test6.cc
+++ b/clang_delta/tests/member-to-global/test6.cc
@@ -1,0 +1,10 @@
+
+class C {
+public:
+	struct x {
+	};
+};
+
+void func() {
+	C::x v;
+}

--- a/clang_delta/tests/member-to-global/test6.output
+++ b/clang_delta/tests/member-to-global/test6.output
@@ -1,0 +1,11 @@
+
+struct x {
+	};
+class C {
+public:
+	
+};
+
+void func() {
+	x v;
+}

--- a/clang_delta/tests/test_clang_delta.py
+++ b/clang_delta/tests/test_clang_delta.py
@@ -568,3 +568,21 @@ class TestClangDelta(unittest.TestCase):
 
     def test_replace_simple_typedef_test2(self):
         self.check_clang_delta('replace-simple-typedef/test2.cc', '--transformation=replace-simple-typedef --counter=1')
+
+    def test_member_to_global_test1(self):
+        self.check_clang_delta('member-to-global/test1.cc', '--transformation=member-to-global --counter=1')
+
+    def test_member_to_global_test2(self):
+        self.check_clang_delta('member-to-global/test2.cc', '--transformation=member-to-global --counter=1')
+
+    def test_member_to_global_test3(self):
+        self.check_clang_delta('member-to-global/test3.cc', '--transformation=member-to-global --counter=1')
+
+    def test_member_to_global_test4(self):
+        self.check_clang_delta('member-to-global/test4.cc', '--transformation=member-to-global --counter=1')
+
+    def test_member_to_global_test5(self):
+        self.check_clang_delta('member-to-global/test5.cc', '--transformation=member-to-global --counter=1')
+
+    def test_member_to_global_test6(self):
+        self.check_clang_delta('member-to-global/test6.cc', '--transformation=member-to-global --counter=1')

--- a/cvise/pass_groups/all.json
+++ b/cvise/pass_groups/all.json
@@ -105,6 +105,7 @@
     {"pass": "clang", "arg": "vector-to-array", "c": true },
     {"pass": "clang", "arg": "remove-try-catch", "c": true },
     {"pass": "clang", "arg": "class-to-struct", "c": true },
+    {"pass": "clang", "arg": "member-to-global", "c": true },
     {"pass": "lines", "arg": "0"},
     {"pass": "lines", "arg": "1"},
     {"pass": "lines", "arg": "2"},


### PR DESCRIPTION
Added member-to-global pass that tries to move declaration within a record in front of the record.

A supports and was tested with typedefs/using, static/non-static functions, static/non-static variables.