### PR TITLE
Added rename-operator pass that converts operator functions (e.g. operator +) to regular functions

### DIFF
--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -296,6 +296,10 @@ set(SOURCE_FILES
   "/tests/rename-fun/test1.output"
   "/tests/rename-fun/multi.c"
   "/tests/rename-fun/multi.output"
+  "/tests/rename-operator/test1.cc"
+  "/tests/rename-operator/test1.output"
+  "/tests/rename-operator/test2.cc"
+  "/tests/rename-operator/test2.output"
   "/tests/rename-param/invalid.c"
   "/tests/rename-param/invalid.output"
   "/tests/rename-param/stuck.ii"
@@ -526,6 +530,8 @@ add_executable(clang_delta
   RenameClass.h
   RenameFun.cpp
   RenameFun.h
+  RenameOperator.cpp
+  RenameOperator.h
   RenameParam.cpp
   RenameParam.h
   RenameVar.cpp

--- a/clang_delta/RenameOperator.cpp
+++ b/clang_delta/RenameOperator.cpp
@@ -1,0 +1,226 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) 2012, 2013, 2015, 2016, 2017, 2018, 2019, 2020 The University of Utah
+// All rights reserved.
+//
+// This file is distributed under the University of Illinois Open Source
+// License.  See the file COPYING for details.
+//
+//===----------------------------------------------------------------------===//
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif
+
+#include "RenameOperator.h"
+
+#include <sstream>
+
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Lex/Lexer.h"
+
+#include "TransformationManager.h"
+
+using namespace clang;
+
+static const char *DescriptionMsg =
+"A pass to rename operator functions (e.g. operator +) to regular function names op1, op2, ... \
+Relevant operators are replaced by function calls, e.g. a + b => a.op1(b). \
+The pass renames all functions with --count=1 and single functions with >= 2.\n";
+
+static RegisterTransformation<RenameOperator>
+         Trans("rename-operator", DescriptionMsg);
+
+class RenameOperator::CollectionVisitor : public
+  RecursiveASTVisitor<CollectionVisitor> {
+
+public:
+
+  explicit CollectionVisitor(RenameOperator *Instance)
+    : ConsumerInstance(Instance)
+  { }
+
+  bool VisitFunctionDecl(FunctionDecl *FD)
+  {
+    if (!FD->isOverloadedOperator()) {
+      return true;
+    }
+
+    const FunctionDecl *CanonicalFD = FD->getCanonicalDecl();
+    if (ConsumerInstance->isInIncludedFile(FD) ||
+      ConsumerInstance->isInIncludedFile(CanonicalFD))
+      return true;
+
+    ConsumerInstance->addFun(CanonicalFD);
+
+    return true;
+  }
+
+private:
+
+  RenameOperator *ConsumerInstance;
+
+};
+
+class RenameOperator::RenameOperatorVisitor : public RecursiveASTVisitor<RenameOperatorVisitor> {
+ using Base = RecursiveASTVisitor<RenameOperatorVisitor>;
+public:
+
+  explicit RenameOperatorVisitor(RenameOperator *Instance)
+    : ConsumerInstance(Instance)
+  { }
+
+  std::string* GetNewName(FunctionDecl* FD) {
+    FunctionDecl *CanonicalDecl = FD->getCanonicalDecl();
+
+    if (ConsumerInstance->RenameFunc.count(CanonicalDecl))
+        return &ConsumerInstance->RenameFunc[CanonicalDecl];
+
+    return nullptr;
+  }
+
+  bool VisitFunctionDecl(FunctionDecl* FD) {
+    if (auto NewName = GetNewName(FD)) {
+      ConsumerInstance->TheRewriter.ReplaceText(FD->getNameInfo().getSourceRange(), *NewName);
+    }
+
+    return true;
+  }
+
+  bool TraverseCXXOperatorCallExpr(CXXOperatorCallExpr* OCE) {
+    if (auto* MD = dyn_cast<CXXMethodDecl>(OCE->getCalleeDecl())) {
+      if (auto NewName = GetNewName(MD)) {
+        std::string OpSpelling = getOperatorSpelling(OCE->getOperator());
+        if (OCE->getOperator() == OO_Call || OCE->getOperator() == OO_Subscript) {
+          auto L1 = Lexer::getLocForEndOfToken(OCE->getArg(0)->getEndLoc(), 0, *ConsumerInstance->SrcManager, ConsumerInstance->Context->getLangOpts());
+          auto L2 = OCE->getArg(1)->getBeginLoc().getLocWithOffset(-1);
+          ConsumerInstance->TheRewriter.ReplaceText(SourceRange(L1, L2), "." + *NewName + "(");
+          ConsumerInstance->TheRewriter.ReplaceText(OCE->getOperatorLoc(), 1, ")");
+        } else if (OCE->getNumArgs() == 1 || OCE->getOperator() == OO_PlusPlus || OCE->getOperator() == OO_MinusMinus) {
+          ConsumerInstance->TheRewriter.ReplaceText(OCE->getOperatorLoc(), OpSpelling.size(), "");
+          ConsumerInstance->TheRewriter.InsertTextAfterToken(OCE->getArg(0)->getEndLoc(), "." + *NewName + (OCE->getNumArgs() == 2 ? "(0)" : "()"));
+        } else if (OCE->getNumArgs() == 2) {
+          ConsumerInstance->TheRewriter.ReplaceText(OCE->getOperatorLoc(), OpSpelling.size(), "." + *NewName + "(");
+          ConsumerInstance->TheRewriter.InsertTextAfterToken(OCE->getArg(1)->getEndLoc(), ")");
+        }
+      }
+    } else if (auto* FD = dyn_cast<FunctionDecl>(OCE->getCalleeDecl())) {
+      if (auto NewName = GetNewName(FD)) {
+        std::string OpSpelling = getOperatorSpelling(OCE->getOperator());
+        if (OCE->getNumArgs() == 1 || OCE->getOperator() == OO_PlusPlus || OCE->getOperator() == OO_MinusMinus) {
+          ConsumerInstance->TheRewriter.InsertTextBefore(OCE->getArg(0)->getBeginLoc(), *NewName + "(");
+          ConsumerInstance->TheRewriter.ReplaceText(OCE->getOperatorLoc(), OpSpelling.size(), "");
+          ConsumerInstance->TheRewriter.InsertTextAfterToken(OCE->getArg(0)->getEndLoc(), OCE->getNumArgs() == 2 ? ",0)" : ")");
+        } else if (OCE->getNumArgs() == 2) {
+          ConsumerInstance->TheRewriter.InsertTextBefore(OCE->getArg(0)->getBeginLoc(), *NewName + "(");
+          ConsumerInstance->TheRewriter.ReplaceText(OCE->getOperatorLoc(), OpSpelling.size(), ",");
+          ConsumerInstance->TheRewriter.InsertTextAfterToken(OCE->getArg(1)->getEndLoc(), ")");
+        }
+      }
+    }
+
+    // Only traverse into arguments and not into callee. That would call VisitDeclRefExpr.
+    for (auto arg : OCE->arguments())
+      Base::TraverseStmt(arg);
+
+    return true;
+  }
+
+  bool VisitDeclRefExpr(DeclRefExpr *DRE)
+  {
+    if (ConsumerInstance->isInIncludedFile(DRE))
+      return true;
+
+    if (FunctionDecl* FD = dyn_cast<FunctionDecl>(DRE->getDecl())) {
+      if (auto NewName = GetNewName(FD)) {
+        ConsumerInstance->TheRewriter.ReplaceText(DRE->getNameInfo().getSourceRange(), *NewName);
+      }
+    }
+
+    return true;
+  }
+
+
+  bool VisitMemberExpr(MemberExpr *ME)
+  {
+    if (ConsumerInstance->isInIncludedFile(ME))
+      return true;
+
+    if (FunctionDecl* FD = dyn_cast<FunctionDecl>(ME->getMemberDecl())) {
+      if (auto NewName = GetNewName(FD)) {
+        ConsumerInstance->TheRewriter.ReplaceText(ME->getMemberNameInfo().getSourceRange(), *NewName);
+      }
+    }
+
+    return true;
+  }
+
+private:
+
+  RenameOperator *ConsumerInstance;
+
+};
+
+void RenameOperator::Initialize(ASTContext &context) 
+{
+  Transformation::Initialize(context);
+  ValidInstanceNum = 1;
+}
+
+std::string RenameOperator::getNextFuncName() {
+  std::string Name;
+
+  do {
+    auto No = NextFunNo++;
+    Name = FunNamePrefix + std::to_string(No);
+  } while (UsedNames.count(Name));
+
+  return Name;
+}
+
+void RenameOperator::HandleTranslationUnit(ASTContext &Ctx)
+{
+  //Ctx.getTranslationUnitDecl()->dump();
+
+  CollectionVisitor(this).TraverseDecl(Ctx.getTranslationUnitDecl());
+
+  ValidInstanceNum = 0;
+  if (FunctionList.size())
+    ValidInstanceNum = FunctionList.size() + 1;
+
+  if (QueryInstanceOnly) {
+    return;
+  }
+
+  if (TransformationCounter > ValidInstanceNum) {
+    TransError = TransMaxInstanceError;
+    return;
+  }
+
+  if (TransformationCounter == 1) {
+    for (auto F : FunctionList)
+      RenameFunc[F] = getNextFuncName();
+  } else {
+    auto Fun = FunctionList[TransformationCounter - 2];
+    RenameFunc[Fun] = getNextFuncName();
+  }
+
+  Ctx.getDiagnostics().setSuppressAllDiagnostics(false);
+
+  RenameOperatorVisitor(this).TraverseDecl(Ctx.getTranslationUnitDecl());
+
+  if (Ctx.getDiagnostics().hasErrorOccurred() ||
+      Ctx.getDiagnostics().hasFatalErrorOccurred())
+    TransError = TransInternalError;
+}
+
+void RenameOperator::addFun(const FunctionDecl *FD)
+{
+  FD = FD->getCanonicalDecl();
+  if (!FunctionSet.count(FD)) {
+    FunctionSet.insert(FD);
+    FunctionList.push_back(FD);
+  }
+}

--- a/clang_delta/RenameOperator.h
+++ b/clang_delta/RenameOperator.h
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) 2012, 2013 The University of Utah
+// All rights reserved.
+//
+// This file is distributed under the University of Illinois Open Source
+// License.  See the file COPYING for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef RENAME_OPERATOR_H
+#define RENAME_OPERATOR_H
+
+#include <string>
+#include <set>
+#include "llvm/ADT/DenseMap.h"
+#include "Transformation.h"
+
+namespace clang {
+  class DeclGroupRef;
+  class ASTContext;
+  class FunctionDecl;
+}
+
+class RenameOperator : public Transformation {
+  class CollectionVisitor;
+  class RenameOperatorVisitor;
+
+public:
+
+  RenameOperator(const char *TransName, const char *Desc)
+    : Transformation(TransName, Desc)
+  { }
+
+  virtual bool skipCounter(void) {
+    return true;
+  }
+
+private:
+  
+  virtual void Initialize(clang::ASTContext &context);
+
+  virtual void HandleTranslationUnit(clang::ASTContext &Ctx);
+
+  void addFun(const clang::FunctionDecl *FD);
+
+  std::string getNextFuncName();
+
+  std::set<const clang::FunctionDecl*> FunctionSet;
+
+  std::vector<const clang::FunctionDecl*> FunctionList;
+
+  std::map<const clang::FunctionDecl*, std::string> RenameFunc;
+
+  std::set<std::string> UsedNames;
+
+  const std::string FunNamePrefix = "op";
+
+  int NextFunNo = 1;
+};
+#endif

--- a/clang_delta/tests/rename-operator/test1.cc
+++ b/clang_delta/tests/rename-operator/test1.cc
@@ -1,0 +1,37 @@
+
+class test {
+public:
+	test operator + (test);
+	test operator ~ ();
+	test operator ++ ();
+	test operator ++ (int);
+
+	test operator () (int);
+	test operator () (int, int);
+	test operator () (int, int, int);
+
+	test operator [] (int);
+};
+
+test test::operator ~ () {
+	return test();
+}
+
+void func() {
+	test t1,t2,t3;
+	
+	t3 = t1 + t2;
+	t3 = ~t1;
+
+	(t1) [ 0];
+
+	t1(0);
+	t1 ( 1, 2 );
+	t1  (3, 4, 5 );
+
+	++t3;
+	t3++;
+
+	t3.operator ~();
+	&test::operator~;
+}

--- a/clang_delta/tests/rename-operator/test1.output
+++ b/clang_delta/tests/rename-operator/test1.output
@@ -1,0 +1,37 @@
+
+class test {
+public:
+	test op1 (test);
+	test op2 ();
+	test op3 ();
+	test op4 (int);
+
+	test op5 (int);
+	test op6 (int, int);
+	test op7 (int, int, int);
+
+	test op8 (int);
+};
+
+test test::op2 () {
+	return test();
+}
+
+void func() {
+	test t1,t2,t3;
+	
+	t3 = t1 .op1( t2);
+	t3 = t1.op2();
+
+	(t1).op8( 0);
+
+	t1.op5(0);
+	t1.op6( 1, 2 );
+	t1.op7(3, 4, 5 );
+
+	t3.op3();
+	t3.op4(0);
+
+	t3.op2();
+	&test::op2;
+}

--- a/clang_delta/tests/rename-operator/test2.cc
+++ b/clang_delta/tests/rename-operator/test2.cc
@@ -1,0 +1,22 @@
+
+class test {
+public:
+};
+
+test operator + (test&, test);
+test operator ~ (test&);
+test operator ++ (test&);
+test operator ++ (test&, int);
+
+void func() {
+	test t1,t2,t3;
+	
+	t3 = t1 + t2;
+	t3 = ~t1;
+
+	++t3;
+	t3++;
+
+	operator ~(t3);
+	&operator~;
+}

--- a/clang_delta/tests/rename-operator/test2.output
+++ b/clang_delta/tests/rename-operator/test2.output
@@ -1,0 +1,22 @@
+
+class test {
+public:
+};
+
+test op1 (test&, test);
+test op2 (test&);
+test op3 (test&);
+test op4 (test&, int);
+
+void func() {
+	test t1,t2,t3;
+	
+	t3 = op1(t1 , t2);
+	t3 = op2(t1);
+
+	op3(t3);
+	op4(t3,0);
+
+	op2(t3);
+	&op2;
+}

--- a/clang_delta/tests/test_clang_delta.py
+++ b/clang_delta/tests/test_clang_delta.py
@@ -586,3 +586,9 @@ class TestClangDelta(unittest.TestCase):
 
     def test_member_to_global_test6(self):
         self.check_clang_delta('member-to-global/test6.cc', '--transformation=member-to-global --counter=1')
+
+    def test_rename_operator_test1(self):
+        self.check_clang_delta('rename-operator/test1.cc', '--transformation=rename-operator --counter=1')
+
+    def test_rename_operator_test2(self):
+        self.check_clang_delta('rename-operator/test2.cc', '--transformation=rename-operator --counter=1')

--- a/cvise/pass_groups/all.json
+++ b/cvise/pass_groups/all.json
@@ -54,6 +54,7 @@
     {"pass": "clang", "arg": "param-to-global", "c": true },
     {"pass": "clang", "arg": "param-to-local", "c": true },
     {"pass": "clang", "arg": "remove-nested-function", "c": true },
+    {"pass": "clang", "arg": "rename-operator", "renaming": true},
     {"pass": "clang", "arg": "union-to-struct", "c": true },
     {"pass": "clang", "arg": "return-void", "c": true },
     {"pass": "clang", "arg": "simple-inliner", "c": true },


### PR DESCRIPTION
A pass to rename operator functions (e.g. operator +) to regular function names op1, op2, ...
Relevant operators are replaced by function calls, e.g. a + b => a.op1(b).
The pass renames all functions with --count=1 and single functions with >= 2.