### PR TITLE
Bugfix: instantiate-template-param transformation used always the type of the first template parameter

### DIFF
--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -92,6 +92,8 @@ set(SOURCE_FILES
   "/tests/instantiate-template-param/test3.cc"
   "/tests/instantiate-template-param/test4.cc"
   "/tests/instantiate-template-param/test4.output"
+  "/tests/instantiate-template-param/test6.cc"
+  "/tests/instantiate-template-param/test6.output"
   "/tests/local-to-global/macro.c"
   "/tests/local-to-global/macro.output"
   "/tests/local-to-global/unnamed_1.c"

--- a/clang_delta/InstantiateTemplateParam.cpp
+++ b/clang_delta/InstantiateTemplateParam.cpp
@@ -360,19 +360,16 @@ void InstantiateTemplateParam::handleOneTemplateSpecialization(
     return;
 
   unsigned NumArgs = ArgList.size(); (void)NumArgs;
-  unsigned Idx = 0;
+  unsigned Idx = -1;
   TemplateParameterList *TPList = D->getTemplateParameters();
-  for (TemplateParameterList::const_iterator I = TPList->begin(),
-       E = TPList->end(); I != E; ++I) {
-    const NamedDecl *ND = (*I);
+  for (NamedDecl* ND : *TPList) {
+    ++Idx;
     // make it simple, skip NonTypeTemplateParmDecl and 
     // TemplateTemplateParmDecl for now
     const TemplateTypeParmDecl *TyParmDecl = 
       dyn_cast<TemplateTypeParmDecl>(ND);
-    if (!TyParmDecl || TyParmDecl->isParameterPack() || !ParamsSet.count(ND)) {
-      Idx++;
+    if (!TyParmDecl || TyParmDecl->isParameterPack() || !ParamsSet.count(ND))
       continue;
-    }
 
     TransAssert((Idx < NumArgs) && "Invalid Idx!");
     const TemplateArgument &Arg = ArgList.get(Idx);

--- a/clang_delta/tests/instantiate-template-param/test6.cc
+++ b/clang_delta/tests/instantiate-template-param/test6.cc
@@ -1,0 +1,5 @@
+template <class f, class g> void C(f, g) {}
+
+void f() {
+	C<int, double>(10, 1.0);
+}

--- a/clang_delta/tests/instantiate-template-param/test6.output
+++ b/clang_delta/tests/instantiate-template-param/test6.output
@@ -1,0 +1,5 @@
+template <class f, class g> void C(f, double) {}
+
+void f() {
+	C<int, double>(10, 1.0);
+}

--- a/clang_delta/tests/test_clang_delta.py
+++ b/clang_delta/tests/test_clang_delta.py
@@ -123,6 +123,9 @@ class TestClangDelta(unittest.TestCase):
     def test_instantiate_template_param_default_test4(self):
         self.check_clang_delta('instantiate-template-param/test4.cc', '--transformation=instantiate-template-param --counter=1')
 
+    def test_instantiate_template_param_default_test6(self):
+        self.check_clang_delta('instantiate-template-param/test6.cc', '--transformation=instantiate-template-param --counter=2')
+
     def test_local_to_global_macro(self):
         self.check_clang_delta('local-to-global/macro.c', '--transformation=local-to-global --counter=1')
 


### PR DESCRIPTION
This my first of a series of PR for improving the instantiate-template-param pass.

It fixes a bug that always the type of the first parameter was used for replacement. In the example g was replaced by int instead of double.