### PR TITLE
Fixed crash in reduce-class-template-param

### DIFF
--- a/clang_delta/ReduceClassTemplateParameter.cpp
+++ b/clang_delta/ReduceClassTemplateParameter.cpp
@@ -206,10 +206,8 @@ bool ReduceClassTemplateParameterRewriteVisitor::
                                               "<>");
   }
   else if ((ConsumerInstance->TheParameterIndex + 1) == NumArgs) {
-    SourceLocation EndLoc = Loc.getRAngleLoc();
-    EndLoc = EndLoc.getLocWithOffset(-1);
     ConsumerInstance->RewriteHelper->removeTextFromLeftAt(
-                                       Range, ',', EndLoc);
+                                       Range, ',', Range.getEnd());
   }
   else {
     ConsumerInstance->RewriteHelper->removeTextUntil(Range, ',');


### PR DESCRIPTION
Unfortunately, I do not have a test case. My smallest one is 3000 bytes because cvise cannot reduce it further :( I think we need some kind of template reordering pass...