### PR TITLE
Improved merge-base-class transformation

### DIFF
--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -118,6 +118,20 @@ set(SOURCE_FILES
   "/tests/reduce-array-dim/non-type-temp-arg.output"
   "/tests/reduce-pointer-level/scalar-init-expr.cpp"
   "/tests/reduce-pointer-level/scalar-init-expr.output"
+  "/tests/merge-base-class/test1.cc"
+  "/tests/merge-base-class/test1.output"
+  "/tests/merge-base-class/test2.cc"
+  "/tests/merge-base-class/test2.output"
+  "/tests/merge-base-class/test3.cc"
+  "/tests/merge-base-class/test3.output"
+  "/tests/remove-base-class/test1.cc"
+  "/tests/remove-base-class/test1.output"
+  "/tests/remove-base-class/test2.cc"
+  "/tests/remove-base-class/test2.output"
+  "/tests/remove-base-class/test3.cc"
+  "/tests/remove-base-class/test3.output"
+  "/tests/remove-base-class/test4.cc"
+  "/tests/remove-base-class/test4.output"
   "/tests/move-function-body/test1.cc"
   "/tests/move-function-body/test1.output"
   "/tests/move-function-body/test2.cc"
@@ -529,6 +543,7 @@ add_executable(clang_delta
   RemoveArray.h
   RemoveBaseClass.cpp
   RemoveBaseClass.h
+  MergeBaseClass.cpp
   RemoveCtorInitializer.cpp
   RemoveCtorInitializer.h
   RemoveEnumMemberValue.cpp

--- a/clang_delta/MergeBaseClass.cpp
+++ b/clang_delta/MergeBaseClass.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) 2012, 2013, 2014, 2015, 2016, 2017, 2018 The University of Utah
+// All rights reserved.
+//
+// This file is distributed under the University of Illinois Open Source
+// License.  See the file COPYING for details.
+//
+//===----------------------------------------------------------------------===//
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif
+
+#include "RemoveBaseClass.h"
+
+#include "TransformationManager.h"
+
+static const char* DescriptionMsg =
+"This pass merges a base class into a derived class if \n\
+  * it has less than or equal to 5 declarations. \n\
+All its declarations will be moved into one of its subclasses, \
+and all references to this base class will be replaced with \
+the corresponding subclass. \n";
+
+static RegisterTransformation<RemoveBaseClass, RemoveBaseClass::EMode>
+         Trans("merge-base-class", DescriptionMsg, RemoveBaseClass::EMode::Merge);
+
+
+// Implementation is in RemoveBaseClass.cp
+

--- a/clang_delta/MoveFunctionBody.cpp
+++ b/clang_delta/MoveFunctionBody.cpp
@@ -87,7 +87,8 @@ void MoveFunctionBody::HandleTranslationUnit(ASTContext &Ctx)
     TransError = TransInternalError;
 }
 
-// Needed for backwards compatibility. Copyied from Decl::getDescribedTemplateParams.
+// Decl::getDescribedTemplateParams was introduced in LLVM 11.
+// Copied here for backwards compatibility.
 static const TemplateParameterList* getDescribedTemplateParams(Decl* D) {
   if (auto* TD = D->getDescribedTemplate())
     return TD->getTemplateParameters();

--- a/clang_delta/RemoveBaseClass.cpp
+++ b/clang_delta/RemoveBaseClass.cpp
@@ -24,19 +24,14 @@ using namespace clang;
 using namespace clang_delta_common_visitor;
 
 static const char *DescriptionMsg = 
-"This pass removes a base class from its class hierarchy if \n\
-  * it has less than or equal to 5 declarations, and \n\
-  * it is not a templated class. \n\
-All its declarations will be moved into one of its subclasses, \
-and all references to this base class will be replaced with \
-the corresponding subclass. \n";
+"This pass removes a base class from a derived class. \n";
 
 // Note that this pass doesn't do much analysis, so
-// it will produce quite a few incompilable code, especially
+// it will produce quite a few uncompilable code, especially
 // when multi-inheritance is involved.
 
-static RegisterTransformation<RemoveBaseClass>
-         Trans("remove-base-class", DescriptionMsg);
+static RegisterTransformation<RemoveBaseClass, RemoveBaseClass::EMode>
+         Trans("remove-base-class", DescriptionMsg, RemoveBaseClass::EMode::Remove);
 
 class RemoveBaseClassBaseVisitor : public 
   RecursiveASTVisitor<RemoveBaseClassBaseVisitor> {
@@ -59,20 +54,6 @@ bool RemoveBaseClassBaseVisitor::VisitCXXRecordDecl(
   ConsumerInstance->handleOneCXXRecordDecl(CXXRD);
   return true;
 }
-
-class RemoveBaseClassRewriteVisitor : public
-  CommonRenameClassRewriteVisitor<RemoveBaseClassRewriteVisitor> 
-{
-public:
-  RemoveBaseClassRewriteVisitor(Transformation *Instance,
-                                Rewriter *RT,
-                                RewriteUtils *Helper,
-                                const CXXRecordDecl *CXXRD,
-                                const std::string &Name)
-    : CommonRenameClassRewriteVisitor<RemoveBaseClassRewriteVisitor>
-      (Instance, RT, Helper, CXXRD, Name)
-  { }
-};
 
 void RemoveBaseClass::Initialize(ASTContext &context) 
 {
@@ -102,13 +83,6 @@ void RemoveBaseClass::HandleTranslationUnit(ASTContext &Ctx)
   TransAssert(TheDerivedClass && "TheDerivedClass is NULL!");
   Ctx.getDiagnostics().setSuppressAllDiagnostics(false);
 
-  RewriteVisitor = 
-    new RemoveBaseClassRewriteVisitor(this, &TheRewriter, RewriteHelper,
-                                      TheBaseClass->getCanonicalDecl(),
-                                      TheDerivedClass->getNameAsString());
-
-  TransAssert(RewriteVisitor && "NULL RewriteVisitor!");
-  RewriteVisitor->TraverseDecl(Ctx.getTranslationUnitDecl());
   doRewrite();
 
   if (Ctx.getDiagnostics().hasErrorOccurred() ||
@@ -134,59 +108,39 @@ bool RemoveBaseClass::isDirectlyDerivedFrom(const CXXRecordDecl *SubC,
 
 void RemoveBaseClass::handleOneCXXRecordDecl(const CXXRecordDecl *CXXRD)
 {
-  if (isSpecialRecordDecl(CXXRD) || CXXRD->getDescribedClassTemplate() || 
-      !CXXRD->hasDefinition())
+  if (isSpecialRecordDecl(CXXRD) || !CXXRD->isThisDeclarationADefinition())
     return;
 
-  const CXXRecordDecl *CanonicalRD = CXXRD->getCanonicalDecl();
-  if (VisitedCXXRecordDecls.count(CanonicalRD))
-    return;
-  VisitedCXXRecordDecls.insert(CanonicalRD);
-  if (CanonicalRD->getNumBases()) {
-    const CXXRecordDecl *Base = NULL;
-    for (CXXRecordDeclSet::iterator I = AllBaseClasses.begin(), 
-         E = AllBaseClasses.end(); I != E; ++I) {
-      if (const ClassTemplateSpecializationDecl * CTSD = 
-          dyn_cast<ClassTemplateSpecializationDecl>
-            (CanonicalRD->getDefinition())) {
-        if (!CTSD->isExplicitSpecialization())
-          continue;
-      }
+  for (const CXXBaseSpecifier& BS : CXXRD->bases()) {
+    auto* Base = BS.getType()->getAsCXXRecordDecl();
 
-      if (isInIncludedFile(*I))
-        continue;
-      if (isDirectlyDerivedFrom(CanonicalRD, *I)) {
-        Base = (*I);
-        ValidInstanceNum++;
-        if (ValidInstanceNum == TransformationCounter) {
-          TransAssert(Base->hasDefinition() && 
-                      "Base class does not have any definition!");
-          TheBaseClass = Base->getDefinition();
-          TransAssert(CanonicalRD->hasDefinition() && 
-                      "Derived class does not have any definition!");
-          TheDerivedClass = CanonicalRD->getDefinition();
-        }
-      }
+    if (Base == nullptr)
+      continue;
+    if (Mode == EMode::Merge && getNumExplicitDecls(Base) > MaxNumDecls)
+      continue;
+    if (isInIncludedFile(Base))
+      continue;
+
+    ValidInstanceNum++;
+    if (ValidInstanceNum == TransformationCounter) {
+      TransAssert(Base->hasDefinition() && "Base class does not have any definition!");
+      TheBaseClass = Base->getDefinition();
+      TheDerivedClass = CXXRD;
     }
-    return;
   }
-
-  if (getNumExplicitDecls(CanonicalRD) > MaxNumDecls)
-    return;
-
-  if (!AllBaseClasses.count(CanonicalRD))
-    AllBaseClasses.insert(CanonicalRD);
 }
 
 void RemoveBaseClass::doRewrite(void)
 {
-  copyBaseClassDecls();
+  if (Mode == EMode::Merge)
+    copyBaseClassDecls();
   removeBaseSpecifier();
-  RewriteHelper->removeClassDecls(TheBaseClass);
+  if (Mode == EMode::Merge)
+    RewriteHelper->removeClassDecls(TheBaseClass);
 
   // ISSUE: I didn't handle Base initializer in a Ctor's initlist.
   //        * keeping it untouched is wrong, because delegating constructors 
-  //        are only valie in c++11
+  //        are only valid in c++11
   //        * naively removing the base initializer doesn't work in some cases,
   //        e.g., 
   //        class A { 
@@ -207,13 +161,37 @@ void RemoveBaseClass::copyBaseClassDecls(void)
 {
   if (!getNumExplicitDecls(TheBaseClass))
     return;
-  SourceLocation StartLoc = TheBaseClass->getBraceRange().getBegin();
-  SourceLocation EndLoc = TheBaseClass->getBraceRange().getEnd();
-  TransAssert(EndLoc.isValid() && "Invalid RBraceLoc!");
-  EndLoc = EndLoc.getLocWithOffset(-1);
 
-  std::string DeclsStr = 
-    TheRewriter.getRewrittenText(SourceRange(StartLoc, EndLoc));
+  std::string DeclsStr;
+  auto* CTSD = dyn_cast<ClassTemplateSpecializationDecl>(TheBaseClass);
+  if (CTSD && CTSD->getSpecializationKind() == TSK_ImplicitInstantiation) {
+    // For template bases, we use the printing feature of clang to generate
+    // the class with all resolved template parameters
+
+    // Rename internally the constructors to the derived class
+    for (CXXConstructorDecl* CD : CTSD->ctors()) {
+      CD->setDeclName(TheDerivedClass->getDeclName());
+    }
+
+    llvm::raw_string_ostream Strm(DeclsStr);
+    CTSD->print(Strm);
+
+    DeclsStr.erase(0, DeclsStr.find('{') + 1);
+    DeclsStr.erase(DeclsStr.rfind('}'), 1);
+  } else {
+    // Rename constructors
+    for (CXXConstructorDecl* CD : TheBaseClass->ctors()) {
+      TheRewriter.ReplaceText(CD->getNameInfo().getSourceRange(), TheDerivedClass->getDeclName().getAsString());
+    }
+
+    SourceLocation StartLoc = TheBaseClass->getBraceRange().getBegin();
+    SourceLocation EndLoc = TheBaseClass->getBraceRange().getEnd();
+    TransAssert(EndLoc.isValid() && "Invalid RBraceLoc!");
+    StartLoc = StartLoc.getLocWithOffset(1);
+    EndLoc = EndLoc.getLocWithOffset(-1);
+
+    DeclsStr = TheRewriter.getRewrittenText(SourceRange(StartLoc, EndLoc)) + "\n";
+  }
 
   TransAssert(!DeclsStr.empty() && "Empty DeclsStr!");
   SourceLocation InsertLoc = TheDerivedClass->getBraceRange().getEnd();
@@ -290,16 +268,16 @@ void RemoveBaseClass::rewriteOneCtor(const CXXConstructorDecl *Ctor)
 
 void RemoveBaseClass::removeBaseInitializer(void)
 {
-  for (CXXRecordDecl::ctor_iterator I = TheDerivedClass->ctor_begin(),
-       E = TheDerivedClass->ctor_end(); I != E; ++I) {
-    if ((*I)->isThisDeclarationADefinition() && !(*I)->isDefaulted())
-      rewriteOneCtor(*I);
+  for (Decl* D : TheDerivedClass->decls()) {
+    if (auto* FTD = dyn_cast<FunctionTemplateDecl>(D))
+      D =FTD->getTemplatedDecl();
+    if (auto* Ctor = dyn_cast<CXXConstructorDecl>(D))
+      if (Ctor->isThisDeclarationADefinition() && !Ctor->isDefaulted())
+        rewriteOneCtor(Ctor);
   }
 }
 
 RemoveBaseClass::~RemoveBaseClass(void)
 {
   delete CollectionVisitor;
-  delete RewriteVisitor;
 }
-

--- a/clang_delta/RemoveBaseClass.h
+++ b/clang_delta/RemoveBaseClass.h
@@ -22,21 +22,17 @@ namespace clang {
 }
 
 class RemoveBaseClassBaseVisitor;
-class RemoveBaseClassRewriteVisitor;
 
 class RemoveBaseClass : public Transformation {
 friend class RemoveBaseClassBaseVisitor;
 
 public:
-  RemoveBaseClass(const char *TransName, const char *Desc)
-    : Transformation(TransName, Desc),
-      CollectionVisitor(NULL),
-      RewriteVisitor(NULL),
-      TheBaseClass(NULL),
-      TheDerivedClass(NULL),
-      MaxNumDecls(5)
-  { }
+  enum class EMode { Remove, Merge };
 
+  RemoveBaseClass(const char *TransName, const char *Desc, EMode Mode)
+    : Transformation(TransName, Desc),
+      Mode(Mode)
+  { }
   ~RemoveBaseClass(void);
 
 private:
@@ -63,19 +59,15 @@ private:
 
   bool isTheBaseClass(const clang::CXXBaseSpecifier &Specifier);
 
-  CXXRecordDeclSet VisitedCXXRecordDecls;
+  RemoveBaseClassBaseVisitor *CollectionVisitor = nullptr;
 
-  CXXRecordDeclSet AllBaseClasses;
+  const clang::CXXRecordDecl *TheBaseClass = nullptr;
 
-  RemoveBaseClassBaseVisitor *CollectionVisitor;
+  const clang::CXXRecordDecl *TheDerivedClass = nullptr;
 
-  RemoveBaseClassRewriteVisitor *RewriteVisitor;
+  const unsigned MaxNumDecls = 5;
 
-  const clang::CXXRecordDecl *TheBaseClass;
-
-  const clang::CXXRecordDecl *TheDerivedClass;
-
-  const unsigned MaxNumDecls;
+  EMode Mode;
 
   // Unimplemented
   RemoveBaseClass(void);

--- a/clang_delta/RewriteUtils.h
+++ b/clang_delta/RewriteUtils.h
@@ -282,7 +282,7 @@ public:
   clang::SourceLocation getLocationAfterSkiping(clang::SourceLocation StartLoc,
                                                 char Symbol);
 
-  clang::SourceRange getDeclFullSourceRange(clang::Decl* D);
+  clang::SourceRange getDeclFullSourceRange(const clang::Decl* D);
 
 private:
 

--- a/clang_delta/TransformationManager.h
+++ b/clang_delta/TransformationManager.h
@@ -184,12 +184,12 @@ private:
 
 };
 
-template<typename TransformationClass>
+template<typename TransformationClass, typename... Args>
 class RegisterTransformation {
 
 public:
-  RegisterTransformation(const char *TransName, const char *Desc) {
-    Transformation *TransImpl = new TransformationClass(TransName, Desc);
+  RegisterTransformation(const char *TransName, const char *Desc, Args... args) {
+    Transformation *TransImpl = new TransformationClass(TransName, Desc, args...);
     assert(TransImpl && "Fail to create TransformationClass");
  
     TransformationManager::registerTransformation(TransName, TransImpl);

--- a/clang_delta/tests/merge-base-class/test1.cc
+++ b/clang_delta/tests/merge-base-class/test1.cc
@@ -1,0 +1,14 @@
+
+struct c1 {
+	int x;
+	int y;
+	
+	// hello
+	c1(int x);
+};
+
+struct c2 : public c1 {
+	c2() :  c1(5) {
+	}
+	
+};

--- a/clang_delta/tests/merge-base-class/test1.output
+++ b/clang_delta/tests/merge-base-class/test1.output
@@ -1,0 +1,13 @@
+
+
+
+struct c2  {
+	c2()  {
+	}
+	
+
+	int x;
+	int y;
+	
+	// hello
+	c2(int x);};

--- a/clang_delta/tests/merge-base-class/test2.cc
+++ b/clang_delta/tests/merge-base-class/test2.cc
@@ -1,0 +1,14 @@
+
+template <class T>
+struct c1 {
+	c1(T x);
+	
+	// hello
+	T y;
+};
+
+struct c2 : public c1<int> {
+	c2() :  c1<int>(5) {
+	}
+	
+};

--- a/clang_delta/tests/merge-base-class/test2.output
+++ b/clang_delta/tests/merge-base-class/test2.output
@@ -1,0 +1,11 @@
+
+
+
+struct c2  {
+	c2()  {
+	}
+	
+
+    c2(int x);
+    int y;
+};

--- a/clang_delta/tests/merge-base-class/test3.cc
+++ b/clang_delta/tests/merge-base-class/test3.cc
@@ -1,0 +1,18 @@
+
+template <class T>
+struct c1 {
+};
+
+template <>
+struct c1<int> {
+	c1(int x);
+	
+	// hello
+	int y;
+};
+
+struct c2 : public c1<int> {
+	c2() :  c1<int>(5) {
+	}
+	
+};

--- a/clang_delta/tests/merge-base-class/test3.output
+++ b/clang_delta/tests/merge-base-class/test3.output
@@ -1,0 +1,16 @@
+
+template <class T>
+struct c1 {
+};
+
+
+
+struct c2  {
+	c2()  {
+	}
+	
+
+	c2(int x);
+	
+	// hello
+	int y;};

--- a/clang_delta/tests/remove-base-class/test1.cc
+++ b/clang_delta/tests/remove-base-class/test1.cc
@@ -1,0 +1,14 @@
+
+struct c1 {
+	int x;
+	int y;
+	
+	// hello
+	c1(int x);
+};
+
+struct c2 : public c1 {
+	c2() :  c1(5) {
+	}
+	
+};

--- a/clang_delta/tests/remove-base-class/test1.output
+++ b/clang_delta/tests/remove-base-class/test1.output
@@ -1,0 +1,14 @@
+
+struct c1 {
+	int x;
+	int y;
+	
+	// hello
+	c1(int x);
+};
+
+struct c2  {
+	c2()  {
+	}
+	
+};

--- a/clang_delta/tests/remove-base-class/test2.cc
+++ b/clang_delta/tests/remove-base-class/test2.cc
@@ -1,0 +1,14 @@
+
+template <class T>
+struct c1 {
+	c1(T x);
+	
+	// hello
+	T y;
+};
+
+struct c2 : public c1<int> {
+	c2() :  c1<int>(5) {
+	}
+	
+};

--- a/clang_delta/tests/remove-base-class/test2.output
+++ b/clang_delta/tests/remove-base-class/test2.output
@@ -1,0 +1,14 @@
+
+template <class T>
+struct c1 {
+	c1(T x);
+	
+	// hello
+	T y;
+};
+
+struct c2  {
+	c2()  {
+	}
+	
+};

--- a/clang_delta/tests/remove-base-class/test3.cc
+++ b/clang_delta/tests/remove-base-class/test3.cc
@@ -1,0 +1,18 @@
+
+template <class T>
+struct c1 {
+};
+
+template <>
+struct c1<int> {
+	c1(int x);
+	
+	// hello
+	int y;
+};
+
+struct c2 : public c1<int> {
+	c2() :  c1<int>(5) {
+	}
+	
+};

--- a/clang_delta/tests/remove-base-class/test3.output
+++ b/clang_delta/tests/remove-base-class/test3.output
@@ -1,0 +1,18 @@
+
+template <class T>
+struct c1 {
+};
+
+template <>
+struct c1<int> {
+	c1(int x);
+	
+	// hello
+	int y;
+};
+
+struct c2  {
+	c2()  {
+	}
+	
+};

--- a/clang_delta/tests/remove-base-class/test4.cc
+++ b/clang_delta/tests/remove-base-class/test4.cc
@@ -1,0 +1,9 @@
+template <class T> 
+struct c {
+  c(T) {}
+};
+
+struct i : c<double>, c<int> {
+  template <class T>
+  i() : c<double>(1.0), c<int>(10) {}
+};

--- a/clang_delta/tests/remove-base-class/test4.output
+++ b/clang_delta/tests/remove-base-class/test4.output
@@ -1,0 +1,9 @@
+template <class T> 
+struct c {
+  c(T) {}
+};
+
+struct i :  c<int> {
+  template <class T>
+  i() :  c<int>(10) {}
+};

--- a/clang_delta/tests/test_clang_delta.py
+++ b/clang_delta/tests/test_clang_delta.py
@@ -632,6 +632,28 @@ class TestClangDelta(unittest.TestCase):
     def test_rename_operator_test2(self):
         self.check_clang_delta('rename-operator/test2.cc', '--transformation=rename-operator --counter=1')
 
+    def test_merge_base_class_test1(self):
+        self.check_clang_delta('merge-base-class/test1.cc', '--transformation=merge-base-class --counter=1')
+
+    @unittest.skipIf(get_llvm_version() <= 9, 'Fails with LLVM <= 9')
+    def test_merge_base_class_test2(self):
+        self.check_clang_delta('merge-base-class/test2.cc', '--transformation=merge-base-class --counter=1')
+
+    def test_merge_base_class_test3(self):
+        self.check_clang_delta('merge-base-class/test3.cc', '--transformation=merge-base-class --counter=1')
+
+    def test_remove_base_class_test1(self):
+        self.check_clang_delta('remove-base-class/test1.cc', '--transformation=remove-base-class --counter=1')
+
+    def test_remove_base_class_test2(self):
+        self.check_clang_delta('remove-base-class/test2.cc', '--transformation=remove-base-class --counter=1')
+
+    def test_remove_base_class_test3(self):
+        self.check_clang_delta('remove-base-class/test3.cc', '--transformation=remove-base-class --counter=1')
+
+    def test_remove_base_class_test4(self):
+        self.check_clang_delta('remove-base-class/test4.cc', '--transformation=remove-base-class --counter=1')
+
     def test_move_function_body_test1(self):
         self.check_clang_delta('move-function-body/test1.cc', '--transformation=move-function-body --counter=1')
 

--- a/cvise/pass_groups/all.json
+++ b/cvise/pass_groups/all.json
@@ -85,6 +85,7 @@
     {"pass": "clang", "arg": "reduce-class-template-param", "c": true },
     {"pass": "clang", "arg": "remove-trivial-base-template", "c": true },
     {"pass": "clang", "arg": "class-template-to-class", "c": true },
+    {"pass": "clang", "arg": "merge-base-class", "c": true },
     {"pass": "clang", "arg": "remove-base-class", "c": true },
     {"pass": "clang", "arg": "replace-derived-class", "c": true },
     {"pass": "clang", "arg": "remove-unresolved-base", "c": true },


### PR DESCRIPTION
1. The transformation learned to merge templated base classes
2. The transformation was splitted into two transformation: (1) remove-base-class only removes the base class, (2) merge-base-class removes the base class and copies the content of the base class