### PR TITLE
cvise.py: call shell vial `/usr/bin/env` indirection instead of `/bin`

### DIFF
--- a/cvise.py
+++ b/cvise.py
@@ -291,7 +291,7 @@ if __name__ == '__main__':
     script = None
     if args.commands:
         with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.sh') as script:
-            script.write(f'#!/bin/{args.shell}\n\n')
+            script.write(f'#!/usr/bin/env {args.shell}\n\n')
             script.write(args.commands + '\n')
         os.chmod(script.name, 0o744)
         logging.info('Using temporary interestingness test: %s' % script.name)


### PR DESCRIPTION
My system (`NixOS`) has one well-defined shell: `/bin/sh`.

But normally programs use either `/run/current-system/sw/bin/bash` or the `bash` from `PATH`. They use `/usr/bin/env` for that.

The change calls shell via `/usr/bin/env` to use `PATH` lookup.