### PR TITLE
Add clang version string to clang_delta --version

### DIFF
--- a/clang_delta/ClangDelta.cpp
+++ b/clang_delta/ClangDelta.cpp
@@ -17,6 +17,7 @@
 #include <cstdlib>
 
 #include "llvm/Support/raw_ostream.h"
+#include "clang/Basic/Version.h"
 #include "TransformationManager.h"
 #include "git_version.h"
 
@@ -25,8 +26,15 @@ static int ErrorCode = -1;
 
 static void PrintVersion()
 {
+  // Some versions of the clang library (notably Ubuntu) prefixes its version
+  // string with uninteresting information. Strip this.
+  auto version = clang::getClangFullVersion();
+  auto start = version.find("clang version");
+  assert(start != version.npos);
+
   llvm::outs() << "clang_delta " << PACKAGE_VERSION << "\n";
   llvm::outs() << "Git version: " << git_version << "\n";
+  llvm::outs() << version.substr(start) << "\n";
   // XXX print copyright, contact info, etc.?
 }
 

--- a/clang_delta/tests/test_clang_delta.py
+++ b/clang_delta/tests/test_clang_delta.py
@@ -4,18 +4,14 @@ import subprocess
 import unittest
 
 
-def get_llvm_version():
+def get_clang_version():
     current = os.path.dirname(__file__)
     binary = os.path.join(current, '../clang_delta')
-    output = subprocess.check_output(f'ldd {binary}', shell=True, text=True)
+    output = subprocess.check_output(f'{binary} --version', shell=True, text=True)
     for line in output.splitlines():
-        part = line.strip().split()[0]
-        if part.startswith('libLLVM'):
-            m = re.match(r'libLLVM-(?P<version>[0-9]+)\.so', part)
-            if m:
-                return int(m.group('version'))
-            else:
-                return int(part.split('.')[-1])
+        m = re.match(r'clang version (?P<version>[0-9]+)\.', line)
+        if m:
+            return int(m.group('version'))
 
     raise AssertionError()
 
@@ -378,7 +374,7 @@ class TestClangDelta(unittest.TestCase):
     def test_rename_class_bool(self):
         self.check_clang_delta('rename-class/bool.cc', '--transformation=rename-class --counter=1')
 
-    @unittest.skipIf(get_llvm_version() >= 16, 'Fails with LLVM >= 16')
+    @unittest.skipIf(get_clang_version() >= 16, 'Fails with LLVM >= 16')
     def test_rename_class_class_template(self):
         self.check_clang_delta('rename-class/class_template.cc', '--transformation=rename-class --counter=1')
 
@@ -639,7 +635,7 @@ class TestClangDelta(unittest.TestCase):
     def test_merge_base_class_test1(self):
         self.check_clang_delta('merge-base-class/test1.cc', '--transformation=merge-base-class --counter=1')
 
-    @unittest.skipIf(get_llvm_version() <= 9, 'Fails with LLVM <= 9')
+    @unittest.skipIf(get_clang_version() <= 9, 'Fails with LLVM <= 9')
     def test_merge_base_class_test2(self):
         self.check_clang_delta('merge-base-class/test2.cc', '--transformation=merge-base-class --counter=1')
 


### PR DESCRIPTION
This adds the version of clang currently in use to the output from clang_delta --version and changes the test script to use this information instead of looking at the list of dynamic libraries when checking which clang version is in use. This allows the tests to run when clang_delta is statically linked against libClang.