### PR TITLE
CMakeLists changes to fix macOS build:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,7 @@ check_cxx_compiler_flag(
 )
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-    OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # XXX figure out how to get "-std=c++17 -fno-rtti" from LLVM.  That's how we
   # get those options in the Automake path...
   set(COMMON_FLAGS "-Wall -Wextra -Werror -pedantic -Wno-unused-parameter")

--- a/clex/CMakeLists.txt
+++ b/clex/CMakeLists.txt
@@ -50,9 +50,9 @@ add_executable(strlex
   )
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-    OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-set_source_files_properties(clex.c PROPERTIES COMPILE_FLAGS -Wno-unused-function)
-set_source_files_properties(strlex.c PROPERTIES COMPILE_FLAGS -Wno-unused-function)
+    OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+set_source_files_properties(clex.c PROPERTIES COMPILE_FLAGS "-Wno-unused-function -Wno-sign-compare")
+set_source_files_properties(strlex.c PROPERTIES COMPILE_FLAGS "-Wno-unused-function -Wno-sign-compare")
 endif()
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 set_source_files_properties(clex.c PROPERTIES COMPILE_FLAGS -DYY_NO_UNISTD_H)

--- a/delta/CMakeLists.txt
+++ b/delta/CMakeLists.txt
@@ -30,8 +30,8 @@ add_executable(topformflat
   )
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-    OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-set_source_files_properties(topformflat.c PROPERTIES COMPILE_FLAGS "-Wno-unused-function -Wno-unused-parameter")
+    OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+set_source_files_properties(topformflat.c PROPERTIES COMPILE_FLAGS "-Wno-unused-function -Wno-unused-parameter -Wno-sign-compare")
 endif()
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 set_source_files_properties(topformflat.c PROPERTIES COMPILE_FLAGS -DYY_NO_UNISTD_H)


### PR DESCRIPTION
- Check whether `CMAKE_CXX_COMPILER_ID` contains the string `Clang` rather than being exactly equal.  This way it also matches `AppleClang`, which is what CMake uses for the default compiler on macOS; see also:

  https://cmake.org/cmake/help/latest/policy/CMP0025.html

- Add `-Wno-sign-compare` to the special options for Flex-generated .c files, because Apple's Flex generates code that produces this warning by default.  Compare to e.g.:

  https://github.com/vlm/asn1c/issues/321