### PR TITLE
Fix working of --log-file parameter

### DIFF
--- a/cvise.py
+++ b/cvise.py
@@ -361,7 +361,6 @@ if __name__ == '__main__':
     syslog = logging.StreamHandler()
     formatter = DeltaTimeFormatter(log_format)
     syslog.setFormatter(formatter)
-    logging.getLogger().handlers = []
     logging.getLogger().addHandler(syslog)
 
     pass_options = set()


### PR DESCRIPTION
We're removing all handlers after creating the basicConfig object & then only appending the syslog!

BTW, since we have a custom formatter shouldn't it be set on the file stream handler as well?