### PR TITLE
Removed basicConfig & fixed working of --log-file arg

### DIFF
--- a/cvise.py
+++ b/cvise.py
@@ -354,8 +354,7 @@ if __name__ == '__main__':
     else:
         log_config['level'] = getattr(logging, args.log_level.upper())
 
-    logging.getLogger().setLevel(log_config["level"])
-
+    logging.getLogger().setLevel(log_config['level'])
 
     syslog = logging.StreamHandler()
     formatter = DeltaTimeFormatter(log_format)

--- a/cvise.py
+++ b/cvise.py
@@ -354,15 +354,20 @@ if __name__ == '__main__':
     else:
         log_config['level'] = getattr(logging, args.log_level.upper())
 
-    if args.log_file is not None:
-        log_config['filename'] = args.log_file
+    logging.getLogger().setLevel(log_config["level"])
 
-    logging.basicConfig(**log_config)
+
     syslog = logging.StreamHandler()
     formatter = DeltaTimeFormatter(log_format)
     syslog.setFormatter(formatter)
-    logging.getLogger().handlers = []
-    logging.getLogger().addHandler(syslog)
+
+    root_logger = logging.getLogger()
+    root_logger.addHandler(syslog)
+
+    if args.log_file is not None:
+        file_handler = logging.FileHandler(args.log_file)
+        file_handler.setFormatter(formatter)
+        root_logger.addHandler(file_handler)
 
     pass_options = set()
 

--- a/cvise.py
+++ b/cvise.py
@@ -355,18 +355,17 @@ if __name__ == '__main__':
         log_config['level'] = getattr(logging, args.log_level.upper())
 
     logging.getLogger().setLevel(log_config['level'])
-
-    syslog = logging.StreamHandler()
     formatter = DeltaTimeFormatter(log_format)
-    syslog.setFormatter(formatter)
-
     root_logger = logging.getLogger()
-    root_logger.addHandler(syslog)
 
     if args.log_file is not None:
         file_handler = logging.FileHandler(args.log_file)
         file_handler.setFormatter(formatter)
         root_logger.addHandler(file_handler)
+    else:
+        syslog = logging.StreamHandler()
+        syslog.setFormatter(formatter)
+        root_logger.addHandler(syslog)
 
     pass_options = set()
 


### PR DESCRIPTION
I followed the discussion in this(https://github.com/marxin/cvise/pull/129) thread and decided to send a PR.

With these changes, logs are both displayed on stdout and stored in the logfile when the `--log-file` parameter is provided.

Would it be more appropriate to solely store them in a file without displaying them on stdout if the parameter is provided?