### PR TITLE
Implement a stopping threshold

### DIFF
--- a/cvise.py
+++ b/cvise.py
@@ -337,6 +337,11 @@ if __name__ == '__main__':
         help='Executable to check interestingness of test cases',
     )
     parser.add_argument('test_cases', metavar='TEST_CASE', nargs='+', help='Test cases')
+    parser.add_argument(
+        '--stopping-threshold',
+        default=1.0,
+        type=float,
+        help='CVise will stop reducing a test case once it has reduced by this fraction of its original size.  Between 0.0 and 1.0.')
 
     args = parser.parse_args()
 
@@ -464,6 +469,7 @@ if __name__ == '__main__':
         args.also_interesting,
         args.start_with_pass,
         args.skip_after_n_transforms,
+        args.stopping_threshold,
     )
 
     reducer = CVise(test_manager, args.skip_interestingness_test_check)

--- a/cvise/cvise.py
+++ b/cvise/cvise.py
@@ -189,7 +189,14 @@ class CVise:
         while True:
             total_file_size = self.test_manager.total_file_size
 
+            met_stopping_threshold = False
             for p in passes:
+                # Exit early if we're already reduced enough
+                improvement = (self.test_manager.orig_total_file_size - total_file_size) / self.test_manager.orig_total_file_size
+                logging.info(f'Termination check: stopping threshold is {self.test_manager.stopping_threshold}; current improvement is {improvement}')
+                if (improvement >= self.test_manager.stopping_threshold):
+                    met_stopping_threshold = True
+                    break
                 if not p.check_prerequisites():
                     logging.error(f'Skipping pass {p}')
                 else:
@@ -197,5 +204,5 @@ class CVise:
 
             logging.info(f'Termination check: size was {total_file_size}; now {self.test_manager.total_file_size}')
 
-            if self.test_manager.total_file_size >= total_file_size:
+            if (self.test_manager.total_file_size >= total_file_size) or met_stopping_threshold:
                 break

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -148,6 +148,7 @@ class TestManager:
         also_interesting,
         start_with_pass,
         skip_after_n_transforms,
+        stopping_threshold,
     ):
         self.test_script = Path(test_script).absolute()
         self.timeout = timeout
@@ -166,6 +167,7 @@ class TestManager:
         self.also_interesting = also_interesting
         self.start_with_pass = start_with_pass
         self.skip_after_n_transforms = skip_after_n_transforms
+        self.stopping_threshold = stopping_threshold
 
         for test_case in test_cases:
             test_case = Path(test_case)


### PR DESCRIPTION
Sometimes it's enough to reduce a testcase by, say, 95%.  This commit lets the user specify this threshold and CVise doesn't need to spend time trying to make progress until it can no longer do so.

For example:

`cvise <args> --stopping-threshold 0.95 ./interesting.sh test_case`

This can speed up CVise in some cases.

Constructive feedback is very welcome.