### PR TITLE
Ensure that clang delta is also compiled with C++17 on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
 
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELEASE} -O3 -g")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17 /GR-")
 endif()
 
 ###############################################################################

--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -728,7 +728,7 @@ if(MSVC)
 
   foreach(flag ${msvc_warning_flags})
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${flag}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${flag}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
   endforeach(flag)
 endif(MSVC)
 


### PR DESCRIPTION
Without this, it's compiled with C++14, which makes the build fail, because `std:optional` is not supported under C++14.