### PR TITLE
Delete assert of exitcode in TestManager

### DIFF
--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -420,7 +420,6 @@ class TestManager:
                 else:
                     self.pass_statistic.add_failure(self.current_pass)
                     if test_env.result == PassResult.OK:
-                        assert test_env.exitcode
                         if self.also_interesting is not None and test_env.exitcode == self.also_interesting:
                             self.save_extra_dir(test_env.test_case_path)
                     elif test_env.result == PassResult.STOP:


### PR DESCRIPTION
The exitcode isn't guaranteed to be set whenever |result| is |OK|, because the code that sets it (the caller of run_test()) might be skipped on exception.

The code after the assert seems to correctly handle the case when |exitcode| is |None|, so this commit just deletes the assert. This fixes #157.