### PR TITLE
Fix unclosed file in is_readable_file

### DIFF
--- a/cvise/utils/misc.py
+++ b/cvise/utils/misc.py
@@ -5,7 +5,8 @@ from contextlib import contextmanager
 
 def is_readable_file(filename):
     try:
-        open(filename).read()
+        with open(filename) as f:
+            f.read()
         return True
     except UnicodeDecodeError:
         return False


### PR DESCRIPTION
Close the file handle after it's not needed anymore.

This problem was detected by pytest in my work for #156:

```
  cvise/utils/misc.py:8: ResourceWarning: unclosed file
  <_io.TextIOWrapper name='input.txt' mode='r' encoding='UTF-8'>
    open(filename).read()
```