### PR TITLE
Trim leading/trailing spaces after topformflat

### DIFF
--- a/cvise/passes/lines.py
+++ b/cvise/passes/lines.py
@@ -19,31 +19,40 @@ class LinesPass(AbstractPass):
         with (
             CloseableTemporaryFile(mode='w+', dir=tmp) as backup,
             CloseableTemporaryFile(mode='w+', dir=tmp) as tmp_file,
+            CloseableTemporaryFile(mode='w+', dir=tmp) as stripped_tmp_file,
         ):
             backup.close()
             with open(test_case) as in_file:
                 try:
                     cmd = [self.external_programs['topformflat'], self.arg]
-                    proc = subprocess.run(cmd, stdin=in_file, capture_output=True, text=True)
+                    with subprocess.Popen(cmd, stdin=in_file, stdout=subprocess.PIPE, text=True) as proc:
+                        for line in proc.stdout:
+                            if not line.isspace():
+                                tmp_file.write(line)
+                                linebreak = '\n' if line.endswith('\n') else ''
+                                stripped_tmp_file.write(line.strip() + linebreak)
                 except subprocess.SubprocessError:
                     return
-
-            for line in proc.stdout.splitlines(keepends=True):
-                if not line.isspace():
-                    tmp_file.write(line)
             tmp_file.close()
+            stripped_tmp_file.close()
 
             # we need to check that sanity check is still fine
             if check_sanity:
                 shutil.copy(test_case, backup.name)
-                shutil.copy(tmp_file.name, test_case)
-                try:
-                    check_sanity()
-                except InsaneTestCaseError:
-                    shutil.copy(backup.name, test_case)
-                    # if we are not the first lines pass, we should bail out
-                    if self.arg != '0':
-                        self.bailout = True
+                # try the stripped file first, fall back to the original stdout if needed
+                candidates = [stripped_tmp_file.name, tmp_file.name]
+                for candidate in candidates:
+                    shutil.copy(candidate, test_case)
+                    try:
+                        check_sanity()
+                    except InsaneTestCaseError:
+                        pass
+                    else:
+                        return
+                shutil.copy(backup.name, test_case)
+                # if we are not the first lines pass, we should bail out
+                if self.arg != '0':
+                    self.bailout = True
             else:
                 shutil.copy(tmp_file.name, test_case)
 

--- a/tests/test_cvise.py
+++ b/tests/test_cvise.py
@@ -23,5 +23,5 @@ class TestCvise(unittest.TestCase):
         self.check_cvise(
             'blocksort-part.c',
             '-c "gcc -c blocksort-part.c && grep nextHi blocksort-part.c"',
-            ['#define nextHi', '#define  nextHi '],
+            ['#define nextHi', '#define  nextHi'],
         )


### PR DESCRIPTION
This reduces the overhead slightly and prevents the files from
growing noticeably when the lines passes start. This fixes #163.

Note that this new logic has a safeguard that falls back to the
previous behavior (which takes the topformflat's output as-is) in
case the interestingness script starts failing.