### PR TITLE
Modifications to allow reducing for/bisecting cvise: --no-diagnostics-on-pass-bug & return 1 with error on "die-on-pass-bug" error

### DIFF
--- a/cvise.py
+++ b/cvise.py
@@ -152,6 +152,11 @@ if __name__ == '__main__':
         help='Do not create diagnostics folder on pass bug',
     )
     parser.add_argument(
+        '--no-dir-on-timeout',
+        action='store_true',
+        help='Do not create a folder with the source on timeout',
+    )
+    parser.add_argument(
         '--sllooww',
         action='store_true',
         help='Try harder to reduce, but perhaps take a long time to do so',
@@ -426,6 +431,7 @@ if __name__ == '__main__':
         args.shaddap,
         args.die_on_pass_bug,
         args.no_diagnostics_on_pass_bug,
+        args.no_dir_on_timeout,
         args.print_diff,
         args.max_improvement,
         args.no_give_up,

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -155,6 +155,7 @@ class TestManager:
         silent_pass_bug,
         die_on_pass_bug,
         no_diagnostics_on_pass_bug,
+        no_dir_on_timeout,
         print_diff,
         max_improvement,
         no_give_up,
@@ -175,6 +176,7 @@ class TestManager:
         self.silent_pass_bug = silent_pass_bug
         self.die_on_pass_bug = die_on_pass_bug
         self.no_diagnostics_on_pass_bug = no_diagnostics_on_pass_bug
+        self.no_dir_on_timeout = no_dir_on_timeout
         self.print_diff = print_diff
         self.max_improvement = max_improvement
         self.no_give_up = no_give_up
@@ -415,7 +417,8 @@ class TestManager:
                     if type(future.exception()) in (TimeoutError, concurrent.futures.TimeoutError):
                         self.timeout_count += 1
                         logging.warning('Test timed out.')
-                        self.save_extra_dir(self.temporary_folders[future])
+                        if not self.no_dir_on_timeout:
+                            self.save_extra_dir(self.temporary_folders[future])
                         if self.timeout_count >= self.MAX_TIMEOUTS:
                             logging.warning('Maximum number of timeout were reached: %d' % self.MAX_TIMEOUTS)
                             quit_loop = True


### PR DESCRIPTION
Allows reducing on cvise errors for when otherwise cvise can't reduce the source code by much fixes #173 ~~I'm yet to test this patch~~ it works!