### PR TITLE
ruff: Assume Python 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,5 +64,5 @@ jobs:
     - run: zypper -n install python3-pip
     - uses: actions/checkout@v4
     - run: pip install --break-system-packages ruff
-    - run: ruff check
+    - run: ruff check --target-version py38
     - run: ruff format --diff


### PR DESCRIPTION
This is to prevent the Ruff linter from complaining on valid code needed for
compatibility with Python 3.8 - e.g., the usage of types imported from the
"typing" module.

Ruff assumes Python 3.9 by default, meanwhile C-Vise according to is
INSTALL.md only requires 3.8.

This commit is preparation for #175.