### PR TITLE
CI: Stop testing LLVM 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        llvm: [17, 18, 19, 20]
+        llvm: [18, 19, 20]
         build-type: [DEBUG]
         include:
           - llvm: 20


### PR DESCRIPTION
The support for LLVM 17 has been removed from openSUSE: https://build.opensuse.org/request/show/1270227 . openSUSE is the container used for CI jobs.

This fixes #178.