### PR TITLE
Refactor arg passing for Pass.new()

### DIFF
--- a/cvise/passes/balanced.py
+++ b/cvise/passes/balanced.py
@@ -16,7 +16,7 @@ class BalancedPass(AbstractPass):
 
         return m
 
-    def new(self, test_case, _=None):
+    def new(self, test_case, **kwargs):
         return self.__get_next_match(test_case, pos=0)
 
     def advance(self, test_case, state):

--- a/cvise/passes/blank.py
+++ b/cvise/passes/blank.py
@@ -10,7 +10,7 @@ class BlankPass(AbstractPass):
     def check_prerequisites(self):
         return True
 
-    def new(self, test_case, _=None):
+    def new(self, test_case, **kwargs):
         return 0
 
     def advance(self, test_case, state):

--- a/cvise/passes/clang.py
+++ b/cvise/passes/clang.py
@@ -10,7 +10,7 @@ class ClangPass(AbstractPass):
     def check_prerequisites(self):
         return self.check_external_program('clang_delta')
 
-    def new(self, test_case, _=None):
+    def new(self, test_case, **kwargs):
         return 1
 
     def advance(self, test_case, state):

--- a/cvise/passes/clangbinarysearch.py
+++ b/cvise/passes/clangbinarysearch.py
@@ -33,7 +33,7 @@ class ClangBinarySearchPass(AbstractPass):
         # Use the best standard option
         self.clang_delta_std = best
 
-    def new(self, test_case, _=None):
+    def new(self, test_case, **kwargs):
         if not self.user_clang_delta_std:
             self.detect_best_standard(test_case)
         else:

--- a/cvise/passes/clex.py
+++ b/cvise/passes/clex.py
@@ -9,7 +9,7 @@ class ClexPass(AbstractPass):
     def check_prerequisites(self):
         return self.check_external_program('clex')
 
-    def new(self, test_case, _=None):
+    def new(self, test_case, **kwargs):
         return 0
 
     def advance(self, test_case, state):

--- a/cvise/passes/comments.py
+++ b/cvise/passes/comments.py
@@ -7,7 +7,7 @@ class CommentsPass(AbstractPass):
     def check_prerequisites(self):
         return True
 
-    def new(self, test_case, _=None):
+    def new(self, test_case, **kwargs):
         return -2
 
     def advance(self, test_case, state):

--- a/cvise/passes/gcdabinary.py
+++ b/cvise/passes/gcdabinary.py
@@ -36,7 +36,7 @@ class GCDABinaryPass(AbstractPass):
             logging.warning(f'gcov-dump -p failed: {e}')
             return None
 
-    def new(self, test_case, check_sanity=None):
+    def new(self, test_case, **kwargs):
         return self.__create_state(test_case)
 
     def advance(self, test_case, state):

--- a/cvise/passes/ifs.py
+++ b/cvise/passes/ifs.py
@@ -32,7 +32,7 @@ class IfPass(AbstractPass):
                         in_multiline = True
         return count
 
-    def new(self, test_case, _=None):
+    def new(self, test_case, **kwargs):
         bs = BinaryState.create(self.__count_instances(test_case))
         if bs:
             bs.value = 0

--- a/cvise/passes/includeincludes.py
+++ b/cvise/passes/includeincludes.py
@@ -10,7 +10,7 @@ class IncludeIncludesPass(AbstractPass):
     def check_prerequisites(self):
         return True
 
-    def new(self, test_case, _=None):
+    def new(self, test_case, **kwargs):
         return 1
 
     def advance(self, test_case, state):

--- a/cvise/passes/includes.py
+++ b/cvise/passes/includes.py
@@ -10,7 +10,7 @@ class IncludesPass(AbstractPass):
     def check_prerequisites(self):
         return True
 
-    def new(self, test_case, _=None):
+    def new(self, test_case, **kwargs):
         return 1
 
     def advance(self, test_case, state):

--- a/cvise/passes/indent.py
+++ b/cvise/passes/indent.py
@@ -6,7 +6,7 @@ class IndentPass(AbstractPass):
     def check_prerequisites(self):
         return self.check_external_program('clang-format')
 
-    def new(self, test_case, _=None):
+    def new(self, test_case, **kwargs):
         return 0
 
     def advance(self, test_case, state):

--- a/cvise/passes/ints.py
+++ b/cvise/passes/ints.py
@@ -70,7 +70,7 @@ class IntsPass(AbstractPass):
         config['replace_fn'] = replace_fn
         return config
 
-    def new(self, test_case, _=None):
+    def new(self, test_case, **kwargs):
         config = self.__get_config()
         with open(test_case) as in_file:
             prog = in_file.read()

--- a/cvise/passes/line_markers.py
+++ b/cvise/passes/line_markers.py
@@ -20,7 +20,7 @@ class LineMarkersPass(AbstractPass):
                     count += 1
         return count
 
-    def new(self, test_case, _=None):
+    def new(self, test_case, **kwargs):
         return BinaryState.create(self.__count_instances(test_case))
 
     def advance(self, test_case, state):

--- a/cvise/passes/lines.py
+++ b/cvise/passes/lines.py
@@ -61,7 +61,7 @@ class LinesPass(AbstractPass):
             lines = in_file.readlines()
             return len(lines)
 
-    def new(self, test_case, check_sanity=None):
+    def new(self, test_case, check_sanity=None, **kwargs):
         self.bailout = False
         # None means no topformflat
         if self.arg != 'None':

--- a/cvise/passes/peep.py
+++ b/cvise/passes/peep.py
@@ -174,7 +174,7 @@ class PeepPass(AbstractPass):
     def check_prerequisites(self):
         return True
 
-    def new(self, test_case, _=None):
+    def new(self, test_case, **kwargs):
         return {'pos': 0, 'regex': 0}
 
     def advance(self, test_case, state):

--- a/cvise/passes/special.py
+++ b/cvise/passes/special.py
@@ -44,7 +44,7 @@ class SpecialPass(AbstractPass):
 
         return m
 
-    def new(self, test_case, _=None):
+    def new(self, test_case, **kwargs):
         config = self.__get_config()
         with open(test_case) as in_file:
             prog = in_file.read()

--- a/cvise/passes/ternary.py
+++ b/cvise/passes/ternary.py
@@ -33,7 +33,7 @@ class TernaryPass(AbstractPass):
 
         return m
 
-    def new(self, test_case, _=None):
+    def new(self, test_case, **kwargs):
         return self.__get_next_match(test_case, pos=0)
 
     def advance(self, test_case, state):

--- a/cvise/passes/unifdef.py
+++ b/cvise/passes/unifdef.py
@@ -11,7 +11,7 @@ class UnIfDefPass(AbstractPass):
     def check_prerequisites(self):
         return self.check_external_program('unifdef')
 
-    def new(self, test_case, _=None):
+    def new(self, test_case, **kwargs):
         return 0
 
     def advance(self, test_case, state):

--- a/cvise/tests/test_test_manager.py
+++ b/cvise/tests/test_test_manager.py
@@ -20,7 +20,7 @@ class StubPass(AbstractPass):
         super().__init__()
         self.max_transforms = None
 
-    def new(self, test_case, check_sanity):
+    def new(self, test_case, **kwargs):
         return 0
 
     def advance(self, test_case, state):

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -570,7 +570,7 @@ class TestManager:
                             continue
 
                 # create initial state
-                self.state = self.current_pass.new(self.current_test_case, self.check_sanity)
+                self.state = self.current_pass.new(self.current_test_case, check_sanity=self.check_sanity)
                 self.skip = False
 
                 while self.state is not None and not self.skip:


### PR DESCRIPTION
Change all subclasses to use **kwargs instead of mentioning the unused parameter (using the real name or using "_").

This refactoring allows us to easily add/remove parameters needed for specific subclasses without having to change unrelated classes. This is preparation work for adding new logic for #169.