### PR TITLE
hints: Migrate line_markers pass

### DIFF
--- a/cvise/passes/line_markers.py
+++ b/cvise/passes/line_markers.py
@@ -1,46 +1,21 @@
-import os
 import re
-import shutil
-import tempfile
 
-from cvise.passes.abstract import AbstractPass, BinaryState, PassResult
+from cvise.passes.hint_based import HintBasedPass
 
 
-class LineMarkersPass(AbstractPass):
+class LineMarkersPass(HintBasedPass):
     line_regex = re.compile('^\\s*#\\s*[0-9]+')
 
     def check_prerequisites(self):
         return True
 
-    def __count_instances(self, test_case):
-        count = 0
+    def generate_hints(self, test_case):
+        hints = []
         with open(test_case) as in_file:
+            file_pos = 0
             for line in in_file.readlines():
+                end_pos = file_pos + len(line)
                 if self.line_regex.search(line):
-                    count += 1
-        return count
-
-    def new(self, test_case, **kwargs):
-        return BinaryState.create(self.__count_instances(test_case))
-
-    def advance(self, test_case, state):
-        return state.advance()
-
-    def advance_on_success(self, test_case, state):
-        return state.advance_on_success(self.__count_instances(test_case))
-
-    def transform(self, test_case, state, process_event_notifier):
-        tmp = os.path.dirname(test_case)
-        with tempfile.NamedTemporaryFile(mode='w+', delete=False, dir=tmp) as tmp_file:
-            with open(test_case) as in_file:
-                i = 0
-                for line in in_file.readlines():
-                    if self.line_regex.search(line):
-                        if i < state.index or i >= state.end():
-                            tmp_file.write(line)
-                        i += 1
-                    else:
-                        tmp_file.write(line)
-
-        shutil.move(tmp_file.name, test_case)
-        return (PassResult.OK, state)
+                    hints.append({'p': [{'l': file_pos, 'r': end_pos}]})
+                file_pos = end_pos
+        return hints

--- a/cvise/passes/line_markers.py
+++ b/cvise/passes/line_markers.py
@@ -4,6 +4,23 @@ from cvise.passes.hint_based import HintBasedPass
 
 
 class LineMarkersPass(HintBasedPass):
+    """A pass that removes C/C++ preprocessor line markers.
+
+    Quoting the GCC documentation on the preprocessor output:
+
+    > Source file name and line number information is conveyed by lines of the form
+    > # linenum filename flags
+    > These are called linemarkers. They are inserted as needed into the output (but never within a string or character
+    > constant).
+
+    Since minimization inputs are typically preprocessed C/C++ programs, there are line markers in them. They bloat
+    the input size while not usually (*) being essential for the interestingness test, hence this special pass
+    attempts recognizing and deleting them.
+
+    (*) Sometimes the line markers are crucial (e.g., for compiler logic that depends on whether code lives in a
+    system header) and cannot be removed. Also the pass implementation, being a simple regexp, can have false positives.
+    """
+
     line_regex = re.compile('^\\s*#\\s*[0-9]+')
 
     def check_prerequisites(self):

--- a/cvise/tests/test_line_markers.py
+++ b/cvise/tests/test_line_markers.py
@@ -1,6 +1,7 @@
 import pytest
 
 from cvise.passes.line_markers import LineMarkersPass
+from cvise.tests.testabstract import collect_all_transforms
 
 
 @pytest.fixture
@@ -8,27 +9,36 @@ def input_path(tmp_path):
     return tmp_path / 'input.cc'
 
 
-def init_pass(input_path):
+def init_pass(tmp_path, input_path):
     pass_ = LineMarkersPass()
-    state = pass_.new(input_path)
+    state = pass_.new(input_path, tmp_dir=tmp_path)
     return pass_, state
 
 
-def test_all(input_path):
+def test_all(tmp_path, input_path):
     input_path.write_text("# 1 'foo.h'\n# 2 'bar.h'\n#4   'x.h'")
-    pass_, state = init_pass(input_path)
+    pass_, state = init_pass(tmp_path, input_path)
 
     (_, state) = pass_.transform(input_path, state, None)
 
-    assert state.index == 0
-    assert state.instances == 3
     assert input_path.read_text() == ''
 
 
-def test_only_last(input_path):
+def test_only_last(tmp_path, input_path):
     input_path.write_text("# 1 'foo.h'\n# 2 'bar.h'\n#4   'x.h\nint x = 2;")
-    pass_, state = init_pass(input_path)
+    pass_, state = init_pass(tmp_path, input_path)
 
     (_, state) = pass_.transform(input_path, state, None)
 
     assert input_path.read_text() == 'int x = 2;'
+
+
+def test_all_iteration(tmp_path, input_path):
+    input_path.write_text("# 1 'foo.h'\n# 2 'bar.h'\nint x = 2;\n# 4 'x.h'")
+    pass_, state = init_pass(tmp_path, input_path)
+
+    all_transforms = collect_all_transforms(pass_, state, input_path)
+
+    assert "# 2 'bar.h'\nint x = 2;\n# 4 'x.h'" in all_transforms
+    assert "# 1 'foo.h'\nint x = 2;\n# 4 'x.h'" in all_transforms
+    assert "# 1 'foo.h'\n# 2 'bar.h'\nint x = 2;\n" in all_transforms


### PR DESCRIPTION
Reimplement the line_markers pass using the hints architecture -
this acts as the simple first example of a heuristic implemented that
way. This migration is intended to have no functional changes.

This is part of the effort tracked by #169.