### PR TITLE
CI: Allow manual trigger of Github Actions

### DIFF
--- a/.github/workflows/build-llvm-nightly.yml
+++ b/.github/workflows/build-llvm-nightly.yml
@@ -7,6 +7,7 @@ on:
     branches: [ master ]
   schedule:
     - cron: '0 3 * * *'
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
According to Github docs, manually triggering a Github action requires
the `workflow_dispatch` event to be configured.

This will be useful to manually trigger a CI run when the default trigger
doesn't work for whatever reason (e.g., observed for PRs that depend on
others).