### PR TITLE
Improve Lines: only remove exactly at given depth

### DIFF
--- a/cvise/tests/test_lines.py
+++ b/cvise/tests/test_lines.py
@@ -37,15 +37,31 @@ def advance_until(pass_, state, input_path, predicate):
         assert state is not None
 
 
+def is_valid_brace_sequence(s):
+    balance = 0
+    for c in s:
+        if c == '{':
+            balance += 1
+        elif c == '}':
+            balance -= 1
+        if balance < 0:
+            return False
+    return balance == 0
+
+
 def test_func_namespace_level0(tmp_path, input_path):
     """Test that arg=0 deletes top-level functions and namespaces."""
     write_file(input_path, 'int f() {\nchar x;\n}\nnamespace foo\n{\n}\n')
     p, state = init_pass('0', tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
+
     # removal of the namespace
     assert 'int f() {\nchar x;\n}\n' in all_transforms
     # removal of f()
     assert '\nnamespace foo\n{\n}\n' in all_transforms
+    # check no transform violates curly brace sequences
+    for s in all_transforms:
+        assert is_valid_brace_sequence(s)
 
 
 def test_func_namespace_level1(tmp_path, input_path):
@@ -53,10 +69,16 @@ def test_func_namespace_level1(tmp_path, input_path):
     write_file(input_path, 'int f() {\nchar x;\n}\nnamespace foo\n{\nvoid g() {\n}\n}\n')
     p, state = init_pass('1', tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
+
     # removal of code inside f()
     assert 'int f() {\n}\nnamespace foo\n{\nvoid g() {\n}\n}\n' in all_transforms
     # removal of code inside foo
     assert 'int f() {\nchar x;\n}\nnamespace foo\n{\n}\n' in all_transforms
+    # removal of both
+    assert 'int f() {\n}\nnamespace foo\n{\n}\n' in all_transforms
+    # check no transform violates curly brace sequences
+    for s in all_transforms:
+        assert is_valid_brace_sequence(s)
 
 
 def test_multiline_func_signature_level0(tmp_path, input_path):
@@ -64,9 +86,13 @@ def test_multiline_func_signature_level0(tmp_path, input_path):
     write_file(input_path, 'template <class T>\nSomeVeryLongType\nf()\n{\n}')
     p, state = init_pass('0', tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
+
     assert '' in all_transforms
     # no attempts to partially remove the function
     assert len(all_transforms) == 1
+    # check no transform violates curly brace sequences
+    for s in all_transforms:
+        assert is_valid_brace_sequence(s)
 
 
 def test_multiline_func_signature_level1(tmp_path, input_path):
@@ -74,12 +100,175 @@ def test_multiline_func_signature_level1(tmp_path, input_path):
     write_file(input_path, 'namespace {\ntemplate <class T>\nint\nf()\n{\n}\n}\n')
     p, state = init_pass('1', tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
+
     assert 'namespace {\n}\n' in all_transforms
     # the (multi-line) func must be deleted as a whole, not partially
     # FIXME: Improve the heuristic to not try removing just the opening `namespace {` part,
     # and replace the assertion here with "len(all_transforms) == 1".
     for s in all_transforms:
         assert ('template' in s) == ('f()' in s)
+    # check no transform violates curly brace sequences
+    for s in all_transforms:
+        assert is_valid_brace_sequence(s)
+
+
+def test_class_with_methods_level0(tmp_path, input_path):
+    """Test that arg=0 deletes the whole class definition."""
+    write_file(
+        input_path,
+        """
+        class A {
+          void f() {
+            int first;
+            int second;
+          }
+          int g() {
+            return 42;
+          }
+        };
+        """,
+    )
+    p, state = init_pass('0', tmp_path, input_path)
+    all_transforms = collect_all_transforms(p, state, input_path)
+
+    # the first statement in f() deleted
+    assert '' in all_transforms
+    # check no transform violates curly brace sequences
+    for s in all_transforms:
+        assert is_valid_brace_sequence(s)
+
+
+def test_class_with_methods_level1(tmp_path, input_path):
+    """Test that arg=1 deletes class methods."""
+    write_file(
+        input_path,
+        """
+        class A {
+          void f() {
+            int first;
+            int second;
+          }
+          int g() {
+            return 42;
+          }
+        };
+        """,
+    )
+    p, state = init_pass('1', tmp_path, input_path)
+    all_transforms = collect_all_transforms(p, state, input_path)
+
+    # f() deleted
+    assert (
+        """
+        class A {
+          int g() {
+            return 42;
+          }
+        };
+        """
+        in all_transforms
+    )
+    # g() deleted
+    assert (
+        """
+        class A {
+          void f() {
+            int first;
+            int second;
+          }
+        };
+        """
+        in all_transforms
+    )
+    # both f() and g() deleted
+    assert (
+        """
+        class A {
+        };
+        """
+        in all_transforms
+    )
+    # check no transform violates curly brace sequences
+    for s in all_transforms:
+        assert is_valid_brace_sequence(s)
+
+
+def test_class_with_methods_level2(tmp_path, input_path):
+    """Test that arg=2 deletes statements in class methods."""
+    write_file(
+        input_path,
+        """
+        class A {
+          void f() {
+            int first;
+            int second;
+          }
+          int g() {
+            return 42;
+          }
+        };
+        """,
+    )
+    p, state = init_pass('2', tmp_path, input_path)
+    all_transforms = collect_all_transforms(p, state, input_path)
+
+    # the first statement in f() deleted
+    assert (
+        """
+        class A {
+          void f() {
+            int second;
+          }
+          int g() {
+            return 42;
+          }
+        };
+        """
+        in all_transforms
+    )
+    # the second statement in f() deleted
+    assert (
+        """
+        class A {
+          void f() {
+            int first;
+          }
+          int g() {
+            return 42;
+          }
+        };
+        """
+        in all_transforms
+    )
+    # the statement in g() deleted
+    assert (
+        """
+        class A {
+          void f() {
+            int first;
+            int second;
+          }
+          int g() {
+          }
+        };
+        """
+        in all_transforms
+    )
+    # all statements in f() and g() deleted
+    assert (
+        """
+        class A {
+          void f() {
+          }
+          int g() {
+          }
+        };
+        """
+        in all_transforms
+    )
+    # check no transform violates curly brace sequences
+    for s in all_transforms:
+        assert is_valid_brace_sequence(s)
 
 
 def test_c_comment(tmp_path, input_path):
@@ -121,6 +310,7 @@ def test_transform_deletes_lines_range(tmp_path, input_path):
     write_file(input_path, 'A;\nB;\nC;\nD;\nE;\nF;\nG;\nH;\n')
     p, state = init_pass('0', tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
+
     # deletion of a half:
     assert 'A;\nB;\nC;\nD;\n' in all_transforms
     assert '\nE;\nF;\nG;\nH;\n' in all_transforms
@@ -143,4 +333,5 @@ def test_advance_on_success(tmp_path, input_path):
     # interestingness test.
     state = advance_until(p, state, input_path, lambda s: 'bar' in s)
     p.advance_on_success(input_path, state)
+
     assert read_file(input_path) == '\nbar;\n'

--- a/cvise/tests/test_lines.py
+++ b/cvise/tests/test_lines.py
@@ -131,7 +131,6 @@ def test_class_with_methods_level0(tmp_path, input_path):
     p, state = init_pass('0', tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
 
-    # the first statement in f() deleted
     assert '' in all_transforms
     # check no transform violates curly brace sequences
     for s in all_transforms:

--- a/delta/topformflat.l
+++ b/delta/topformflat.l
@@ -11,7 +11,8 @@
 // debugging diagnostic, emitted when enabled
 void diag(char const *str);
 
-// handle a possible newline insertion if nesting <= threshold
+// handle possible toplevel block boundaries if nesting <= threshold
+void possibleChunkBegin(int pos);
 void possibleChunkEnd(int pos);
 
 // index of byte where the current yytext ends in the input.
@@ -50,7 +51,7 @@ int threshold = 0;
 "/\n"         { }     /* end of C comment */
 
 "{"           { nesting++;
-                possibleChunkEnd(token_end_pos);      // so the header is separated from the components
+                possibleChunkBegin(token_end_pos);      // so the header is separated from the components
               }
 
 "}"(";"?)     { nesting--;
@@ -96,12 +97,20 @@ void diag(char const *str)
   //printf("%s", str);
 }
 
-void possibleChunkEnd(int pos)
+void possibleChunkBegin(int pos)
 {
-  if (nesting <= threshold && chunk_start_pos < pos) {
-    printf("{\"p\":[{\"l\":%d,\"r\":%d}]}\n", chunk_start_pos, pos);
+  if (nesting <= threshold) {
     chunk_start_pos = pos;
   }
+}
+
+void possibleChunkEnd(int pos)
+{
+  // Only attempt deleting chunks exactly at the specified nesting.
+  if (nesting == threshold && chunk_start_pos < pos) {
+    printf("{\"p\":[{\"l\":%d,\"r\":%d}]}\n", chunk_start_pos, pos);
+  }
+  possibleChunkBegin(pos);
 }
 
 char *version = "2025.6.25";


### PR DESCRIPTION
Stop producing hints for deleting code at levels smaller than the specified
depth (threshold). This should significantly improve the success rate for
all depths greater than zero, because we'll stop trying partially removing
outer constructs.

For example, for a top-level C function, running Lines with arg=1 should
only attempt removing statements inside the function body, but don't
try deleting the function signature alone or deleting the closing curly
brace alone.

Note: the downside of this change is that when running Lines for arg>1,
the heuristic will stop trying to delete higher-level chunks of code. We
consider this not to be a problem because one of planned follow-up
changes will run all Lines passes concurrently, in an interleaving fashion.