### PR TITLE
Abort active jobs when there's an exception

### DIFF
--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -489,49 +489,54 @@ class TestManager:
     def run_parallel_tests(self) -> Union[Job, None]:
         assert not self.jobs
         with pebble.ProcessPool(max_workers=self.parallel_tests) as pool:
-            order = 1
-            self.timeout_count = 0
-            self.giveup_reported = False
-            while self.state is not None:
-                # do not create too many states
-                if len(self.jobs) >= self.parallel_tests:
-                    wait([job.future for job in self.jobs], return_when=FIRST_COMPLETED)
+            try:
+                order = 1
+                self.timeout_count = 0
+                self.giveup_reported = False
+                while self.state is not None:
+                    # do not create too many states
+                    if len(self.jobs) >= self.parallel_tests:
+                        wait([job.future for job in self.jobs], return_when=FIRST_COMPLETED)
 
-                quit_loop = self.process_done_futures()
-                if quit_loop:
-                    success = self.wait_for_first_success()
-                    self.terminate_all(pool)
-                    return success
+                    quit_loop = self.process_done_futures()
+                    if quit_loop:
+                        success = self.wait_for_first_success()
+                        self.terminate_all(pool)
+                        return success
 
-                folder = Path(tempfile.mkdtemp(prefix=self.TEMP_PREFIX, dir=self.root))
-                test_env = TestEnvironment(
-                    self.state,
-                    order,
-                    self.test_script,
-                    folder,
-                    self.current_test_case,
-                    self.test_cases,
-                    self.current_pass.transform,
-                    self.pid_queue,
-                )
-                future = pool.schedule(test_env.run, timeout=self.timeout)
-                self.pass_statistic.add_executed(self.current_pass)
-                self.jobs.append(
-                    Job(
-                        future=future,
-                        pass_=self.current_pass,
-                        temporary_folder=folder,
+                    folder = Path(tempfile.mkdtemp(prefix=self.TEMP_PREFIX, dir=self.root))
+                    test_env = TestEnvironment(
+                        self.state,
+                        order,
+                        self.test_script,
+                        folder,
+                        self.current_test_case,
+                        self.test_cases,
+                        self.current_pass.transform,
+                        self.pid_queue,
                     )
-                )
-                order += 1
-                state = self.current_pass.advance(self.current_test_case, self.state)
-                # we are at the end of enumeration
-                if state is None:
-                    success = self.wait_for_first_success()
-                    self.terminate_all(pool)
-                    return success
-                else:
-                    self.state = state
+                    future = pool.schedule(test_env.run, timeout=self.timeout)
+                    self.pass_statistic.add_executed(self.current_pass)
+                    self.jobs.append(
+                        Job(
+                            future=future,
+                            pass_=self.current_pass,
+                            temporary_folder=folder,
+                        )
+                    )
+                    order += 1
+                    state = self.current_pass.advance(self.current_test_case, self.state)
+                    # we are at the end of enumeration
+                    if state is None:
+                        success = self.wait_for_first_success()
+                        self.terminate_all(pool)
+                        return success
+                    else:
+                        self.state = state
+            except:
+                # Abort running jobs - by default the process pool waits for the ongoing jobs' completion.
+                self.terminate_all(pool)
+                raise
 
     def run_pass(self, pass_):
         if self.start_with_pass:

--- a/tests/test_cvise.py
+++ b/tests/test_cvise.py
@@ -1,19 +1,28 @@
 import os
 import shutil
+import signal
 import stat
 import subprocess
+import time
 import unittest
 
 
 class TestCvise(unittest.TestCase):
     @classmethod
-    def check_cvise(cls, testcase, arguments, expected):
+    def start_cvise(cls, testcase, arguments):
         current = os.path.dirname(__file__)
         binary = os.path.join(current, '../cvise-cli.py')
         shutil.copy(os.path.join(current, 'sources', testcase), '.')
         os.chmod(testcase, 0o644)
         cmd = f'{binary} {testcase} {arguments}'
-        subprocess.check_output(cmd, shell=True, encoding='utf8')
+        return subprocess.Popen(cmd, shell=True, encoding='utf8')
+
+    @classmethod
+    def check_cvise(cls, testcase, arguments, expected):
+        proc = cls.start_cvise(testcase, arguments)
+        proc.communicate()
+        assert proc.returncode == 0
+
         with open(testcase) as f:
             content = f.read()
         assert content in expected
@@ -25,3 +34,19 @@ class TestCvise(unittest.TestCase):
             '-c "gcc -c blocksort-part.c && grep nextHi blocksort-part.c"',
             ['#define nextHi', '#define  nextHi'],
         )
+
+    @unittest.skipUnless(os.name == 'posix', 'requires POSIX')
+    def test_ctrl_c(self):
+        """Test that Control-C is handled quickly, without waiting for jobs to finish."""
+        INIT_DELAY = 1  # semi-arbitrary delay to let the C-Vise start doing actual work
+        MAX_SHUTDOWN = 10  # tolerance on C-Vise shutdown to prevent flakiness (normally it's fractions of seconds)
+        JOB_SLOWNESS = (INIT_DELAY + MAX_SHUTDOWN) * 2  # make a single job slower than the thresholds
+
+        proc = self.start_cvise(
+            'blocksort-part.c',
+            f'-c "gcc -c blocksort-part.c && sleep {JOB_SLOWNESS}" --skip-interestingness-test-check')
+        time.sleep(INIT_DELAY)
+
+        proc.send_signal(signal.SIGINT)
+        proc.communicate(timeout=MAX_SHUTDOWN)
+        # no assertions needed - a slow shutdown would manifest as a TimeoutExpired exception


### PR DESCRIPTION
Don't wait for already started transform/check jobs if there's an exception raised - which can be because of a real issue or because the user pressed the interrupt hotkey.

This makes C-Vise slightly more responsive when big/slow inputs are involved.