### PR TITLE
interleaving: Manager can run different passes simultaneously

### DIFF
--- a/cvise/cvise.py
+++ b/cvise/cvise.py
@@ -185,7 +185,7 @@ class CVise:
             if not p.check_prerequisites():
                 logging.error(f'Skipping {p}')
             else:
-                self.test_manager.run_pass(p)
+                self.test_manager.run_passes([p])
 
     def _run_main_passes(self, passes):
         while True:
@@ -206,7 +206,7 @@ class CVise:
                 if not p.check_prerequisites():
                     logging.error(f'Skipping pass {p}')
                 else:
-                    self.test_manager.run_pass(p)
+                    self.test_manager.run_passes([p])
 
             logging.info(f'Termination check: size was {total_file_size}; now {self.test_manager.total_file_size}')
 

--- a/cvise/tests/test_test_manager.py
+++ b/cvise/tests/test_test_manager.py
@@ -104,9 +104,6 @@ class LetterRemovingPass(StubPass):
         super().__init__()
         self.letters_to_remove = letters_to_remove
 
-    def __repr__(self):
-        return f'LetterRemovingPass(letters_to_remove={self.letters_to_remove})'
-
     def transform(self, test_case, state, process_event_notifier):
         text = read_file(test_case)
         instances = 0

--- a/cvise/tests/test_test_manager.py
+++ b/cvise/tests/test_test_manager.py
@@ -160,7 +160,7 @@ def input_file(tmp_path):
 
 @pytest.fixture
 def interestingness_script():
-    """The default interestingness script, which trivially returns true.
+    """The default interestingness script, which trivially returns success.
 
     Can be overridden in particular tests."""
     # Just eat the test file name.
@@ -278,12 +278,13 @@ def test_interleaving_letter_removals(input_file, manager):
     assert read_file(input_file) == 'oo\nar\na\n'
 
 
+@pytest.mark.skipif(os.name != 'posix', reason='requires POSIX for command-line tools')
 @pytest.mark.parametrize('interestingness_script', [r"grep a {test_case} && ! grep '\(.\)\1' {test_case}"])
 def test_interleaving_letter_removals_large(input_file, manager):
-    """Test that multiple passes executed in interleaving way can delete all characters in a specific order.
+    """Test that multiple passes executed in interleaving way can delete all but one characters.
 
-    The interestingness test here is "there's the `a` character and no character is repeated immediately", which for
-    the given test requires switching between removing `a`, `b` and `c` many times."""
+    The interestingness test here is "there's the `a` character and no character is repeated twice in a row", which for
+    the given test requires alternating between removing `a`, `b` and `c` many times."""
     input_file.write_text('ababacac' * PARALLEL_TESTS)
     p1 = LetterRemovingPass('a')
     p2 = LetterRemovingPass('b')

--- a/cvise/tests/test_test_manager.py
+++ b/cvise/tests/test_test_manager.py
@@ -278,7 +278,7 @@ def test_interleaving_letter_removals(input_file, manager):
 @pytest.mark.skipif(os.name != 'posix', reason='requires POSIX for command-line tools')
 @pytest.mark.parametrize('interestingness_script', [r"grep a {test_case} && ! grep '\(.\)\1' {test_case}"])
 def test_interleaving_letter_removals_large(input_file, manager):
-    """Test that multiple passes executed in interleaving way can delete all but one characters.
+    """Test that multiple passes executed in interleaving way can delete all but one character.
 
     The interestingness test here is "there's the `a` character and no character is repeated twice in a row", which for
     the given test requires alternating between removing `a`, `b` and `c` many times."""

--- a/cvise/tests/test_test_manager.py
+++ b/cvise/tests/test_test_manager.py
@@ -114,7 +114,7 @@ class LetterRemovingPass(StubPass):
             if c in self.letters_to_remove:
                 if instances == state:
                     # Found a matching letter with the expected index; remove it.
-                    Path(test_case).write_text(text[:i] + text[i+1:])
+                    Path(test_case).write_text(text[:i] + text[i + 1 :])
                     return (PassResult.OK, state)
                 instances += 1
         return (PassResult.STOP, state)

--- a/cvise/utils/statistics.py
+++ b/cvise/utils/statistics.py
@@ -16,13 +16,15 @@ class PassStatistic:
     def __init__(self):
         self.stats = {}
 
-    def add_newed(self, pass_: AbstractPass, start_time: float) -> None:
+    def add_initialized(self, pass_: AbstractPass, start_time: float) -> None:
+        """Record a completion of a new() method for a pass."""
         pass_name = repr(pass_)
         if pass_name not in self.stats:
             self.stats[pass_name] = SinglePassStatistic(pass_name)
         self.stats[pass_name].total_seconds += time.monotonic() - start_time
 
     def add_executed(self, pass_: AbstractPass, start_time: float, parallel_workers: int) -> None:
+        """Record a completion of a transformation and checking task for a pass."""
         pass_name = repr(pass_)
         stat = self.stats[pass_name]
         stat.totally_executed += 1
@@ -30,10 +32,12 @@ class PassStatistic:
         stat.total_seconds += (time.monotonic() - start_time) / parallel_workers
 
     def add_success(self, pass_):
+        """Record that a transformation by the pass passes the interestingness test."""
         pass_name = repr(pass_)
         self.stats[pass_name].worked += 1
 
     def add_failure(self, pass_):
+        """Record that a transformation by the pass failed or didn't pass the interestingness test."""
         pass_name = repr(pass_)
         self.stats[pass_name].failed += 1
 

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -607,9 +607,11 @@ class TestManager:
                 self.states = []
                 for pass_id, pass_ in enumerate(self.current_passes):
                     start_time = time.monotonic()
-                    self.states.append(pass_.new(
-                        self.current_test_case, check_sanity=self.check_sanity, tmp_dir=Path(self.roots[pass_id])
-                    ))
+                    self.states.append(
+                        pass_.new(
+                            self.current_test_case, check_sanity=self.check_sanity, tmp_dir=Path(self.roots[pass_id])
+                        )
+                    )
                     self.pass_statistic.add_newed(pass_, start_time)
                 self.skip = False
 

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -603,7 +603,6 @@ class TestManager:
                             continue
 
                 # create initial states
-
                 self.states = []
                 for pass_id, pass_ in enumerate(self.current_passes):
                     start_time = time.monotonic()
@@ -612,7 +611,7 @@ class TestManager:
                             self.current_test_case, check_sanity=self.check_sanity, tmp_dir=Path(self.roots[pass_id])
                         )
                     )
-                    self.pass_statistic.add_newed(pass_, start_time)
+                    self.pass_statistic.add_initialized(pass_, start_time)
                 self.skip = False
 
                 while any(state is not None for state in self.states) and not self.skip:


### PR DESCRIPTION
Add basic support of executing different passes in an interleaving fashion to TestManager.

This paves the way for improving performance, both worst-case (to avoid C-Vise being
stuck on a badly performing heuristic meanwhile others would reduce the file quicker)
as well as average-case (once we implement folding of concurrently-discovered
reductions). We only plan to enable the interleaving mode for hint-based passes,
because they are designed to leave inputs unmodified and to have easily mergeable
reductions.

This commit doesn't wire up new logic to the CLI; only tests exercise this mode at the moment.