### PR TITLE
hints: Add CLI for applying hints to input

### DIFF
--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -26,7 +26,7 @@ from cvise.utils import misc, statistics, testing  # noqa: E402
 from cvise.utils.error import CViseError  # noqa: E402
 from cvise.utils.error import MissingPassGroupsError  # noqa: E402
 from cvise.utils.externalprograms import find_external_programs  # noqa: E402
-from cvise.utils.hint import apply_hints, load_hints
+from cvise.utils.hint import apply_hints, load_hints  # noqa: E402
 import psutil  # noqa: E402
 
 

--- a/cvise/passes/hint_based.py
+++ b/cvise/passes/hint_based.py
@@ -57,7 +57,8 @@ class HintBasedPass(AbstractPass, metaclass=ABCMeta):
         hints_range_begin = state.binary_state.index
         hints_range_end = state.binary_state.end()
         hints = load_hints(state.hints_file_path, hints_range_begin, hints_range_end)
-        apply_hints(hints, Path(test_case))
+        new_data = apply_hints(hints, Path(test_case))
+        Path(test_case).write_text(new_data)
         return (PassResult.OK, state)
 
     def advance(self, test_case, state):

--- a/cvise/tests/test_hint.py
+++ b/cvise/tests/test_hint.py
@@ -20,9 +20,9 @@ def test_apply_hints_delete_prefix(tmp_file):
     hint = {'p': [{'l': 0, 'r': 4}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
 
-    apply_hints([hint], tmp_file)
+    new_data = apply_hints([hint], tmp_file)
 
-    assert tmp_file.read_text() == 'bar'
+    assert new_data == 'bar'
 
 
 def test_apply_hints_delete_suffix(tmp_file):
@@ -30,9 +30,9 @@ def test_apply_hints_delete_suffix(tmp_file):
     hint = {'p': [{'l': 3, 'r': 7}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
 
-    apply_hints([hint], tmp_file)
+    new_data = apply_hints([hint], tmp_file)
 
-    assert tmp_file.read_text() == 'Foo'
+    assert new_data == 'Foo'
 
 
 def test_apply_hints_delete_middle(tmp_file):
@@ -40,9 +40,9 @@ def test_apply_hints_delete_middle(tmp_file):
     hint = {'p': [{'l': 3, 'r': 7}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
 
-    apply_hints([hint], tmp_file)
+    new_data = apply_hints([hint], tmp_file)
 
-    assert tmp_file.read_text() == 'Foo baz'
+    assert new_data == 'Foo baz'
 
 
 def test_apply_hints_delete_middle_multiple(tmp_file):
@@ -53,9 +53,9 @@ def test_apply_hints_delete_middle_multiple(tmp_file):
     for h in hints:
         jsonschema.validate(h, schema=HINT_SCHEMA)
 
-    apply_hints(hints, tmp_file)
+    new_data = apply_hints(hints, tmp_file)
 
-    assert tmp_file.read_text() == 'Foobarbaz'
+    assert new_data == 'Foobarbaz'
 
 
 def test_apply_hints_delete_all(tmp_file):
@@ -63,9 +63,9 @@ def test_apply_hints_delete_all(tmp_file):
     hint = {'p': [{'l': 0, 'r': 7}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
 
-    apply_hints([hint], tmp_file)
+    new_data = apply_hints([hint], tmp_file)
 
-    assert tmp_file.read_text() == ''
+    assert new_data == ''
 
 
 def test_apply_hints_delete_touching(tmp_file):
@@ -78,9 +78,9 @@ def test_apply_hints_delete_touching(tmp_file):
     for h in hints:
         jsonschema.validate(h, schema=HINT_SCHEMA)
 
-    apply_hints(hints, tmp_file)
+    new_data = apply_hints(hints, tmp_file)
 
-    assert tmp_file.read_text() == 'Foo baz'
+    assert new_data == 'Foo baz'
 
 
 def test_apply_hints_delete_overlapping(tmp_file):
@@ -92,9 +92,9 @@ def test_apply_hints_delete_overlapping(tmp_file):
     for h in hints:
         jsonschema.validate(h, schema=HINT_SCHEMA)
 
-    apply_hints(hints, tmp_file)
+    new_data = apply_hints(hints, tmp_file)
 
-    assert tmp_file.read_text() == 'Foo baz'
+    assert new_data == 'Foo baz'
 
 
 def test_apply_hints_delete_nested(tmp_file):
@@ -105,9 +105,9 @@ def test_apply_hints_delete_nested(tmp_file):
     for h in hints:
         jsonschema.validate(h, schema=HINT_SCHEMA)
 
-    apply_hints(hints, tmp_file)
+    new_data = apply_hints(hints, tmp_file)
 
-    assert tmp_file.read_text() == 'Foo baz'
+    assert new_data == 'Foo baz'
 
 
 def test_store_load_hints(tmp_hints_file):

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -48,7 +48,7 @@ HINT_SCHEMA = {
 }
 
 
-def apply_hints(hints: Sequence[object], file: Path) -> None:
+def apply_hints(hints: Sequence[object], file: Path) -> str:
     """Edits the file applying the specified hints to its contents."""
     patches = sum((h['p'] for h in hints), start=[])
     merged_patches = merge_overlapping_patches(patches)
@@ -69,9 +69,7 @@ def apply_hints(hints: Sequence[object], file: Path) -> None:
         start_pos = right
     # Add the unmodified chunk after the last patch end.
     new_data += orig_data[start_pos:]
-
-    with open(file, 'w') as f:
-        f.write(new_data)
+    return new_data
 
 
 def store_hints(hints: Sequence[object], hints_file_path: Path) -> None:


### PR DESCRIPTION
Add command-line options to C-Vise to apply the given set of hints to the test case.

This is currently intended to be used in clang_delta unit tests (which, despite being written in Python, are not part of the C-Vise module and hence cannot import hints.py directly). Additionally, this might be useful in the long run for developers working on new passes for C-Vise.