### PR TITLE
hints: Migrate clang_delta logic for RemoveUnusedFunction

### DIFF
--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -517,6 +517,8 @@ add_executable(clang_delta
   EmptyStructToInt.h
   ExpressionDetector.cpp
   ExpressionDetector.h
+  HintsBuilder.cpp
+  HintsBuilder.h
   InstantiateTemplateParam.cpp
   InstantiateTemplateParam.h
   InstantiateTemplateTypeParamToInt.cpp

--- a/clang_delta/ClangDelta.cpp
+++ b/clang_delta/ClangDelta.cpp
@@ -12,6 +12,7 @@
 #  include <config.h>
 #endif
 
+#include <limits>
 #include <string>
 #include <sstream>
 #include <cstdlib>
@@ -113,6 +114,10 @@ static void PrintHelpMessage()
   llvm::outs() << "make only warning when a counter is out of bounds ";
   llvm::outs() << "(replace-function-def-with-decl and remove-unused-function are supported)";
   llvm::outs() << "\n";
+
+  llvm::outs() << "  --generate-hints: ";
+  llvm::outs() << "print edit hints instead of the modified input ";
+  llvm::outs() << "\n";
 }
 
 static void DieOnBadCmdArg(const std::string &ArgStr)
@@ -213,6 +218,11 @@ static void HandleOneNoneValueArg(const std::string &ArgStr)
   else if (!ArgStr.compare("verbose-transformations")) {
     TransMgr->printTransformations();
     exit(0);
+  }
+  else if (!ArgStr.compare("generate-hints")) {
+    TransMgr->setGenerateHintsFlag(true);
+    TransMgr->setTransformationCounter(1);
+    TransMgr->setToCounter(std::numeric_limits<int>::max());
   }
   else if (!ArgStr.compare("report-instances-count")) {
     TransMgr->setReportInstancesCount(true);

--- a/clang_delta/HintsBuilder.cpp
+++ b/clang_delta/HintsBuilder.cpp
@@ -1,0 +1,65 @@
+#include "HintsBuilder.h"
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "clang/Basic/LangOptions.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/SourceManager.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/FormatVariadic.h"
+
+HintsBuilder::HintsBuilder(clang::SourceManager &SM, const clang::LangOptions &LO)
+: SourceMgr(SM), NoOpRewriter(SourceMgr, LO) {}
+
+HintsBuilder::~HintsBuilder() = default;
+
+void HintsBuilder::AddPatch(clang::SourceRange R) {
+  AddPatch(R.getBegin(), NoOpRewriter.getRangeSize(R));
+}
+
+void HintsBuilder::AddPatch(clang::CharSourceRange R) {
+  AddPatch(R.getBegin(), NoOpRewriter.getRangeSize(R));
+}
+
+void HintsBuilder::AddPatch(clang::SourceLocation L, int64_t Len) {
+  if (Len <= 0) {
+    // This would be an invalid hint patch.
+    return;
+  }
+  Patch P;
+  P.L = SourceMgr.getFileOffset(L);
+  P.R = P.L + Len;
+  CurrentHint.Patches.push_back(P);
+}
+
+void HintsBuilder::FinishCurrentHint() {
+  if (CurrentHint.Patches.empty()) {
+    // Don't add empty hints.
+    return;
+  }
+  Hints.push_back(std::move(CurrentHint));
+  CurrentHint = {};
+}
+
+void HintsBuilder::ReverseOrder() {
+  std::reverse(Hints.begin(), Hints.end());
+}
+
+std::vector<std::string> HintsBuilder::GetHintJsons() const {
+  std::vector<std::string> Jsons;
+  for (const auto& H : Hints) {
+    std::string Array;
+    for (const auto& P : H.Patches) {
+      if (!Array.empty())
+        Array += ",";
+      Array += llvm::formatv(R"txt({{"l":{0},"r":{1}})txt", P.L, P.R);
+    }
+    Jsons.push_back(llvm::formatv(R"txt({{"p":[{0}]})txt", Array));
+  }
+  return Jsons;
+}

--- a/clang_delta/HintsBuilder.h
+++ b/clang_delta/HintsBuilder.h
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) 2012, 2013, 2014, 2015, 2016, 2018, 2019 The University of Utah
+// All rights reserved.
+//
+// This file is distributed under the University of Illinois Open Source
+// License.  See the file COPYING for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HINTS_BUILDER_H
+#define HINTS_BUILDER_H
+
+#include <stdint.h>
+
+#include <string>
+#include <vector>
+
+#include "clang/Basic/LangOptions.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "llvm/ADT/StringRef.h"
+
+// Helper for generating reduction hints - for the background and data format,
+// see //cvise/utils/hint.py.
+class HintsBuilder {
+ public:
+  HintsBuilder(clang::SourceManager &SM, const clang::LangOptions &LO);
+  ~HintsBuilder();
+
+  void AddPatch(clang::SourceRange R);
+  void AddPatch(clang::CharSourceRange R);
+  void AddPatch(clang::SourceLocation L, int64_t Len);
+
+  void FinishCurrentHint();
+
+  void ReverseOrder();
+
+  std::vector<std::string> GetHintJsons() const;
+
+ private:
+  struct Patch {
+    int64_t L, R;
+  };
+
+  struct Hint {
+    std::vector<Patch> Patches;
+  };
+
+  clang::SourceManager &SourceMgr;
+  // Used to measure token sizes. It's a separate object from
+  // `Transformation::TheRewriter`, because the source locations change in the
+  // latter as rewrites go.
+  const clang::Rewriter NoOpRewriter;
+  std::vector<Hint> Hints;
+  Hint CurrentHint;
+};
+
+#endif

--- a/clang_delta/RewriteUtils.h
+++ b/clang_delta/RewriteUtils.h
@@ -16,6 +16,8 @@
 #include "clang/AST/NestedNameSpecifier.h"
 #include "clang/AST/DeclTemplate.h"
 
+#include "HintsBuilder.h"
+
 #ifndef ENABLE_TRANS_ASSERT
   #define TransAssert(x) {if (!(x)) exit(-1);}
 #else
@@ -55,7 +57,7 @@ namespace clang {
 
 class RewriteUtils {
 public:
-  static RewriteUtils *GetInstance(clang::Rewriter *RW);
+  static RewriteUtils *GetInstance(clang::Rewriter *RW, HintsBuilder *H);
 
   static void Finalize(void);
 
@@ -291,6 +293,8 @@ private:
   static const char *TmpVarNamePrefix;
 
   clang::Rewriter *TheRewriter;
+
+  HintsBuilder *Hints;
 
   clang::SourceManager *SrcManager;
 

--- a/clang_delta/Transformation.h
+++ b/clang_delta/Transformation.h
@@ -11,6 +11,7 @@
 #ifndef TRANSFORMATION_H
 #define TRANSFORMATION_H
 
+#include <memory>
 #include <string>
 #include <cstdlib>
 #include <cassert>
@@ -18,6 +19,7 @@
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/PrettyPrinter.h"
 #include "clang/Rewrite/Core/Rewriter.h"
+#include "HintsBuilder.h"
 #include "RewriteUtils.h"
 
 namespace clang {
@@ -121,6 +123,8 @@ public:
   void outputOriginalSource(llvm::raw_ostream &OutStream);
 
   void outputTransformedSource(llvm::raw_ostream &OutStream);
+
+  void outputHints(llvm::raw_ostream &OutStream);
 
   void setTransformationCounter(int Counter) {
     TransformationCounter = Counter;
@@ -347,6 +351,8 @@ protected:
   clang::Preprocessor *PP;
 
   clang::Rewriter TheRewriter;
+
+  std::unique_ptr<HintsBuilder> Hints;
 
   TransformationError TransError;
   

--- a/clang_delta/TransformationManager.cpp
+++ b/clang_delta/TransformationManager.cpp
@@ -320,7 +320,17 @@ bool TransformationManager::doTransformation(std::string &ErrorMsg, int &ErrorCo
 
   llvm::raw_ostream *OutStream = getOutStream();
   bool RV;
+  if (GenerateHints) {
   if (CurrentTransformationImpl->transSuccess()) {
+      CurrentTransformationImpl->outputHints(*OutStream);
+      RV = true;
+    }
+    else {
+      CurrentTransformationImpl->getTransErrorMsg(ErrorMsg);
+      RV = false;
+    }
+  }
+  else if (CurrentTransformationImpl->transSuccess()) {
     CurrentTransformationImpl->outputTransformedSource(*OutStream);
     RV = true;
   }
@@ -426,6 +436,7 @@ TransformationManager::TransformationManager()
     OutputFileName(""),
     CurrentTransName(""),
     ClangInstance(NULL),
+    GenerateHints(false),
     QueryInstanceOnly(false),
     DoReplacement(false),
     Replacement(""),

--- a/clang_delta/TransformationManager.h
+++ b/clang_delta/TransformationManager.h
@@ -75,6 +75,10 @@ public:
     OutputFileName = FileName;
   }
 
+  void setGenerateHintsFlag(bool Flag) {
+    GenerateHints = Flag;
+  }
+
   void setReplacement(const std::string &Str) {
     Replacement = Str;
     DoReplacement = true;
@@ -154,6 +158,8 @@ private:
   std::string CurrentTransName;
 
   clang::CompilerInstance *ClangInstance;
+
+  bool GenerateHints;
 
   bool QueryInstanceOnly;
 

--- a/clang_delta/tests/test_clang_delta.py
+++ b/clang_delta/tests/test_clang_delta.py
@@ -1,6 +1,8 @@
 import os
+from pathlib import Path
 import re
 import subprocess
+import tempfile
 import unittest
 
 
@@ -16,17 +18,57 @@ def get_clang_version():
     raise AssertionError()
 
 
+def get_clang_delta_path() -> Path:
+    return Path(__file__).parent.parent / 'clang_delta'
+
+
+def get_testcase_path(testcase: str) -> Path:
+    return Path(__file__).parent / testcase
+
+
+def get_expected_output_path(testcase: str, output_file: str = None) -> Path:
+    if not output_file:
+        output_file = os.path.splitext(testcase)[0] + '.output'
+    return Path(__file__).parent / output_file
+
+
+def run_clang_delta(testcase: str, arguments: str) -> str:
+    cmd = f'{get_clang_delta_path()} {get_testcase_path(testcase)} {arguments}'
+    return subprocess.check_output(cmd, shell=True, encoding='utf8')
+
+
+def run_apply_hints(hints_file: Path, begin_index, end_index, testcase) -> str:
+    hints_tool = Path(__file__).parent.parent.parent / 'cvise-cli.py'
+    cmd = [
+        hints_tool,
+        '--action=apply-hints',
+        '--hints-file',
+        hints_file,
+        '--hint-begin-index',
+        str(begin_index),
+        '--hint-end-index',
+        str(end_index),
+        get_testcase_path(testcase),
+    ]
+    return subprocess.check_output(cmd, encoding='utf-8')
+
+
 class TestClangDelta(unittest.TestCase):
     @classmethod
     def check_clang_delta(cls, testcase, arguments, output_file=None):
-        current = os.path.dirname(__file__)
-        binary = os.path.join(current, '../clang_delta')
-        cmd = f'{binary} {os.path.join(current, testcase)} {arguments}'
-        output = subprocess.check_output(cmd, shell=True, encoding='utf8')
-        if not output_file:
-            output_file = os.path.splitext(testcase)[0] + '.output'
-        with open(os.path.join(current, output_file)) as f:
-            expected = f.read()
+        output = run_clang_delta(testcase, arguments)
+        expected = get_expected_output_path(testcase, output_file).read_text()
+        assert output == expected
+
+    @classmethod
+    def check_clang_delta_hints(cls, testcase, arguments, begin_index, end_index, output_file=None):
+        hints = run_clang_delta(testcase, arguments + ' --generate-hints')
+        with tempfile.NamedTemporaryFile(delete_on_close=False, mode='wt', suffix='.jsonl') as hints_file:
+            hints_file.write(hints)
+            hints_file.close()
+            output = run_apply_hints(Path(hints_file.name), begin_index, end_index, testcase)
+
+        expected = get_expected_output_path(testcase, output_file).read_text()
         assert output == expected
 
     @classmethod
@@ -588,16 +630,35 @@ class TestClangDelta(unittest.TestCase):
             'remove-unused-function/class.cc',
             '--transformation=remove-unused-function --counter=1',
         )
+        self.check_clang_delta_hints(
+            'remove-unused-function/class.cc',
+            '--transformation=remove-unused-function',
+            begin_index=0,
+            end_index=1,
+        )
 
     def test_remove_unused_function_const(self):
         self.check_clang_delta(
             'remove-unused-function/const.cc',
             '--transformation=remove-unused-function --counter=1',
         )
+        self.check_clang_delta_hints(
+            'remove-unused-function/const.cc',
+            '--transformation=remove-unused-function',
+            begin_index=0,
+            end_index=1,
+        )
         self.check_clang_delta(
             'remove-unused-function/const.cc',
             '--transformation=remove-unused-function --counter=2',
             'remove-unused-function/const.output2',
+        )
+        self.check_clang_delta_hints(
+            'remove-unused-function/const.cc',
+            '--transformation=remove-unused-function',
+            begin_index=1,
+            end_index=2,
+            output_file='remove-unused-function/const.output2',
         )
 
     def test_remove_unused_function_default(self):
@@ -605,10 +666,23 @@ class TestClangDelta(unittest.TestCase):
             'remove-unused-function/default.cc',
             '--transformation=remove-unused-function --counter=1',
         )
+        self.check_clang_delta_hints(
+            'remove-unused-function/default.cc',
+            '--transformation=remove-unused-function',
+            begin_index=0,
+            end_index=1,
+        )
         self.check_clang_delta(
             'remove-unused-function/default.cc',
             '--transformation=remove-unused-function --counter=2',
             'remove-unused-function/default.output2',
+        )
+        self.check_clang_delta_hints(
+            'remove-unused-function/default.cc',
+            '--transformation=remove-unused-function',
+            begin_index=1,
+            end_index=2,
+            output_file='remove-unused-function/default.output2',
         )
 
     def test_remove_unused_function_delete(self):
@@ -616,29 +690,67 @@ class TestClangDelta(unittest.TestCase):
             'remove-unused-function/delete.cc',
             '--transformation=remove-unused-function --counter=1',
         )
+        self.check_clang_delta_hints(
+            'remove-unused-function/delete.cc',
+            '--transformation=remove-unused-function',
+            begin_index=0,
+            end_index=1,
+        )
 
     def test_remove_unused_function_delete2(self):
         self.check_clang_delta(
             'remove-unused-function/delete2.cc',
             '--transformation=remove-unused-function --counter=1',
         )
+        self.check_clang_delta_hints(
+            'remove-unused-function/delete2.cc',
+            '--transformation=remove-unused-function',
+            begin_index=0,
+            end_index=1,
+        )
         self.check_clang_delta(
             'remove-unused-function/delete2.cc',
             '--transformation=remove-unused-function --counter=2',
             'remove-unused-function/delete2.output2',
+        )
+        self.check_clang_delta_hints(
+            'remove-unused-function/delete2.cc',
+            '--transformation=remove-unused-function',
+            begin_index=1,
+            end_index=2,
+            output_file='remove-unused-function/delete2.output2',
         )
         self.check_clang_delta(
             'remove-unused-function/delete2.cc',
             '--transformation=remove-unused-function --counter=3',
             'remove-unused-function/delete2.output3',
         )
+        self.check_clang_delta_hints(
+            'remove-unused-function/delete2.cc',
+            '--transformation=remove-unused-function',
+            begin_index=2,
+            end_index=3,
+            output_file='remove-unused-function/delete2.output3',
+        )
         self.check_clang_delta(
             'remove-unused-function/delete2.cc',
             '--transformation=remove-unused-function --counter=4',
             'remove-unused-function/delete2.output4',
         )
+        self.check_clang_delta_hints(
+            'remove-unused-function/delete2.cc',
+            '--transformation=remove-unused-function',
+            begin_index=3,
+            end_index=4,
+            output_file='remove-unused-function/delete2.output4',
+        )
 
     def test_remove_unused_function_inline_ns(self):
+        self.check_query_instances(
+            'remove-unused-function/inline_ns.cc',
+            '--query-instances=remove-unused-function',
+            'Available transformation instances: 0',
+        )
         self.check_query_instances(
             'remove-unused-function/inline_ns.cc',
             '--query-instances=remove-unused-function',
@@ -650,11 +762,23 @@ class TestClangDelta(unittest.TestCase):
             'remove-unused-function/macro1.cc',
             '--transformation=remove-unused-function --counter=1',
         )
+        self.check_clang_delta_hints(
+            'remove-unused-function/macro1.cc',
+            '--transformation=remove-unused-function',
+            begin_index=0,
+            end_index=1,
+        )
 
     def test_remove_unused_function_macro2(self):
         self.check_clang_delta(
             'remove-unused-function/macro2.cc',
             '--transformation=remove-unused-function --counter=1',
+        )
+        self.check_clang_delta_hints(
+            'remove-unused-function/macro2.cc',
+            '--transformation=remove-unused-function',
+            begin_index=0,
+            end_index=1,
         )
 
     def test_remove_unused_function_macro3(self):
@@ -662,11 +786,23 @@ class TestClangDelta(unittest.TestCase):
             'remove-unused-function/macro3.cc',
             '--transformation=remove-unused-function --counter=1',
         )
+        self.check_clang_delta_hints(
+            'remove-unused-function/macro3.cc',
+            '--transformation=remove-unused-function',
+            begin_index=0,
+            end_index=1,
+        )
 
     def test_remove_unused_function_template1(self):
         self.check_clang_delta(
             'remove-unused-function/template1.cc',
             '--transformation=remove-unused-function --counter=1',
+        )
+        self.check_clang_delta_hints(
+            'remove-unused-function/template1.cc',
+            '--transformation=remove-unused-function',
+            begin_index=0,
+            end_index=1,
         )
 
     def test_remove_unused_function_template2(self):
@@ -674,14 +810,31 @@ class TestClangDelta(unittest.TestCase):
             'remove-unused-function/template2.cc',
             '--transformation=remove-unused-function --counter=1',
         )
+        self.check_clang_delta_hints(
+            'remove-unused-function/template2.cc',
+            '--transformation=remove-unused-function',
+            begin_index=0,
+            end_index=1,
+        )
 
     def test_remove_unused_function_unused_funcs(self):
         self.check_clang_delta(
             'remove-unused-function/unused-funcs.cc',
             '--transformation=remove-unused-function --counter=1',
         )
+        self.check_clang_delta_hints(
+            'remove-unused-function/unused-funcs.cc',
+            '--transformation=remove-unused-function',
+            begin_index=0,
+            end_index=1,
+        )
 
     def test_remove_unused_function_cyclic_ns_include(self):
+        self.check_query_instances(
+            'remove-unused-function/cyclic-namespace-using.cc',
+            '--query-instances=remove-unused-function',
+            'Available transformation instances: 0',
+        )
         self.check_query_instances(
             'remove-unused-function/cyclic-namespace-using.cc',
             '--query-instances=remove-unused-function',


### PR DESCRIPTION
This adds a new parameter to clang_delta: --generate-hints, which results in emitting JSONL hints instead of the modified text. With this commit, this mode is only supported for the
RemoveUnusedFunction transformation.

Follow-up changes will wire up the Python "pass" logic with this new functionality.