### PR TITLE
Switch to os.path.abspath() instead of os.path.realpath() when search…

### DIFF
--- a/cvise/utils/externalprograms.py
+++ b/cvise/utils/externalprograms.py
@@ -2,7 +2,7 @@ import os
 import platform
 import shutil
 
-SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
+SCRIPT_PATH = os.path.dirname(os.path.abspath(__file__))
 DESTDIR = os.getenv('DESTDIR', '')
 
 


### PR DESCRIPTION
…ing for external binaries. This is sometimes needed due to the symlinks created by build systems.