### PR TITLE
hints: Add bundle class

### DIFF
--- a/cvise/passes/clanghints.py
+++ b/cvise/passes/clanghints.py
@@ -46,22 +46,22 @@ class ClangHintsPass(HintBasedPass):
         # Choose the best standard unless the user provided one.
         std_choices = [self.user_clang_delta_std] if self.user_clang_delta_std else CLANG_STD_CHOICES
         best_std = None
-        best_hints = None
+        best_bundle = None
         for std in std_choices:
             start = time.monotonic()
-            hints = self.generate_hints_for_standard(test_case, std)
+            bundle = self.generate_hints_for_standard(test_case, std)
             took = time.monotonic() - start
             # prefer newer standard if the # of instances is equal
-            if best_hints is None or len(hints.hints) >= len(best_hints.hints):
+            if best_bundle is None or len(bundle.hints) >= len(best_bundle.hints):
                 best_std = std
-                best_hints = hints
+                best_bundle = bundle
             logging.debug(
-                'available transformation opportunities for %s: %d, took: %.2f s' % (std, len(hints.hints), took)
+                'available transformation opportunities for %s: %d, took: %.2f s' % (std, len(bundle.hints), took)
             )
-        logging.info('using C++ standard: %s with %d transformation opportunities' % (best_std, len(best_hints.hints)))
+        logging.info('using C++ standard: %s with %d transformation opportunities' % (best_std, len(best_bundle.hints)))
 
         # Let the parent class complete the initialization, but create our own state to remember the chosen standard.
-        hint_state = self.new_from_hints(best_hints, tmp_dir)
+        hint_state = self.new_from_hints(best_bundle, tmp_dir)
         return ClangState.wrap(hint_state, best_std)
 
     def advance(self, test_case, state):

--- a/cvise/passes/clanghints.py
+++ b/cvise/passes/clanghints.py
@@ -8,6 +8,7 @@ from typing import Union
 
 from cvise.passes.abstract import BinaryState
 from cvise.passes.hint_based import HintBasedPass, HintState
+from cvise.utils.hint import HintBundle
 
 
 CLANG_STD_CHOICES = ('c++98', 'c++11', 'c++14', 'c++17', 'c++20', 'c++2b')
@@ -45,17 +46,19 @@ class ClangHintsPass(HintBasedPass):
         # Choose the best standard unless the user provided one.
         std_choices = [self.user_clang_delta_std] if self.user_clang_delta_std else CLANG_STD_CHOICES
         best_std = None
-        best_hints = []
+        best_hints = None
         for std in std_choices:
             start = time.monotonic()
             hints = self.generate_hints_for_standard(test_case, std)
             took = time.monotonic() - start
             # prefer newer standard if the # of instances is equal
-            if len(hints) >= len(best_hints):
+            if best_hints is None or len(hints.hints) >= len(best_hints.hints):
                 best_std = std
                 best_hints = hints
-            logging.debug('available transformation opportunities for %s: %d, took: %.2f s' % (std, len(hints), took))
-        logging.info('using C++ standard: %s with %d transformation opportunities' % (best_std, len(best_hints)))
+            logging.debug(
+                'available transformation opportunities for %s: %d, took: %.2f s' % (std, len(hints.hints), took)
+            )
+        logging.info('using C++ standard: %s with %d transformation opportunities' % (best_std, len(best_hints.hints)))
 
         # Let the parent class complete the initialization, but create our own state to remember the chosen standard.
         hint_state = self.new_from_hints(best_hints, tmp_dir)
@@ -73,7 +76,7 @@ class ClangHintsPass(HintBasedPass):
         new_state = self.advance_on_success_from_hints(hints, state)
         return ClangState.wrap(new_state, state.clang_std)
 
-    def generate_hints_for_standard(self, test_case, std):
+    def generate_hints_for_standard(self, test_case, std) -> HintBundle:
         cmd = [
             self.external_programs['clang_delta'],
             f'--transformation={self.arg}',
@@ -90,4 +93,4 @@ class ClangHintsPass(HintBasedPass):
             for line in proc.stdout:
                 if not line.isspace():
                     hints.append(json.loads(line))
-        return hints
+        return HintBundle(hints=hints)

--- a/cvise/passes/hint_based.py
+++ b/cvise/passes/hint_based.py
@@ -61,21 +61,21 @@ class HintBasedPass(AbstractPass):
         hints = self.generate_hints(test_case)
         return self.advance_on_success_from_hints(hints, state)
 
-    def new_from_hints(self, hints: HintBundle, tmp_dir: str) -> Union[HintState, None]:
+    def new_from_hints(self, bundle: HintBundle, tmp_dir: str) -> Union[HintState, None]:
         """Creates a state for pre-generated hints.
 
         Can be used by subclasses which don't follow the typical approach with implementing generate_hints()."""
-        if not hints.hints:
+        if not bundle.hints:
             return None
         hints_file_path = tmp_dir / HINTS_FILE_NAME
-        store_hints(hints, hints_file_path)
-        return HintState.create(len(hints.hints), hints_file_path)
+        store_hints(bundle, hints_file_path)
+        return HintState.create(len(bundle.hints), hints_file_path)
 
-    def advance_on_success_from_hints(self, hints: HintBundle, state: HintState) -> Union[HintState, None]:
+    def advance_on_success_from_hints(self, bundle: HintBundle, state: HintState) -> Union[HintState, None]:
         """Advances the state after a successful reduction, given pre-generated hints.
 
         Can be used by subclasses which don't follow the typical approach with implementing generate_hints()."""
-        if not hints.hints:
+        if not bundle.hints:
             return None
-        store_hints(hints, state.hints_file_path)
-        return state.advance_on_success(len(hints.hints))
+        store_hints(bundle, state.hints_file_path)
+        return state.advance_on_success(len(bundle.hints))

--- a/cvise/passes/hint_based.py
+++ b/cvise/passes/hint_based.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 from pathlib import Path
-from typing import Sequence, Union
+from typing import Union
 
 from cvise.passes.abstract import AbstractPass, BinaryState, PassResult
-from cvise.utils.hint import apply_hints, load_hints, store_hints
+from cvise.utils.hint import apply_hints, HintBundle, load_hints, store_hints
 
 HINTS_FILE_NAME = 'hints.jsonl.zst'
 
@@ -39,7 +39,7 @@ class HintBasedPass(AbstractPass):
     Provides default implementations of new/transform/advance operations, which only require the subclass to implement
     the generate_hints() method."""
 
-    def generate_hints(self, test_case: Path) -> Sequence[object]:
+    def generate_hints(self, test_case: Path) -> HintBundle:
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'generate_hints'!")
 
     def new(self, test_case, tmp_dir, **kwargs):
@@ -61,21 +61,21 @@ class HintBasedPass(AbstractPass):
         hints = self.generate_hints(test_case)
         return self.advance_on_success_from_hints(hints, state)
 
-    def new_from_hints(self, hints: Sequence[object], tmp_dir: str) -> Union[HintState, None]:
+    def new_from_hints(self, hints: HintBundle, tmp_dir: str) -> Union[HintState, None]:
         """Creates a state for pre-generated hints.
 
         Can be used by subclasses which don't follow the typical approach with implementing generate_hints()."""
-        if not hints:
+        if not hints.hints:
             return None
         hints_file_path = tmp_dir / HINTS_FILE_NAME
         store_hints(hints, hints_file_path)
-        return HintState.create(len(hints), hints_file_path)
+        return HintState.create(len(hints.hints), hints_file_path)
 
-    def advance_on_success_from_hints(self, hints: Sequence[object], state: HintState) -> Union[HintState, None]:
+    def advance_on_success_from_hints(self, hints: HintBundle, state: HintState) -> Union[HintState, None]:
         """Advances the state after a successful reduction, given pre-generated hints.
 
         Can be used by subclasses which don't follow the typical approach with implementing generate_hints()."""
-        if not hints:
+        if not hints.hints:
             return None
         store_hints(hints, state.hints_file_path)
-        return state.advance_on_success(len(hints))
+        return state.advance_on_success(len(hints.hints))

--- a/cvise/passes/line_markers.py
+++ b/cvise/passes/line_markers.py
@@ -1,6 +1,7 @@
 import re
 
 from cvise.passes.hint_based import HintBasedPass
+from cvise.utils.hint import HintBundle
 
 
 class LineMarkersPass(HintBasedPass):
@@ -35,4 +36,4 @@ class LineMarkersPass(HintBasedPass):
                 if self.line_regex.search(line):
                     hints.append({'p': [{'l': file_pos, 'r': end_pos}]})
                 file_pos = end_pos
-        return hints
+        return HintBundle(hints=hints)

--- a/cvise/passes/lines.py
+++ b/cvise/passes/lines.py
@@ -3,6 +3,7 @@ import subprocess
 from typing import Sequence
 
 from cvise.passes.hint_based import HintBasedPass
+from cvise.utils.hint import HintBundle
 
 
 class LinesPass(HintBasedPass):
@@ -16,7 +17,7 @@ class LinesPass(HintBasedPass):
         else:
             return self.generate_topformflat_hints(test_case)
 
-    def generate_hints_for_text_lines(self, test_case: str) -> Sequence[object]:
+    def generate_hints_for_text_lines(self, test_case: str) -> HintBundle:
         """Generate a hint per each line in the input as written."""
         hints = []
         with open(test_case) as in_file:
@@ -25,9 +26,9 @@ class LinesPass(HintBasedPass):
                 end_pos = file_pos + len(line)
                 hints.append({'p': [{'l': file_pos, 'r': end_pos}]})
             file_pos = end_pos
-        return hints
+        return HintBundle(hints=hints)
 
-    def generate_topformflat_hints(self, test_case: str) -> Sequence[object]:
+    def generate_topformflat_hints(self, test_case: str) -> HintBundle:
         """Generate hints via the modified topformflat tool.
 
         A single hint here is, roughly, a curly brace surrounded block at the
@@ -39,4 +40,4 @@ class LinesPass(HintBasedPass):
                 for line in proc.stdout:
                     if not line.isspace():
                         hints.append(json.loads(line))
-        return hints
+        return HintBundle(hints=hints)

--- a/cvise/passes/lines.py
+++ b/cvise/passes/lines.py
@@ -1,6 +1,5 @@
 import json
 import subprocess
-from typing import Sequence
 
 from cvise.passes.hint_based import HintBasedPass
 from cvise.utils.hint import HintBundle

--- a/cvise/tests/test_hint.py
+++ b/cvise/tests/test_hint.py
@@ -2,7 +2,7 @@ import json
 import jsonschema
 import pytest
 
-from cvise.utils.hint import apply_hints, load_hints, store_hints, HINT_SCHEMA
+from cvise.utils.hint import apply_hints, HintBundle, load_hints, store_hints, HINT_SCHEMA
 
 
 @pytest.fixture
@@ -19,8 +19,9 @@ def test_apply_hints_delete_prefix(tmp_file):
     tmp_file.write_text('Foo bar')
     hint = {'p': [{'l': 0, 'r': 4}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
+    bundle = HintBundle(hints=[hint])
 
-    new_data = apply_hints([hint], tmp_file)
+    new_data = apply_hints(bundle, tmp_file)
 
     assert new_data == 'bar'
 
@@ -29,8 +30,9 @@ def test_apply_hints_delete_suffix(tmp_file):
     tmp_file.write_text('Foo bar')
     hint = {'p': [{'l': 3, 'r': 7}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
+    bundle = HintBundle(hints=[hint])
 
-    new_data = apply_hints([hint], tmp_file)
+    new_data = apply_hints(bundle, tmp_file)
 
     assert new_data == 'Foo'
 
@@ -39,8 +41,9 @@ def test_apply_hints_delete_middle(tmp_file):
     tmp_file.write_text('Foo bar baz')
     hint = {'p': [{'l': 3, 'r': 7}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
+    bundle = HintBundle(hints=[hint])
 
-    new_data = apply_hints([hint], tmp_file)
+    new_data = apply_hints(bundle, tmp_file)
 
     assert new_data == 'Foo baz'
 
@@ -52,8 +55,9 @@ def test_apply_hints_delete_middle_multiple(tmp_file):
     hints = [hint1, hint2]
     for h in hints:
         jsonschema.validate(h, schema=HINT_SCHEMA)
+    bundle = HintBundle(hints=hints)
 
-    new_data = apply_hints(hints, tmp_file)
+    new_data = apply_hints(bundle, tmp_file)
 
     assert new_data == 'Foobarbaz'
 
@@ -62,8 +66,9 @@ def test_apply_hints_delete_all(tmp_file):
     tmp_file.write_text('Foo bar')
     hint = {'p': [{'l': 0, 'r': 7}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
+    bundle = HintBundle(hints=[hint])
 
-    new_data = apply_hints([hint], tmp_file)
+    new_data = apply_hints(bundle, tmp_file)
 
     assert new_data == ''
 
@@ -77,8 +82,9 @@ def test_apply_hints_delete_touching(tmp_file):
     hints = [hint1, hint2, hint3]
     for h in hints:
         jsonschema.validate(h, schema=HINT_SCHEMA)
+    bundle = HintBundle(hints=hints)
 
-    new_data = apply_hints(hints, tmp_file)
+    new_data = apply_hints(bundle, tmp_file)
 
     assert new_data == 'Foo baz'
 
@@ -91,8 +97,9 @@ def test_apply_hints_delete_overlapping(tmp_file):
     hints = [hint1, hint2]
     for h in hints:
         jsonschema.validate(h, schema=HINT_SCHEMA)
+    bundle = HintBundle(hints=hints)
 
-    new_data = apply_hints(hints, tmp_file)
+    new_data = apply_hints(bundle, tmp_file)
 
     assert new_data == 'Foo baz'
 
@@ -104,26 +111,29 @@ def test_apply_hints_delete_nested(tmp_file):
     hints = [hint1, hint2]
     for h in hints:
         jsonschema.validate(h, schema=HINT_SCHEMA)
+    bundle = HintBundle(hints=hints)
 
-    new_data = apply_hints(hints, tmp_file)
+    new_data = apply_hints(bundle, tmp_file)
 
     assert new_data == 'Foo baz'
 
 
 def test_store_load_hints(tmp_hints_file):
     hint1 = {'p': [{'l': 0, 'r': 1}]}
-    hint2 = {'p': [{'l': 2, 'r': 3}, {'l': 4, 'r': 5}]}
-    store_hints([hint1, hint2], tmp_hints_file)
+    hint2 = {'p': [{'l': 2, 'r': 3}, {'l': 4, 'r': 5, 'v': 0}]}
+    hints = HintBundle(hints=[hint1, hint2])
+    store_hints(hints, tmp_hints_file)
 
-    assert load_hints(tmp_hints_file, 0, 2) == [hint1, hint2]
-    assert load_hints(tmp_hints_file, 0, 1) == [hint1]
-    assert load_hints(tmp_hints_file, 1, 2) == [hint2]
+    assert load_hints(tmp_hints_file, 0, 2) == HintBundle(hints=[hint1, hint2])
+    assert load_hints(tmp_hints_file, 0, 1) == HintBundle(hints=[hint1])
+    assert load_hints(tmp_hints_file, 1, 2) == HintBundle(hints=[hint2])
 
 
 def test_hints_storage_compression(tmp_file):
     COUNT = 10000
     hints = [{'p': [{'l': i, 'r': i + 1}]} for i in range(COUNT)]
-    store_hints(hints, tmp_file)
+    bundle = HintBundle(hints=hints)
+    store_hints(bundle, tmp_file)
 
     # Check that the file is significantly smaller than a regular JSON representation (without extra spaces around
     # separators).

--- a/cvise/tests/test_hint_based.py
+++ b/cvise/tests/test_hint_based.py
@@ -4,7 +4,7 @@ from typing import Dict, Sequence
 
 from cvise.passes.hint_based import HintBasedPass
 from cvise.tests.testabstract import collect_all_transforms, iterate_pass
-from cvise.utils.hint import HINT_SCHEMA
+from cvise.utils.hint import HintBundle, HINT_SCHEMA
 
 
 class StubHintBasedPass(HintBasedPass):
@@ -15,9 +15,10 @@ class StubHintBasedPass(HintBasedPass):
                 jsonschema.validate(hint, schema=HINT_SCHEMA)
         self.contents_to_hints = contents_to_hints
 
-    def generate_hints(self, test_case: Path) -> Sequence[object]:
+    def generate_hints(self, test_case: Path) -> HintBundle:
         contents = test_case.read_text()
-        return self.contents_to_hints.get(contents, [])
+        hints = self.contents_to_hints.get(contents, [])
+        return HintBundle(hints=hints)
 
 
 def test_hint_based_first_char_once(tmp_path: Path):

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -12,7 +12,7 @@ applied to all heuristics in a uniform way).
 from dataclasses import dataclass
 import json
 from pathlib import Path
-from typing import Any, List, Sequence, TextIO
+from typing import List, Sequence
 import zstandard
 
 

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -65,9 +65,9 @@ HINT_SCHEMA = {
 }
 
 
-def apply_hints(hints: HintBundle, file: Path) -> str:
+def apply_hints(bundle: HintBundle, file: Path) -> str:
     """Edits the file applying the specified hints to its contents."""
-    patches = sum((h['p'] for h in hints.hints), start=[])
+    patches = sum((h['p'] for h in bundle.hints), start=[])
     merged_patches = merge_overlapping_patches(patches)
 
     with open(file) as f:
@@ -89,13 +89,13 @@ def apply_hints(hints: HintBundle, file: Path) -> str:
     return new_data
 
 
-def store_hints(hints: HintBundle, hints_file_path: Path) -> None:
+def store_hints(bundle: HintBundle, hints_file_path: Path) -> None:
     """Serializes hints to the given file.
 
     We currently use the Zstandard compression to reduce the space usage (the empirical compression ratio observed for
     hint JSONs is around 5x..20x)."""
     with zstandard.open(hints_file_path, 'wt') as f:
-        for h in hints.hints:
+        for h in bundle.hints:
             # Skip checks and omit spaces around separators, for the sake of performance.
             json.dump(h, f, check_circular=False, separators=(',', ':'))
             f.write('\n')

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -9,10 +9,27 @@ heuristics and to perform reduction more efficiently (as algorithms can now be
 applied to all heuristics in a uniform way).
 """
 
+from dataclasses import dataclass
 import json
 from pathlib import Path
-from typing import Sequence
+from typing import Any, List, Sequence, TextIO
 import zstandard
+
+
+@dataclass
+class HintBundle:
+    """Stores a collection of hints.
+
+    Its standard serialization format is a newline-separated JSON of the following structure:
+
+      <Hint 1 object>\n
+      <Hint 2 object>\n
+      ...
+    """
+
+    # Hint objects - each item matches the `HINT_SCHEMA`.
+    hints: List[object]
+
 
 # JSON Schemas:
 
@@ -48,9 +65,9 @@ HINT_SCHEMA = {
 }
 
 
-def apply_hints(hints: Sequence[object], file: Path) -> str:
+def apply_hints(hints: HintBundle, file: Path) -> str:
     """Edits the file applying the specified hints to its contents."""
-    patches = sum((h['p'] for h in hints), start=[])
+    patches = sum((h['p'] for h in hints.hints), start=[])
     merged_patches = merge_overlapping_patches(patches)
 
     with open(file) as f:
@@ -72,19 +89,19 @@ def apply_hints(hints: Sequence[object], file: Path) -> str:
     return new_data
 
 
-def store_hints(hints: Sequence[object], hints_file_path: Path) -> None:
+def store_hints(hints: HintBundle, hints_file_path: Path) -> None:
     """Serializes hints to the given file.
 
     We currently use the Zstandard compression to reduce the space usage (the empirical compression ratio observed for
     hint JSONs is around 5x..20x)."""
     with zstandard.open(hints_file_path, 'wt') as f:
-        for h in hints:
+        for h in hints.hints:
             # Skip checks and omit spaces around separators, for the sake of performance.
             json.dump(h, f, check_circular=False, separators=(',', ':'))
             f.write('\n')
 
 
-def load_hints(hints_file_path: Path, begin_index: int, end_index: int) -> Sequence[object]:
+def load_hints(hints_file_path: Path, begin_index: int, end_index: int) -> HintBundle:
     """Deserializes hints with the given indices [begin; end) from a file.
 
     Whether the hints file is compressed is determined based on the file extension."""
@@ -97,7 +114,7 @@ def load_hints(hints_file_path: Path, begin_index: int, end_index: int) -> Seque
                     hints.append(json.loads(line))
                 except json.decoder.JSONDecodeError as e:
                     raise RuntimeError(f'Failed to decode line "{line}": {e}') from e
-    return hints
+    return HintBundle(hints=hints)
 
 
 def merge_overlapping_patches(patches: Sequence[object]) -> Sequence[object]:


### PR DESCRIPTION
Refactor the code to pass hints as a bundle object instead of the naked list.

This is preparation for introducing additional items of data stored next to hints - e.g., "vocabulary" of strings shared between hints.