### PR TITLE
hints: Support text replacement patches

### DIFF
--- a/clang_delta/HintsBuilder.cpp
+++ b/clang_delta/HintsBuilder.cpp
@@ -51,6 +51,11 @@ void HintsBuilder::FinishCurrentHint() {
 
 void HintsBuilder::ReverseOrder() { std::reverse(Hints.begin(), Hints.end()); }
 
+std::string HintsBuilder::GetVocabularyJson() const {
+  // FIXME: return a populated array once text replacement hints are supported.
+  return "[]";
+}
+
 std::vector<std::string> HintsBuilder::GetHintJsons() const {
   std::vector<std::string> Jsons;
   Jsons.reserve(Hints.size());

--- a/clang_delta/HintsBuilder.h
+++ b/clang_delta/HintsBuilder.h
@@ -37,6 +37,7 @@ public:
 
   void ReverseOrder();
 
+  std::string GetVocabularyJson() const;
   std::vector<std::string> GetHintJsons() const;
 
 private:

--- a/clang_delta/Transformation.cpp
+++ b/clang_delta/Transformation.cpp
@@ -133,6 +133,7 @@ void Transformation::outputOriginalSource(llvm::raw_ostream &OutStream)
 
 void Transformation::outputHints(llvm::raw_ostream &OutStream)
 {
+  OutStream << Hints->GetVocabularyJson() << "\n";
   for (const auto& Json : Hints->GetHintJsons()) {
     OutStream << Json << "\n";
   }
@@ -496,7 +497,7 @@ const Type *Transformation::getBasePointerElemType(const Type *Ty)
 
 int Transformation::getIndexAsInteger(const Expr *E)
 {
-  Expr::EvalResult Result; 
+  Expr::EvalResult Result;
   if (!E->EvaluateAsInt(Result, *Context))
     TransAssert(0 && "Failed to Evaluate index!");
 

--- a/cvise/passes/clanghints.py
+++ b/cvise/passes/clanghints.py
@@ -90,7 +90,10 @@ class ClangHintsPass(HintBasedPass):
         hints = []
         # FIXME: Set a timeout.
         with subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True) as proc:
-            vocab = json.loads(next(proc.stdout))
+            # When reading, gracefully handle EOF because the tool might've failed with no output.
+            vocab_string = next(proc.stdout, None)
+            vocab = json.loads(vocab_string) if vocab_string else []
+
             for line in proc.stdout:
                 if not line.isspace():
                     hints.append(json.loads(line))

--- a/cvise/passes/clanghints.py
+++ b/cvise/passes/clanghints.py
@@ -91,8 +91,8 @@ class ClangHintsPass(HintBasedPass):
         # FIXME: Set a timeout.
         with subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True) as proc:
             # When reading, gracefully handle EOF because the tool might've failed with no output.
-            vocab_string = next(proc.stdout, None)
-            vocab = json.loads(vocab_string) if vocab_string else []
+            vocab_line = next(proc.stdout, None)
+            vocab = json.loads(vocab_line) if vocab_line else []
 
             for line in proc.stdout:
                 if not line.isspace():

--- a/cvise/passes/clanghints.py
+++ b/cvise/passes/clanghints.py
@@ -90,7 +90,8 @@ class ClangHintsPass(HintBasedPass):
         hints = []
         # FIXME: Set a timeout.
         with subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True) as proc:
+            vocab = json.loads(next(proc.stdout))
             for line in proc.stdout:
                 if not line.isspace():
                     hints.append(json.loads(line))
-        return HintBundle(hints=hints)
+        return HintBundle(vocabulary=vocab, hints=hints)

--- a/cvise/tests/test_clanghints.py
+++ b/cvise/tests/test_clanghints.py
@@ -44,3 +44,11 @@ def test_inline_ns(tmp_path):
     p, state = init_pass('remove-unused-function', tmp_path, input_path)
 
     assert state is None
+
+
+def test_malformed_code(tmp_path):
+    input_path = tmp_path / 'input.cc'
+    input_path.write_text('!?badbadbad@#')
+    p, state = init_pass('remove-unused-function', tmp_path, input_path)
+
+    assert state is None

--- a/cvise/tests/test_hint.py
+++ b/cvise/tests/test_hint.py
@@ -160,7 +160,7 @@ def test_apply_hints_replacement_discarded_inside_deletion(tmp_file):
     assert new_data == 'Foo  baz'
 
 
-def test_apply_hints_replacement_discarded_inside_deletion(tmp_file):
+def test_apply_hints_deletion_discarded_inside_replacement(tmp_file):
     """Test that a deletion is a no-op if happening inside a to-be-replaced fragment."""
     tmp_file.write_text('Foo bar baz')
     vocab = ['some']

--- a/cvise/tests/test_hint.py
+++ b/cvise/tests/test_hint.py
@@ -118,15 +118,126 @@ def test_apply_hints_delete_nested(tmp_file):
     assert new_data == 'Foo baz'
 
 
+def test_apply_hints_replace_with_shorter(tmp_file):
+    """Test a hint replacing a fragment with a shorter value."""
+    tmp_file.write_text('Foo bar baz')
+    vocab = ['x']
+    hint = {'p': [{'l': 4, 'r': 7, 'v': 0}]}
+    jsonschema.validate(hint, schema=HINT_SCHEMA)
+    bundle = HintBundle(vocabulary=vocab, hints=[hint])
+
+    new_data = apply_hints(bundle, tmp_file)
+
+    assert new_data == 'Foo x baz'
+
+
+def test_apply_hints_replace_with_longer(tmp_file):
+    """Test a hint replacing a fragment with a longer value."""
+    tmp_file.write_text('Foo x baz')
+    vocab = ['x', 'bar']
+    hint = {'p': [{'l': 4, 'r': 5, 'v': 1}]}
+    jsonschema.validate(hint, schema=HINT_SCHEMA)
+    bundle = HintBundle(vocabulary=vocab, hints=[hint])
+
+    new_data = apply_hints(bundle, tmp_file)
+
+    assert new_data == 'Foo bar baz'
+
+
+def test_apply_hints_replacement_discarded_inside_deletion(tmp_file):
+    """Test that a replacement is a no-op if happening inside a to-be-deleted fragment."""
+    tmp_file.write_text('Foo bar baz')
+    vocab = ['x']
+    hint1 = {'p': [{'l': 5, 'r': 6, 'v': 0}]}  # replaces "a" with "x" in "bar"
+    hint2 = {'p': [{'l': 4, 'r': 7}]}  # deletes "bar"
+    hints = [hint1, hint2]
+    for h in hints:
+        jsonschema.validate(h, schema=HINT_SCHEMA)
+    bundle = HintBundle(vocabulary=vocab, hints=hints)
+
+    new_data = apply_hints(bundle, tmp_file)
+
+    assert new_data == 'Foo  baz'
+
+
+def test_apply_hints_replacement_discarded_inside_deletion(tmp_file):
+    """Test that a deletion is a no-op if happening inside a to-be-replaced fragment."""
+    tmp_file.write_text('Foo bar baz')
+    vocab = ['some']
+    hint1 = {'p': [{'l': 5, 'r': 6}]}  # deletes "a" in "bar"
+    hint2 = {'p': [{'l': 4, 'r': 7, 'v': 0}]}  # replaces "bar" with "some"
+    hints = [hint1, hint2]
+    for h in hints:
+        jsonschema.validate(h, schema=HINT_SCHEMA)
+    bundle = HintBundle(vocabulary=vocab, hints=hints)
+
+    new_data = apply_hints(bundle, tmp_file)
+
+    assert new_data == 'Foo some baz'
+
+
+def test_apply_hints_replacement_superseded_by_same_pos_deletion(tmp_file):
+    """Test that a deletion takes precedence over a replacement in the same location."""
+    tmp_file.write_text('Foo bar baz')
+    vocab = ['x']
+    hint1 = {'p': [{'l': 4, 'r': 5, 'v': 0}]}  # replaces "b" with "x" in "bar"
+    hint2 = {'p': [{'l': 4, 'r': 7}]}  # deletes "bar"
+    hints = [hint1, hint2]
+    for h in hints:
+        jsonschema.validate(h, schema=HINT_SCHEMA)
+    bundle = HintBundle(vocabulary=vocab, hints=hints)
+
+    new_data = apply_hints(bundle, tmp_file)
+
+    assert new_data == 'Foo  baz'
+
+
+def test_apply_hints_replacement_and_deletion_touching(tmp_file):
+    """Test that deletions and replacements in touching, but not overlapping, fragments are applied independently."""
+    tmp_file.write_text('Foo bar baz')
+    vocab = ['some']
+    hint1 = {'p': [{'l': 5, 'r': 7, 'v': 0}]}  # replaces "ar" with "some"
+    hint2 = {'p': [{'l': 4, 'r': 5}]}  # deletes "b" in "bar"
+    hint3 = {'p': [{'l': 7, 'r': 8}]}  # deletes " " after "bar"
+    hints = [hint1, hint2, hint3]
+    for h in hints:
+        jsonschema.validate(h, schema=HINT_SCHEMA)
+    bundle = HintBundle(vocabulary=vocab, hints=hints)
+
+    new_data = apply_hints(bundle, tmp_file)
+
+    assert new_data == 'Foo somebaz'
+
+
+def test_apply_hints_overlapping_replacements(tmp_file):
+    """Test overlapping replacements are handled gracefully.
+
+    As there's no ideal solution for this kind of merge conflict, the main goal is to verify the implementation doesn't
+    break. At the moment, the leftwise patch wins in this case, but this is subject to change in the future."""
+    tmp_file.write_text('abcd')
+    vocab = ['foo', 'x']
+    hint1 = {'p': [{'l': 1, 'r': 3, 'v': 0}]}  # replaces "bc" with "foo"
+    hint2 = {'p': [{'l': 2, 'r': 4, 'v': 1}]}  # replaces "cd" with "x"
+    hints = [hint1, hint2]
+    for h in hints:
+        jsonschema.validate(h, schema=HINT_SCHEMA)
+    bundle = HintBundle(vocabulary=vocab, hints=hints)
+
+    new_data = apply_hints(bundle, tmp_file)
+
+    assert new_data == 'afoo'
+
+
 def test_store_load_hints(tmp_hints_file):
+    vocab = ['new text']
     hint1 = {'p': [{'l': 0, 'r': 1}]}
     hint2 = {'p': [{'l': 2, 'r': 3}, {'l': 4, 'r': 5, 'v': 0}]}
-    hints = HintBundle(hints=[hint1, hint2])
+    hints = HintBundle(vocabulary=vocab, hints=[hint1, hint2])
     store_hints(hints, tmp_hints_file)
 
-    assert load_hints(tmp_hints_file, 0, 2) == HintBundle(hints=[hint1, hint2])
-    assert load_hints(tmp_hints_file, 0, 1) == HintBundle(hints=[hint1])
-    assert load_hints(tmp_hints_file, 1, 2) == HintBundle(hints=[hint2])
+    assert load_hints(tmp_hints_file, 0, 2) == HintBundle(vocabulary=vocab, hints=[hint1, hint2])
+    assert load_hints(tmp_hints_file, 0, 1) == HintBundle(vocabulary=vocab, hints=[hint1])
+    assert load_hints(tmp_hints_file, 1, 2) == HintBundle(vocabulary=vocab, hints=[hint2])
 
 
 def test_hints_storage_compression(tmp_file):

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -92,7 +92,7 @@ def apply_hints(bundle: HintBundle, file: Path) -> str:
         new_data += orig_data[start_pos:left]
         # Skip the original chunk inside the current patch.
         start_pos = right
-        # Insert the replcement value, if provided.
+        # Insert the replacement value, if provided.
         if 'v' in p:
             new_data += hints.vocabulary[p['v']]
     # Add the unmodified chunk after the last patch end.
@@ -122,7 +122,7 @@ def load_hints(hints_file_path: Path, begin_index: int, end_index: int) -> HintB
     with zstandard.open(hints_file_path, 'rt') if hints_file_path.suffix == '.zst' else open(hints_file_path) as f:
         vocab = try_parse_json_line(next(f))
         # Do a lightweight check that'd catch a basic mistake (a hint object coming instead of a vocabulary array). We
-        # don't want to perform ful type/schema checking during loading due to performance concerns.
+        # don't want to perform full type/schema checking during loading due to performance concerns.
         if not isinstance(vocab, list):
             raise RuntimeError(f'Failed to read hint vocabulary: expected array, instead got: {vocab}')
 

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -95,7 +95,7 @@ def apply_hints(bundle: HintBundle, file: Path) -> str:
         start_pos = right
         # Insert the replacement value, if provided.
         if 'v' in p:
-            new_data += hints.vocabulary[p['v']]
+            new_data += bundle.vocabulary[p['v']]
     # Add the unmodified chunk after the last patch end.
     new_data += orig_data[start_pos:]
     return new_data

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -31,7 +31,8 @@ class HintBundle:
     # Hint objects - each item matches the `HINT_SCHEMA`.
     hints: List[object]
     # Strings that hints can refer to.
-    vocabulary: List[str] = field(default_factory=list)  # default to an empty list
+    # Note: a simple "= []" wouldn't be suitable because mutable default values are error-prone in Python.
+    vocabulary: List[str] = field(default_factory=list)
 
 
 # JSON Schemas:

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -9,10 +9,10 @@ heuristics and to perform reduction more efficiently (as algorithms can now be
 applied to all heuristics in a uniform way).
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import json
 from pathlib import Path
-from typing import List, Sequence
+from typing import Any, List, Sequence, TextIO
 import zstandard
 
 
@@ -22,6 +22,7 @@ class HintBundle:
 
     Its standard serialization format is a newline-separated JSON of the following structure:
 
+      <Vocabulary array>\n
       <Hint 1 object>\n
       <Hint 2 object>\n
       ...
@@ -29,6 +30,8 @@ class HintBundle:
 
     # Hint objects - each item matches the `HINT_SCHEMA`.
     hints: List[object]
+    # Strings that hints can refer to.
+    vocabulary: List[str] = field(default_factory=list)  # default to an empty list
 
 
 # JSON Schemas:
@@ -45,6 +48,11 @@ HINT_PATCH_SCHEMA = {
         'r': {
             'description': "Right position of the chunk (index of the next character in the text after the chunk's last character). Must be greater than 'l'.",
             'type': 'integer',
+        },
+        'v': {
+            'description': 'Indicates that the chunk needs to be replaced with a new value - the string with the specified index in the vocabulary.',
+            'type': 'integer',
+            'minimum': 0,
         },
     },
     'required': ['l', 'r'],
@@ -82,8 +90,11 @@ def apply_hints(bundle: HintBundle, file: Path) -> str:
         assert left < right <= len(orig_data)
         # Add the unmodified chunk up to the current patch begin.
         new_data += orig_data[start_pos:left]
-        # Delete the chunk inside the current patch.
+        # Skip the original chunk inside the current patch.
         start_pos = right
+        # Insert the replcement value, if provided.
+        if 'v' in p:
+            new_data += hints.vocabulary[p['v']]
     # Add the unmodified chunk after the last patch end.
     new_data += orig_data[start_pos:]
     return new_data
@@ -95,9 +106,10 @@ def store_hints(bundle: HintBundle, hints_file_path: Path) -> None:
     We currently use the Zstandard compression to reduce the space usage (the empirical compression ratio observed for
     hint JSONs is around 5x..20x)."""
     with zstandard.open(hints_file_path, 'wt') as f:
+        write_compact_json(bundle.vocabulary, f)
+        f.write('\n')
         for h in bundle.hints:
-            # Skip checks and omit spaces around separators, for the sake of performance.
-            json.dump(h, f, check_circular=False, separators=(',', ':'))
+            write_compact_json(h, f)
             f.write('\n')
 
 
@@ -108,20 +120,40 @@ def load_hints(hints_file_path: Path, begin_index: int, end_index: int) -> HintB
     assert begin_index < end_index
     hints = []
     with zstandard.open(hints_file_path, 'rt') if hints_file_path.suffix == '.zst' else open(hints_file_path) as f:
+        vocab = try_parse_json_line(next(f))
+        # Do a lightweight check that'd catch a basic mistake (a hint object coming instead of a vocabulary array). We
+        # don't want to perform ful type/schema checking during loading due to performance concerns.
+        if not isinstance(vocab, list):
+            raise RuntimeError(f'Failed to read hint vocabulary: expected array, instead got: {vocab}')
+
         for i, line in enumerate(f):
             if begin_index <= i < end_index:
-                try:
-                    hints.append(json.loads(line))
-                except json.decoder.JSONDecodeError as e:
-                    raise RuntimeError(f'Failed to decode line "{line}": {e}') from e
-    return HintBundle(hints=hints)
+                hints.append(try_parse_json_line(line))
+    return HintBundle(hints=hints, vocabulary=vocab)
+
+
+def write_compact_json(value: Any, file: TextIO) -> str:
+    """Writes a JSON dump, as a compact representation (without unnecessary spaces), to the file.
+
+    Skips circular structure checks, for performance reasons."""
+    # Specify custom separators - the default ones have spaces after them.
+    return json.dump(value, file, check_circular=False, separators=(',', ':'))
+
+
+def try_parse_json_line(text: str) -> Any:
+    try:
+        return json.loads(text)
+    except json.decoder.JSONDecodeError as e:
+        raise RuntimeError(f'Failed to decode line "{text}": {e}') from e
 
 
 def merge_overlapping_patches(patches: Sequence[object]) -> Sequence[object]:
     """Returns non-overlapping hint patches, merging patches where necessary."""
 
     def sorting_key(patch):
-        return patch['l']
+        is_replacement = 'v' in patch
+        # Among all patches starting in the same location, deletion should take precedence over text replacement.
+        return patch['l'], is_replacement
 
     merged = []
     for patch in sorted(patches, key=sorting_key):

--- a/tests/test_cvise.py
+++ b/tests/test_cvise.py
@@ -111,7 +111,8 @@ def test_apply_hints(tmp_path: Path):
     """Test the application of hints via the --action=apply-hints mode."""
     hints_path = tmp_path / 'hints.jsonl'
     hints_path.write_text(
-        """{"p": [{"l": 0, "r": 1}]}
+        """[]
+        {"p": [{"l": 0, "r": 1}]}
         {"p": [{"l": 1, "r": 2}]}
         {"p": [{"l": 2, "r": 3}]}
         """


### PR DESCRIPTION
Implement support for hints that replace text with the new value. In order to have a compact representation, use a "vocabulary" - a string table that hints can refer to; the vocabulary can also be used for other features in the future.

This is preparation for porting heuristics that do text replacements to the hint-based framework.