### PR TITLE
cli: Don't close stderr

### DIFF
--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+from contextlib import nullcontext
 import datetime
 import importlib.util
 from itertools import chain
@@ -475,7 +476,7 @@ def do_reduce(args):
         print(err)
     else:
         time_stop = time.monotonic()
-        with open(args.log_file, 'a') if args.log_file else sys.stderr as fs:
+        with open(args.log_file, 'a') if args.log_file else nullcontext(sys.stderr) as fs:
             fs.write('===< PASS statistics >===\n')
             fs.write(
                 '  %-60s %8s %8s %8s %8s %15s\n'


### PR DESCRIPTION
The "with sys.stderr" construct was closing the stderr file descriptor. While this happened near the program exit, it was still error-prone since if there are background threads or processes they'd start hitting (highly unusual) errors when printing to stderr.

In particular, this closed stderr would've broken the typical "Logging to a single file from multiple processes" pattern (which we're planning to switch to in order to switch to the forkserver multiprocessing mode).