### PR TITLE
Stop using check_sanity for passes

### DIFF
--- a/cvise/cvise.py
+++ b/cvise/cvise.py
@@ -184,7 +184,7 @@ class CVise:
     def reduce(self, pass_group, skip_initial):
         self._check_prerequisites(pass_group)
         if not self.skip_interestingness_test_check:
-            self.test_manager.check_sanity(True)
+            self.test_manager.check_sanity()
 
         logging.info(f'===< {os.getpid()} >===')
         logging.info(

--- a/cvise/passes/abstract.py
+++ b/cvise/passes/abstract.py
@@ -94,7 +94,7 @@ class AbstractPass:
     def check_prerequisites(self):
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'check_prerequisites'!")
 
-    def new(self, test_case, check_sanity, tmp_dir):
+    def new(self, test_case, tmp_dir):
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'new'!")
 
     def advance(self, test_case, state):

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -349,14 +349,14 @@ class TestManager:
 
         return ''.join(diffed_lines)
 
-    def check_sanity(self, verbose=False):
+    def check_sanity(self):
         logging.debug('perform sanity check... ')
 
         folder = Path(tempfile.mkdtemp(prefix=f'{self.TEMP_PREFIX}sanity-'))
         test_env = TestEnvironment(None, 0, self.test_script, folder, list(self.test_cases)[0], self.test_cases, None)
         logging.debug(f'sanity check tmpdir = {test_env.folder}')
 
-        returncode = test_env.run_test(verbose)
+        returncode = test_env.run_test(verbose=True)
         if returncode == 0:
             rmfolder(folder)
             logging.debug('sanity check successful')

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -606,11 +606,7 @@ class TestManager:
                 self.states = []
                 for pass_id, pass_ in enumerate(self.current_passes):
                     start_time = time.monotonic()
-                    self.states.append(
-                        pass_.new(
-                            self.current_test_case, check_sanity=self.check_sanity, tmp_dir=Path(self.roots[pass_id])
-                        )
-                    )
+                    self.states.append(pass_.new(self.current_test_case, tmp_dir=Path(self.roots[pass_id])))
                     self.pass_statistic.add_initialized(pass_, start_time)
                 self.skip = False
 


### PR DESCRIPTION
Since the migration of the Lines pass to hints, none of heuristics modifies the input file during initialization. This means the "check_sanity" logic (double-checking whether the modified input still satisfies the interestingness script) isn't needed anymore as a pass parameter.