### PR TITLE
passes: Ensure max_transforms is initialized

### DIFF
--- a/cvise/cvise.py
+++ b/cvise/cvise.py
@@ -156,7 +156,6 @@ class CVise:
                     raise CViseError('Unknown pass {}'.format(pass_dict['pass'])) from None
 
                 pass_instance = pass_class(pass_dict.get('arg'), external_programs)
-                pass_instance.max_transforms = None
                 if str(pass_instance) in removed_passes:
                     continue
 

--- a/cvise/passes/abstract.py
+++ b/cvise/passes/abstract.py
@@ -71,6 +71,7 @@ class AbstractPass:
     def __init__(self, arg=None, external_programs=None):
         self.external_programs = external_programs
         self.arg = arg
+        self.max_transforms = None
 
     def __repr__(self):
         if self.arg is not None:

--- a/cvise/tests/test_test_manager.py
+++ b/cvise/tests/test_test_manager.py
@@ -18,10 +18,6 @@ PARALLEL_TESTS = 10
 
 
 class StubPass(AbstractPass):
-    def __init__(self):
-        super().__init__()
-        self.max_transforms = None
-
     def new(self, test_case, **kwargs):
         return 0
 


### PR DESCRIPTION
The "max_transforms" property used to be read when debug-printing a Pass object, but wasn't guaranteed to be initialized on all codepaths (especially not in unit tests). Ensure this via constructor, to prevent misleading error messages.