### PR TITLE
Allow the search for cvise script in the top-level directory.

### DIFF
--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -47,6 +47,7 @@ def get_share_dir():
     share_dirs = [
         os.path.join('@CMAKE_INSTALL_FULL_DATADIR@', '@cvise_PACKAGE@'),
         destdir + os.path.join('@CMAKE_INSTALL_FULL_DATADIR@', '@cvise_PACKAGE@'),
+        os.path.join(script_path),
         os.path.join(script_path, 'cvise'),
     ]
 


### PR DESCRIPTION
This is to support a different file layout in downstream projects, placing the `cvise` Python package in a top-level folder.