### PR TITLE
CI: Don't cancel jobs for the master branch

### DIFF
--- a/.github/workflows/build-llvm-nightly.yml
+++ b/.github/workflows/build-llvm-nightly.yml
@@ -9,9 +9,10 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch: {}
 
+# Cancel the workflow if a new one is requested for the same PR/branch, but still test all commits on the master branch.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master'}}
 
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,10 @@ on:
     branches: [ master ]
   workflow_dispatch: {}
 
+# Cancel the workflow if a new one is requested for the same PR/branch, but still test all commits on the master branch.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master'}}
 
 jobs:
   CI:


### PR DESCRIPTION
Even when multiple commits land in a quick succession to the master branch, we still want to test them all; cancelling concurrent jobs was resulting in spurious "failures" displayed on Github.