### PR TITLE
Revert "Allow the search for cvise script in the top-level directory."

### DIFF
--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -48,7 +48,6 @@ def get_share_dir():
     share_dirs = [
         os.path.join('@CMAKE_INSTALL_FULL_DATADIR@', '@cvise_PACKAGE@'),
         destdir + os.path.join('@CMAKE_INSTALL_FULL_DATADIR@', '@cvise_PACKAGE@'),
-        os.path.join(script_path),
         os.path.join(script_path, 'cvise'),
     ]
 


### PR DESCRIPTION
Reverts marxin/cvise#215 - the change breaks the tests.