### PR TITLE
Revert "Allow the search for cvise script in the top-level directory."

### DIFF
--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -48,7 +48,6 @@ def get_share_dir():
     share_dirs = [
         os.path.join('@CMAKE_INSTALL_FULL_DATADIR@', '@cvise_PACKAGE@'),
         destdir + os.path.join('@CMAKE_INSTALL_FULL_DATADIR@', '@cvise_PACKAGE@'),
-        os.path.join(script_path),
         os.path.join(script_path, 'cvise'),
     ]
 


### PR DESCRIPTION
Reverts marxin/cvise#215 - tests start hanging/failing with:

  File "build/cvise-cli.py", line 70, in get_available_pass_groups                                                                                                                           
    raise MissingPassGroupsError()                                                                                                                                                                                                     
cvise.utils.error.MissingPassGroupsError: Could not find a directory with definitions for pass groups!