### PR TITLE
hints: Introduce hint type; run independent binsrch per type

### DIFF
--- a/cvise/passes/clanghints.py
+++ b/cvise/passes/clanghints.py
@@ -1,12 +1,10 @@
 import json
 import logging
-from pathlib import Path
 import shlex
 import subprocess
 import time
 from typing import Union
 
-from cvise.passes.abstract import BinaryState
 from cvise.passes.hint_based import HintBasedPass, HintState
 from cvise.utils.hint import HintBundle
 

--- a/cvise/passes/clanghints.py
+++ b/cvise/passes/clanghints.py
@@ -19,15 +19,14 @@ class ClangState(HintState):
 
     See the comment in ClangHintsPass for the background."""
 
-    def __init__(self, clang_std: str, hint_count: int, hints_file_path: Path, binary_state: BinaryState):
-        super().__init__(hint_count, hints_file_path, binary_state)
-        self.clang_std = clang_std
-
     @staticmethod
     def wrap(parent: Union[HintState, None], clang_std: str) -> Union[HintState, None]:
         if parent is None:
             return None
-        return ClangState(clang_std, parent.hint_count, parent.hints_file_path, parent.binary_state)
+        wrapped = object.__new__(ClangState)
+        wrapped.__dict__.update(parent.__dict__)
+        wrapped.clang_std = clang_std
+        return wrapped
 
 
 class ClangHintsPass(HintBasedPass):

--- a/cvise/passes/hint_based.py
+++ b/cvise/passes/hint_based.py
@@ -1,43 +1,120 @@
 from __future__ import annotations
+from copy import copy
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Union
+from typing import Dict, List, Union
 
 from cvise.passes.abstract import AbstractPass, BinaryState, PassResult
-from cvise.utils.hint import apply_hints, HintBundle, load_hints, store_hints
+from cvise.utils.hint import apply_hints, group_hints_by_type, HintBundle, load_hints, store_hints
 
-HINTS_FILE_NAME = 'hints.jsonl.zst'
+HINTS_FILE_NAME_TEMPLATE = 'hints{type}.jsonl.zst'
+
+
+@dataclass
+class PerTypeHintState:
+    """A sub-item of HintState storing information for a particular hint type.
+
+    See the comment in the HintBasedPass.
+    """
+
+    # A hint type for which this state is for; an empty string if a hint doesn't explicitly specify types.
+    type: str
+    # Only the base name, not a full path - it's a small optimization (and we anyway need to store the tmp dir in the
+    # HintState).
+    hints_file_name: Path
+    # State of the binary search over hints with this particular type.
+    binary_state: BinaryState
+
+    @staticmethod
+    def create(type: str, hint_count: int, hints_file_name: Path) -> PerTypeHintState:
+        assert hint_count > 0
+        return PerTypeHintState(type=type, hints_file_name=hints_file_name, binary_state=BinaryState.create(hint_count))
+
+    def advance(self) -> Union[PerTypeHintState, None]:
+        # Move to the next step in the binary search, or to None if this was the last step.
+        next_binary = self.binary_state.advance()
+        if next_binary is None:
+            return None
+        new = copy(self)
+        new.binary_state = next_binary
+        return new
+
+    def advance_on_success(self, new_hint_count: int) -> Union[PerTypeHintState, None]:
+        next_binary = self.binary_state.advance_on_success(new_hint_count)
+        if next_binary is None:
+            return None
+        new = copy(self)
+        new.binary_state = next_binary
+        return new
 
 
 class HintState:
-    def __init__(self, hint_count: int, hints_file_path: Path, binary_state: BinaryState):
-        assert hint_count > 0
-        self.hint_count = hint_count
-        self.hints_file_path = hints_file_path
-        self.binary_state = binary_state
+    """Stores the current state of the HintBasedPass.
+
+    Conceptually, it's representing multple binary searches, one for each hint type. These are applied & advanced in a
+    round-robin fashion. See the comment in the HintBasedPass.
+    """
+
+    def __init__(self, tmp_dir: Path, per_type_states: Dict[str, PerTypeHintState]):
+        self.tmp_dir = tmp_dir
+        # Sort the per-type states to have deterministic and repeatable enumeration order.
+        self.per_type_states = sorted(per_type_states, key=lambda s: s.type if s else '')
+        # Pointer to the current per-type state in the round-robin enumeration.
+        self.ptr = 0
 
     @staticmethod
-    def create(hint_count: int, hints_file_path: Path) -> HintState:
-        binary_state = BinaryState.create(hint_count)
-        return HintState(hint_count, hints_file_path, binary_state)
+    def create(tmp_dir: Path, type_to_bundle: Dict[str, HintBundle], type_to_file_name: Dict[str, Path]) -> HintState:
+        sub_states = []
+        # Initialize a separate binary search for each group of hints sharing a particular type.
+        for type, sub_bundle in type_to_bundle.items():
+            sub_states.append(PerTypeHintState.create(type, len(sub_bundle.hints), type_to_file_name[type]))
+        return HintState(tmp_dir, sub_states)
 
     def advance(self) -> Union[HintState, None]:
-        next_state = self.binary_state.advance()
-        if next_state is None:
-            return None
-        return HintState(self.hint_count, self.hints_file_path, next_state)
+        new = HintState(self.tmp_dir, copy(self.per_type_states))
+        new.ptr = self.ptr
+        # Switch to the next hint type in the round-robin fashion, but also prepare the current type's sub-state to
+        # point to the next binary search step.
+        new.per_type_states[new.ptr] = new.per_type_states[new.ptr].advance()
+        for _ in range(len(new.per_type_states)):
+            new.ptr = (new.ptr + 1) % len(new.per_type_states)
+            if new.per_type_states[new.ptr] is not None:
+                return new
+        # The current type turned out to be the very last which had a binary search running. Nothing to be done more.
+        return None
 
-    def advance_on_success(self, new_hint_count) -> Union[HintState, None]:
-        next_state = self.binary_state.advance_on_success(new_hint_count)
-        if next_state is None:
+    def advance_on_success(self, type_to_bundle: Dict[str, HintBundle]):
+        sub_states = []
+        # Advance all previously present hint types' substates. We ignore any newly appearing hint types because it's
+        # nontrivial to distinguish geniunely new hints from those that we (unsuccessfully) checked.
+        for old_substate in self.per_type_states:
+            if old_substate.type not in type_to_bundle:
+                # This hint type disappeared - probably all candidates have been removed by the reduction.
+                continue
+            new_hint_count = len(type_to_bundle[old_substate.type].hints)
+            new_substate = old_substate.advance_on_success(new_hint_count)
+            if new_substate:
+                sub_states.append(new_substate)
+        if not sub_states:
             return None
-        return HintState(new_hint_count, self.hints_file_path, next_state)
+        return HintState(self.tmp_dir, sub_states)
 
 
 class HintBasedPass(AbstractPass):
     """Base class for hint-based passes.
 
     Provides default implementations of new/transform/advance operations, which only require the subclass to implement
-    the generate_hints() method."""
+    the generate_hints() method.
+
+    Takes care of managing multiple binary searches, one per each hint type. For example, if the pass generated 10 hints
+    of "comment" type and 40 hints of "function" type, the order of enumeration in this pass' jobs would be:
+    * transform #1: attempt applying [0..10) "comment" hints;
+    * transform #2: attempt applying [0..40) "function" hints;
+    * transform #3: attempt applying [0..5) "comment" hints;
+    * transform #4: attempt applying [0..20) "function" hints;
+    * transform #5: attempt applying [5..10) "comment" hints;
+    * etc.
+    """
 
     def generate_hints(self, test_case: Path) -> HintBundle:
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'generate_hints'!")
@@ -46,10 +123,11 @@ class HintBasedPass(AbstractPass):
         hints = self.generate_hints(test_case)
         return self.new_from_hints(hints, tmp_dir)
 
-    def transform(self, test_case, state, process_event_notifier):
-        hints_range_begin = state.binary_state.index
-        hints_range_end = state.binary_state.end()
-        hints = load_hints(state.hints_file_path, hints_range_begin, hints_range_end)
+    def transform(self, test_case, state: HintState, process_event_notifier):
+        sub_state = state.per_type_states[state.ptr]
+        hints_range_begin = sub_state.binary_state.index
+        hints_range_end = sub_state.binary_state.end()
+        hints = load_hints(state.tmp_dir / sub_state.hints_file_name, hints_range_begin, hints_range_end)
         new_data = apply_hints(hints, Path(test_case))
         Path(test_case).write_text(new_data)
         return (PassResult.OK, state)
@@ -61,15 +139,15 @@ class HintBasedPass(AbstractPass):
         hints = self.generate_hints(test_case)
         return self.advance_on_success_from_hints(hints, state)
 
-    def new_from_hints(self, bundle: HintBundle, tmp_dir: str) -> Union[HintState, None]:
+    def new_from_hints(self, bundle: HintBundle, tmp_dir: Path) -> Union[HintState, None]:
         """Creates a state for pre-generated hints.
 
         Can be used by subclasses which don't follow the typical approach with implementing generate_hints()."""
         if not bundle.hints:
             return None
-        hints_file_path = tmp_dir / HINTS_FILE_NAME
-        store_hints(bundle, hints_file_path)
-        return HintState.create(len(bundle.hints), hints_file_path)
+        type_to_bundle = group_hints_by_type(bundle)
+        type_to_file_name = store_hints_per_type(tmp_dir, type_to_bundle)
+        return HintState.create(tmp_dir, type_to_bundle, type_to_file_name)
 
     def advance_on_success_from_hints(self, bundle: HintBundle, state: HintState) -> Union[HintState, None]:
         """Advances the state after a successful reduction, given pre-generated hints.
@@ -77,5 +155,15 @@ class HintBasedPass(AbstractPass):
         Can be used by subclasses which don't follow the typical approach with implementing generate_hints()."""
         if not bundle.hints:
             return None
-        store_hints(bundle, state.hints_file_path)
-        return state.advance_on_success(len(bundle.hints))
+        type_to_bundle = group_hints_by_type(bundle)
+        type_to_file_name = store_hints_per_type(state.tmp_dir, type_to_bundle)
+        return state.advance_on_success(type_to_bundle)
+
+
+def store_hints_per_type(tmp_dir: Path, type_to_bundle: Dict[str, HintBundle]) -> Dict[str, Path]:
+    type_to_file_name = {}
+    for type, sub_bundle in type_to_bundle.items():
+        file_name = Path(HINTS_FILE_NAME_TEMPLATE.format(type=type))
+        store_hints(sub_bundle, tmp_dir / file_name)
+        type_to_file_name[type] = file_name
+    return type_to_file_name

--- a/cvise/passes/hint_based.py
+++ b/cvise/passes/hint_based.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from copy import copy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, Union
 
 from cvise.passes.abstract import AbstractPass, BinaryState, PassResult
 from cvise.utils.hint import apply_hints, group_hints_by_type, HintBundle, load_hints, store_hints
@@ -156,7 +156,7 @@ class HintBasedPass(AbstractPass):
         if not bundle.hints:
             return None
         type_to_bundle = group_hints_by_type(bundle)
-        type_to_file_name = store_hints_per_type(state.tmp_dir, type_to_bundle)
+        store_hints_per_type(state.tmp_dir, type_to_bundle)
         return state.advance_on_success(type_to_bundle)
 
 

--- a/cvise/tests/test_hint_based.py
+++ b/cvise/tests/test_hint_based.py
@@ -109,11 +109,7 @@ def test_hint_based_state_iteration(tmp_path: Path):
 
 
 def test_hint_based_multiple_types(tmp_path: Path):
-    """Test advancing through hints of multiple types.
-
-    Unlike iterate_pass-based tests which pretend that any transformation leads
-    to a successful interestingness test and proceed immediately, here we
-    verify how different hints are attempted."""
+    """Test advancing through hints of multiple types."""
     vocab = ['space_removal', 'b_removal']
     hint_space1 = {'t': 0, 'p': [{'l': 3, 'r': 4}]}
     hint_space2 = {'t': 0, 'p': [{'l': 7, 'r': 8}]}

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -149,7 +149,7 @@ def group_hints_by_type(bundle: HintBundle) -> Dict[str, HintBundle]:
         type = bundle.vocabulary[h['t']] if 't' in h else ''
         if type not in grouped:
             grouped[type] = HintBundle(vocabulary=bundle.vocabulary, hints=[])
-        # FIXME: drop the 't' property in favor of storing it in the bundle's preamble
+        # FIXME: drop the 't' property in favor of storing it once, in the bundle's preamble
         grouped[type].hints.append(h)
     return grouped
 

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -12,7 +12,7 @@ applied to all heuristics in a uniform way).
 from dataclasses import dataclass, field
 import json
 from pathlib import Path
-from typing import Any, List, Sequence, TextIO
+from typing import Any, Dict, List, Sequence, TextIO
 import zstandard
 
 
@@ -41,6 +41,15 @@ HINT_PATCH_SCHEMA = {
     'description': 'Hint patch object. By default, unless a specific property is specified, the object denotes a simple deletion of the specified chunk.',
     'type': 'object',
     'properties': {
+        't': {
+            'description': (
+                'Indicates the type of the hint, as an index in the vocabulary. The purpose of the type is to let a '
+                'pass split hints into distinct groups, to guide the generic logic that attempts taking consecutive '
+                'ranges of same-typed hints.'
+            ),
+            'type': 'integer',
+            'minimum': 0,
+        },
         'l': {
             'description': 'Left position of the chunk (position is an index of the character in the text)',
             'type': 'integer',
@@ -131,6 +140,18 @@ def load_hints(hints_file_path: Path, begin_index: int, end_index: int) -> HintB
             if begin_index <= i < end_index:
                 hints.append(try_parse_json_line(line))
     return HintBundle(hints=hints, vocabulary=vocab)
+
+
+def group_hints_by_type(bundle: HintBundle) -> Dict[str, HintBundle]:
+    """Splits the bundle into multiple, one per each hint type."""
+    grouped: Dict[str, HintBundle] = {}
+    for h in bundle.hints:
+        type = bundle.vocabulary[h['t']] if 't' in h else ''
+        if type not in grouped:
+            grouped[type] = HintBundle(vocabulary=bundle.vocabulary, hints=[])
+        # FIXME: drop the 't' property in favor of storing it in the bundle's preamble
+        grouped[type].hints.append(h)
+    return grouped
 
 
 def write_compact_json(value: Any, file: TextIO) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ line-length = 120
 ignore = [
     "E501",
     "UP031",
+    "UP006",  # incorrectly suggests "Use `list` instead of `List` for type annotation" which is incompatible with Python 3.8
     "UP007",  # incorrectly suggests "Use `X | Y` for type annotations" which is incompatible with Python 3.8
 ]
 select = ["B", "E", "F", "W", "UP", "C4"] # consider: ["I", "RUF"]


### PR DESCRIPTION
This will be used for passes that return several groups of reduction opportunities, with different success rate and whose contiguous ranges are better to attempt separately (e.g., the "balanced" pass replacing round bracket pairs vs. square bracket pairs).