### PR TITLE
Add a variable for local tools directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ set(cvise_PACKAGE_URL         "https://github.com/marxin/cvise/")
 set(cvise_PACKAGE_VERSION     "2.11.0")
 set(cvise_VERSION             "2.11.0")
 set(cvise_LLVM_VERSION        "${LLVM_PACKAGE_VERSION}")
+set(LOCAL_TOOLS_DIR,          "${CMAKE_SOURCE_DIR}")
 
 configure_file("cmake_config.h.in" "${PROJECT_BINARY_DIR}/config.h")
 add_definitions("-DHAVE_CONFIG_H")

--- a/cvise/utils/externalprograms.py
+++ b/cvise/utils/externalprograms.py
@@ -18,7 +18,7 @@ def find_external_programs():
     for prog, local_folder in programs.items():
         path = None
         if local_folder:
-            local_folder = os.path.join(SCRIPT_PATH, '..', '..', local_folder)
+            local_folder = os.path.join('@LOCAL_TOOLS_DIR@', local_folder)
             if platform.system() == 'Windows':
                 for configuration in ['Debug', 'Release']:
                     new_local_folder = os.path.join(local_folder, configuration)


### PR DESCRIPTION
This allows to set a flexible path instead of relying to on the fragile directory layout, referring to the parent directory with `..`, etc.