### PR TITLE
lines: Configure Flex to use fast scanning mode

### DIFF
--- a/delta/topformflat.l
+++ b/delta/topformflat.l
@@ -34,6 +34,8 @@ int threshold = 0;
 
 %}
 
+/* optimize the scanner for performance */
+%option fast
 /* don't try to call yywrap() */
 %option noyywrap
 /* dsw: don't define yyunput() */


### PR DESCRIPTION
"%option fast" makes the topformflat scanner faster at the cost of binary size. Empirical improvement is ~50%: improving the throughput from 200 MiB/sec to 300 MiB/sec (numbers taken on my machine). The topformflat binary size increase is O(KBs), which is negligible.