### PR TITLE
lines: Don't generate hints for whitespace-only blocks

### DIFF
--- a/cvise/pass_groups/all.json
+++ b/cvise/pass_groups/all.json
@@ -188,6 +188,7 @@
     {"pass": "lines", "arg": "0"},
     {"pass": "clex", "arg": "rename-toks", "renaming": true},
     {"pass": "clex", "arg": "delete-string"},
+    {"pass": "blank"},
     {"pass": "indent", "arg": "final"}
  ]
 }

--- a/cvise/tests/test_lines.py
+++ b/cvise/tests/test_lines.py
@@ -429,8 +429,7 @@ def test_macro_level0(tmp_path, input_path):
     """Test removal of preprocessor macros with arg=0."""
     write_file(
         input_path,
-        """
-        #ifndef FOO
+        """#ifndef FOO
         #define FOO
         int x;
         FOO
@@ -456,8 +455,7 @@ def test_macro_level0(tmp_path, input_path):
     )
     # "#define FOO" deleted
     assert (
-        """
-        #ifndef FOO
+        """#ifndef FOO
         int x;
         FOO
         #define BAR \\
@@ -468,8 +466,7 @@ def test_macro_level0(tmp_path, input_path):
     )
     # "int x" deleted
     assert (
-        """
-        #ifndef FOO
+        """#ifndef FOO
         #define FOO
 
         FOO
@@ -481,8 +478,7 @@ def test_macro_level0(tmp_path, input_path):
     )
     # FOO usage deleted
     assert (
-        """
-        #ifndef FOO
+        """#ifndef FOO
         #define FOO
         int x;
         #define BAR \\
@@ -493,8 +489,7 @@ def test_macro_level0(tmp_path, input_path):
     )
     # "#define BAR" deleted
     assert (
-        """
-        #ifndef FOO
+        """#ifndef FOO
         #define FOO
         int x;
         FOO
@@ -504,8 +499,7 @@ def test_macro_level0(tmp_path, input_path):
     )
     # "int y" deleted
     assert (
-        """
-        #ifndef FOO
+        """#ifndef FOO
         #define FOO
         int x;
         FOO

--- a/cvise/tests/test_lines.py
+++ b/cvise/tests/test_lines.py
@@ -436,7 +436,7 @@ def test_macro_level0(tmp_path, input_path):
         #define BAR \\
           FOO 42
         int y;
-        """
+        """,
     )
     p, state = init_pass('0', tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
@@ -508,7 +508,7 @@ def test_nested_macro_level0(tmp_path, input_path):
         #define AFIELD foo
           AFIELD
         #undef AFIELD
-        };"""
+        };""",
     )
     p, state = init_pass('0', tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
@@ -528,7 +528,7 @@ def test_nested_macro_level1(tmp_path, input_path):
           AFIELD
         #undef AFIELD
         };
-        """
+        """,
     )
     p, state = init_pass('1', tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)

--- a/cvise/tests/test_lines.py
+++ b/cvise/tests/test_lines.py
@@ -585,6 +585,7 @@ def test_nested_macro_level1(tmp_path, input_path):
 
 
 def test_hash_character_not_macro_start(tmp_path, input_path):
+    """Test hash characters aren't mistakenly treated as macro/block start."""
     write_file(
         input_path,
         """

--- a/delta/topformflat.l
+++ b/delta/topformflat.l
@@ -28,6 +28,10 @@ int nesting = 0;
 // newlines are suppressed
 int threshold = 0;
 
+// indices of bytes of the most recent consecutive whitespace block.
+int whitespace_start_pos = -1;
+int whitespace_end_pos = -1;
+
 // update the position whenever a token is about to be processed
 // (this macro is triggered by Flex prior to executing the matched rule’s action).
 #define YY_USER_ACTION token_end_pos += yyleng;
@@ -59,16 +63,15 @@ int threshold = 0;
               }
 
   /* parse a preprocessor directive:
-   * a hash, then some non-newlines.  then, possibly, an escaped
-   * newline followed by more non-newlines (repeat as needed).
+   * start of the line with possible leading whitespaces, a hash, then some non-newlines.
+   * then, possibly, an escaped newline followed by more non-newlines (repeat as needed).
    * finally, a newline */
-"#".*("\\\n".*)*"\n" {
-                int hash_pos = token_end_pos - yyleng;
-                possibleChunkEnd(hash_pos);                 /* make sure starts on own line */
-                possibleChunkEnd(token_end_pos);
+"\n"?[[:blank:]]*"#".*("\\\n".*)*"\n" {
+                int start_pos = token_end_pos - yyleng;
+                possibleChunkEnd(start_pos);                /* make sure starts on own line */
+                possibleChunkEnd(token_end_pos - 1);        /* minus one to preserve the newline */
+                possibleChunkBegin(token_end_pos);          /* don't eat the newline in the subsequent chunk */
               }
-
-"\n"          { }                                           /* not any above case, skip it*/
 
 "//".*"\n"    { }                                           /* C++ comment */
 
@@ -87,6 +90,15 @@ int threshold = 0;
   "\'"        { diag("</CHAR>"); BEGIN(INITIAL); }          /* close tick */
   (.|\n)      {  }                                          /* ordinary char */
 }
+
+\n            |                                             /* line break, not matched in any other rule */
+[[:blank:]]+  {                                             /* chunk of whitespaces */
+                int token_start_pos = token_end_pos - yyleng;
+                // Start a new whitespace block, unless the previous one is to be continued.
+                if (token_start_pos != whitespace_end_pos)
+                  whitespace_start_pos = token_start_pos;
+                whitespace_end_pos = token_end_pos;
+              }
 
 .             { }
 
@@ -108,7 +120,10 @@ void possibleChunkEnd(int pos)
 {
   // Only attempt deleting chunks exactly at the specified nesting.
   if (nesting == threshold && chunk_start_pos < pos) {
-    printf("{\"p\":[{\"l\":%d,\"r\":%d}]}\n", chunk_start_pos, pos);
+    // Skip deleting chunks consisting of whitespaces only.
+    if (chunk_start_pos < whitespace_start_pos || pos > whitespace_end_pos) {
+      printf("{\"p\":[{\"l\":%d,\"r\":%d}]}\n", chunk_start_pos, pos);
+    }
   }
   possibleChunkBegin(pos);
 }

--- a/delta/topformflat.l
+++ b/delta/topformflat.l
@@ -66,7 +66,7 @@ int whitespace_end_pos = -1;
    * start of the line with possible leading whitespaces, a hash, then some non-newlines.
    * then, possibly, an escaped newline followed by more non-newlines (repeat as needed).
    * finally, a newline */
-"\n"?[[:blank:]]*"#".*("\\\n".*)*"\n" {
+("\n"|^)[[:blank:]]*"#".*("\\\n".*)*"\n" {
                 int start_pos = token_end_pos - yyleng;
                 possibleChunkEnd(start_pos);                /* make sure starts on own line */
                 possibleChunkEnd(token_end_pos - 1);        /* minus one to preserve the newline */

--- a/delta/topformflat.l
+++ b/delta/topformflat.l
@@ -66,9 +66,9 @@ int whitespace_end_pos = -1;
    * start of the line with possible leading whitespaces, a hash, then some non-newlines.
    * then, possibly, an escaped newline followed by more non-newlines (repeat as needed).
    * finally, a newline */
-("\n"|^)[[:blank:]]*"#".*("\\\n".*)*"\n" {
+^[[:blank:]]*"#".*("\\\n".*)*"\n" {
                 int start_pos = token_end_pos - yyleng;
-                possibleChunkEnd(start_pos);                /* make sure starts on own line */
+                possibleChunkEnd(start_pos - 1);            /* make sure starts on own line */
                 possibleChunkEnd(token_end_pos - 1);        /* minus one to preserve the newline */
                 possibleChunkBegin(token_end_pos);          /* don't eat the newline in the subsequent chunk */
               }
@@ -91,7 +91,7 @@ int whitespace_end_pos = -1;
   (.|\n)      {  }                                          /* ordinary char */
 }
 
-\n            |                                             /* line break, not matched in any other rule */
+"\n"          |                                             /* line break, not matched in any other rule */
 [[:blank:]]+  {                                             /* chunk of whitespaces */
                 int token_start_pos = token_end_pos - yyleng;
                 // Start a new whitespace block, unless the previous one is to be continued.

--- a/delta/topformflat.l
+++ b/delta/topformflat.l
@@ -68,7 +68,8 @@ int whitespace_end_pos = -1;
    * finally, a newline */
 ^[[:blank:]]*"#".*("\\\n".*)*"\n" {
                 int start_pos = token_end_pos - yyleng;
-                possibleChunkEnd(start_pos - 1);            /* make sure starts on own line */
+                if (start_pos > 0)
+                  possibleChunkEnd(start_pos - 1);          /* make sure starts on own line */
                 possibleChunkEnd(token_end_pos - 1);        /* minus one to preserve the newline */
                 possibleChunkBegin(token_end_pos);          /* don't eat the newline in the subsequent chunk */
               }

--- a/tests/test_cvise.py
+++ b/tests/test_cvise.py
@@ -103,7 +103,8 @@ def test_interleaving_passes(tmp_path: Path):
         copy_path.read_text()
         == """
         int foo() {
-        }"""
+        }
+        """
     )
 
 


### PR DESCRIPTION
Enhance the topformflat Flex grammar rules to only generate nontrivial hints, i.e. those consisting of non-whitespaces. Empirically, this reduces the number of hints by around 20%; and extra whitespaces are easy to remove at the end of reduction.

As a byproduct of this change, we were able to stricten some unit tests - now the distracting whitespace-only removals don't happen.

Another functional change: only treat "#" characters as a start of a macro if it's the first character or there are only whitespaces before it; this should be a pure improvement too.