### PR TITLE
CI: Don't cd into build dir when running tests

### DIFF
--- a/.github/workflows/build-llvm-nightly.yml
+++ b/.github/workflows/build-llvm-nightly.yml
@@ -38,5 +38,5 @@ jobs:
         working-directory: objdir
       - run: make -j`nproc` VERBOSE=1
         working-directory: objdir
-      - name: test
-        run: pytest objdir
+      - run: pytest
+        working-directory: objdir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,8 @@ jobs:
             ${{ matrix.env }} cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_FLAGS=${{ matrix.extra-flags }}
             make -j`nproc` VERBOSE=1
     - name: test
-      run: pytest objdir
+      run: pytest
+      working-directory: objdir
 
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This slightly improves the test coverage as it actually requires the
path juggling logic in externalprograms.py to work correctly -
instead of falling back to locate stuff in the cwd.