### PR TITLE
hints: Migrate blank pass

### DIFF
--- a/cvise/CMakeLists.txt
+++ b/cvise/CMakeLists.txt
@@ -93,6 +93,7 @@ set(SOURCE_FILES
   "tests/__init__.py"
   "tests/testabstract.py"
   "tests/test_balanced.py"
+  "tests/test_blank.py"
   "tests/test_clanghints.py"
   "tests/test_comments.py"
   "tests/test_hint.py"

--- a/cvise/tests/test_blank.py
+++ b/cvise/tests/test_blank.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import pytest
+from typing import Tuple, Union
+
+from cvise.passes.hint_based import HintState
+from cvise.passes.blank import BlankPass
+from cvise.tests.testabstract import collect_all_transforms
+
+
+@pytest.fixture
+def input_path(tmp_path: Path) -> Path:
+    return tmp_path / 'input.txt'
+
+
+def init_pass(tmp_dir: Path, input_path: Path) -> Tuple[BlankPass, Union[HintState, None]]:
+    pass_ = BlankPass()
+    state = pass_.new(input_path, tmp_dir=tmp_dir)
+    return pass_, state
+
+
+def test_empty_lines_removal(tmp_path: Path, input_path: Path):
+    input_path.write_text('\n\nabc\n\n\ndef\n\n')
+    p, state = init_pass(tmp_path, input_path)
+    all_transforms = collect_all_transforms(p, state, input_path)
+
+    assert 'abc\ndef\n' in all_transforms
+
+
+def test_whitespace_only_lines_removal(tmp_path: Path, input_path: Path):
+    input_path.write_text('   \n abc \n   \n ')
+    p, state = init_pass(tmp_path, input_path)
+    all_transforms = collect_all_transforms(p, state, input_path)
+
+    assert ' abc \n' in all_transforms
+
+
+def test_hash_lines_removal(tmp_path: Path, input_path: Path):
+    input_path.write_text('# foo\nbar#1\n')
+    p, state = init_pass(tmp_path, input_path)
+    all_transforms = collect_all_transforms(p, state, input_path)
+
+    assert 'bar#1\n' in all_transforms


### PR DESCRIPTION
Similar to other commits in the series, porting a pass to the hint-based architecture allows for better parallelization in the future.

I've ported the heuristic as-is - with both '^\s*$' and '^#' regexps, even though I'm not sure about the benefit of the second pattern. The new implementation gives them different "t", so that they're attempted independently, like the old implementation was doing.