### PR TITLE
Refactor arg passing for Pass.advance_on_success()

### DIFF
--- a/cvise/passes/abstract.py
+++ b/cvise/passes/abstract.py
@@ -101,7 +101,7 @@ class AbstractPass:
     def advance(self, test_case, state):
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'advance'!")
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'advance_on_success'!")
 
     def transform(self, test_case, state, process_event_notifier):

--- a/cvise/passes/balanced.py
+++ b/cvise/passes/balanced.py
@@ -22,7 +22,7 @@ class BalancedPass(AbstractPass):
     def advance(self, test_case, state):
         return self.__get_next_match(test_case, pos=state[0] + 1)
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return self.__get_next_match(test_case, pos=state[0])
 
     def __get_config(self):

--- a/cvise/passes/blank.py
+++ b/cvise/passes/blank.py
@@ -16,7 +16,7 @@ class BlankPass(AbstractPass):
     def advance(self, test_case, state):
         return state + 1
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return state
 
     @staticmethod

--- a/cvise/passes/clang.py
+++ b/cvise/passes/clang.py
@@ -16,7 +16,7 @@ class ClangPass(AbstractPass):
     def advance(self, test_case, state):
         return state + 1
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return state
 
     def transform(self, test_case, state, process_event_notifier):

--- a/cvise/passes/clangbinarysearch.py
+++ b/cvise/passes/clangbinarysearch.py
@@ -43,7 +43,7 @@ class ClangBinarySearchPass(AbstractPass):
     def advance(self, test_case, state):
         return state.advance()
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         instances = state.real_num_instances - state.real_chunk()
         state = state.advance_on_success(instances)
         if state:

--- a/cvise/passes/clanghints.py
+++ b/cvise/passes/clanghints.py
@@ -66,7 +66,7 @@ class ClangHintsPass(HintBasedPass):
         # Re-attach the remembered standard.
         return ClangState.wrap(new_state, state.clang_std)
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         # Keep using the same standard as the one chosen in new() - repeating the choose procedure on every successful
         # reduction would be too costly.
         hints = self.generate_hints_for_standard(test_case, state.clang_std)

--- a/cvise/passes/clex.py
+++ b/cvise/passes/clex.py
@@ -15,7 +15,7 @@ class ClexPass(AbstractPass):
     def advance(self, test_case, state):
         return state + 1
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return state
 
     def transform(self, test_case, state, process_event_notifier):

--- a/cvise/passes/comments.py
+++ b/cvise/passes/comments.py
@@ -13,7 +13,7 @@ class CommentsPass(AbstractPass):
     def advance(self, test_case, state):
         return state + 1
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return state
 
     def transform(self, test_case, state, process_event_notifier):

--- a/cvise/passes/gcdabinary.py
+++ b/cvise/passes/gcdabinary.py
@@ -42,7 +42,7 @@ class GCDABinaryPass(AbstractPass):
     def advance(self, test_case, state):
         return state.advance()
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return self.__create_state(test_case)
 
     def transform(self, test_case, state, process_event_notifier):

--- a/cvise/passes/hint_based.py
+++ b/cvise/passes/hint_based.py
@@ -135,7 +135,7 @@ class HintBasedPass(AbstractPass):
     def advance(self, test_case, state):
         return state.advance()
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         hints = self.generate_hints(test_case)
         return self.advance_on_success_from_hints(hints, state)
 

--- a/cvise/passes/ifs.py
+++ b/cvise/passes/ifs.py
@@ -48,7 +48,7 @@ class IfPass(AbstractPass):
                 state.value = 0
         return state
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return state.advance_on_success(self.__count_instances(test_case))
 
     def transform(self, test_case, state, process_event_notifier):

--- a/cvise/passes/includeincludes.py
+++ b/cvise/passes/includeincludes.py
@@ -16,7 +16,7 @@ class IncludeIncludesPass(AbstractPass):
     def advance(self, test_case, state):
         return state + 1
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return state
 
     def transform(self, test_case, state, process_event_notifier):

--- a/cvise/passes/includes.py
+++ b/cvise/passes/includes.py
@@ -16,7 +16,7 @@ class IncludesPass(AbstractPass):
     def advance(self, test_case, state):
         return state + 1
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return state
 
     def transform(self, test_case, state, process_event_notifier):

--- a/cvise/passes/indent.py
+++ b/cvise/passes/indent.py
@@ -12,7 +12,7 @@ class IndentPass(AbstractPass):
     def advance(self, test_case, state):
         return state + 1
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return state + 1
 
     def transform(self, test_case, state, process_event_notifier):

--- a/cvise/passes/ints.py
+++ b/cvise/passes/ints.py
@@ -87,7 +87,7 @@ class IntsPass(AbstractPass):
             return None
         return state
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return self.new(test_case)
 
     def transform(self, test_case, state, process_event_notifier):

--- a/cvise/passes/peep.py
+++ b/cvise/passes/peep.py
@@ -202,7 +202,7 @@ class PeepPass(AbstractPass):
 
         return new_state
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return state
 
     def transform(self, test_case, state, process_event_notifier):

--- a/cvise/passes/special.py
+++ b/cvise/passes/special.py
@@ -61,7 +61,7 @@ class SpecialPass(AbstractPass):
             return None
         return state
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return self.new(test_case)
 
     def transform(self, test_case, state, process_event_notifier):

--- a/cvise/passes/ternary.py
+++ b/cvise/passes/ternary.py
@@ -39,7 +39,7 @@ class TernaryPass(AbstractPass):
     def advance(self, test_case, state):
         return self.__get_next_match(test_case, pos=state['all'][0] + 1)
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return self.__get_next_match(test_case, pos=state['all'][0])
 
     def transform(self, test_case, state, process_event_notifier):

--- a/cvise/passes/unifdef.py
+++ b/cvise/passes/unifdef.py
@@ -17,7 +17,7 @@ class UnIfDefPass(AbstractPass):
     def advance(self, test_case, state):
         return state + 1
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return state
 
     def transform(self, test_case, state, process_event_notifier):

--- a/cvise/tests/test_test_manager.py
+++ b/cvise/tests/test_test_manager.py
@@ -24,7 +24,7 @@ class StubPass(AbstractPass):
     def advance(self, test_case, state):
         return state + 1
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return state
 
 
@@ -68,7 +68,7 @@ class NInvalidThenLinesPass(NaiveLinePass):
 class OneOffLinesPass(NaiveLinePass):
     """Removes a single line but doesn't progress further."""
 
-    def advance_on_success(self, test_case, state):
+    def advance_on_success(self, test_case, state, **kwargs):
         return None
 
 


### PR DESCRIPTION
Let all advance_on_success() methods receive arbitrary key-value arguments without needlessly mentioning them explicitly.

This is analogous to #180, and is a preparation for passing timeouts to passes which need them.