### PR TITLE
clang_delta: Use real timeout for old&new passes

### DIFF
--- a/cvise/tests/test_clanghints.py
+++ b/cvise/tests/test_clanghints.py
@@ -18,7 +18,7 @@ def get_data_path(testcase):
 def init_pass(transformation, tmp_dir, input_path):
     pass_ = ClangHintsPass(transformation, find_external_programs())
     pass_.user_clang_delta_std = None
-    state = pass_.new(input_path, tmp_dir=tmp_dir)
+    state = pass_.new(input_path, tmp_dir=tmp_dir, job_timeout=100)
     return pass_, state
 
 
@@ -60,20 +60,28 @@ def test_clang_delta_crash(tmp_path, monkeypatch):
 
     We simulate this by patching the subprocess API to return a nonzero exit code and an empty output."""
 
-    class StubPopen:
-        def __init__(self, *args, **kwargs):
-            self.stdout = iter([])
-            self.returncode = 1
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *args):
-            pass
+    def stub_run(arg, **kwargs):
+        return subprocess.CompletedProcess(arg, returncode=1, stdout='', stderr='')
 
     input_path = tmp_path / 'input.c'
     input_path.touch()
-    monkeypatch.setattr(subprocess, 'Popen', StubPopen)
+    monkeypatch.setattr(subprocess, 'run', stub_run)
+    p, state = init_pass('remove-unused-function', tmp_path, input_path)
+
+    assert state is None
+
+
+def test_clang_delta_timeout(tmp_path, monkeypatch):
+    """Test the case of clang_delta timing out.
+
+    We simulate this by patching the subprocess API to raise a timeout error."""
+
+    def stub_run(args, **kwargs):
+        raise subprocess.TimeoutExpired(args, timeout=0)
+
+    input_path = tmp_path / 'input.c'
+    input_path.touch()
+    monkeypatch.setattr(subprocess, 'run', stub_run)
     p, state = init_pass('remove-unused-function', tmp_path, input_path)
 
     assert state is None

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -622,7 +622,9 @@ class TestManager:
                 # create initial states
                 for ctx in self.pass_contexts:
                     start_time = time.monotonic()
-                    ctx.state = ctx.pass_.new(self.current_test_case, tmp_dir=ctx.temporary_root, job_timeout=self.timeout)
+                    ctx.state = ctx.pass_.new(
+                        self.current_test_case, tmp_dir=ctx.temporary_root, job_timeout=self.timeout
+                    )
                     self.pass_statistic.add_initialized(ctx.pass_, start_time)
                 self.skip = False
 
@@ -705,7 +707,9 @@ class TestManager:
 
             old_state = test_env.state if pass_id == job.pass_id else context.state
             context.state = (
-                None if old_state is None else context.pass_.advance_on_success(test_env.test_case_path, old_state, job_timeout=self.timeout)
+                None
+                if old_state is None
+                else context.pass_.advance_on_success(test_env.test_case_path, old_state, job_timeout=self.timeout)
             )
         self.pass_statistic.add_success(job.pass_)
 

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -606,7 +606,9 @@ class TestManager:
                 self.states = []
                 for pass_id, pass_ in enumerate(self.current_passes):
                     start_time = time.monotonic()
-                    self.states.append(pass_.new(self.current_test_case, tmp_dir=Path(self.roots[pass_id])))
+                    self.states.append(
+                        pass_.new(self.current_test_case, tmp_dir=Path(self.roots[pass_id]), job_timeout=self.timeout)
+                    )
                     self.pass_statistic.add_initialized(pass_, start_time)
                 self.skip = False
 
@@ -688,7 +690,9 @@ class TestManager:
             # for other passes, continue the iteration from where the last advance() stopped.
             old_state = test_env.state if pass_id == job.pass_id else self.states[pass_id]
             self.states[pass_id] = (
-                None if old_state is None else pass_.advance_on_success(test_env.test_case_path, old_state)
+                None
+                if old_state is None
+                else pass_.advance_on_success(test_env.test_case_path, old_state, job_timeout=self.timeout)
             )
         self.pass_statistic.add_success(job.pass_)
 


### PR DESCRIPTION
The old ClangBinarySearchPass class used to hardcode the 10-second timeout, which was insufficient for big inputs and led to a significant slowdown of the reduction as this heuristic didn't work at all. The new ClangHintsPass didn't have the timeout logic at all, which would result in hanging C-Vise if building Clang AST hangs.

Fix both places to use the --timeout command-line parameter value.