### PR TITLE
hints: Fix type annotations

### DIFF
--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -154,12 +154,12 @@ def group_hints_by_type(bundle: HintBundle) -> Dict[str, HintBundle]:
     return grouped
 
 
-def write_compact_json(value: Any, file: TextIO) -> str:
+def write_compact_json(value: Any, file: TextIO) -> None:
     """Writes a JSON dump, as a compact representation (without unnecessary spaces), to the file.
 
     Skips circular structure checks, for performance reasons."""
     # Specify custom separators - the default ones have spaces after them.
-    return json.dump(value, file, check_circular=False, separators=(',', ':'))
+    json.dump(value, file, check_circular=False, separators=(',', ':'))
 
 
 def try_parse_json_line(text: str) -> Any:


### PR DESCRIPTION
Fix some trivial violations. Also fix HintState to not store empty per-type substates - to make the type linters happy but also to have a better preconditions in the code.

Found using a manual execution of Mypy (a TODO would be to properly integrate it into CI).