### PR TITLE
test_manager: Know whether pass category is interleaving

### DIFF
--- a/cvise/cvise.py
+++ b/cvise/cvise.py
@@ -236,13 +236,13 @@ class CVise:
             return False
 
         if interleaving:
-            self.test_manager.run_passes(available_passes)
+            self.test_manager.run_passes(available_passes, interleaving)
         else:
             for p in available_passes:
                 # Exit early if we're already reduced enough
                 if check_threshold and self._met_stopping_threshold():
                     return True
-                self.test_manager.run_passes([p])
+                self.test_manager.run_passes([p], interleaving)
         return check_threshold and self._met_stopping_threshold()
 
     def _met_stopping_threshold(self) -> bool:

--- a/cvise/tests/test_test_manager.py
+++ b/cvise/tests/test_test_manager.py
@@ -205,7 +205,7 @@ def manager(tmp_path, input_file, interestingness_script):
 def test_succeed_via_naive_pass(input_file, manager):
     """Check that we completely empty the file via the naive lines pass."""
     p = NaiveLinePass()
-    manager.run_passes([p])
+    manager.run_passes([p], interleaving=False)
     assert read_file(input_file) == ''
     assert bug_dir_count() == 0
 
@@ -216,7 +216,7 @@ def test_succeed_via_n_one_off_passes(input_file, manager):
     for lines in range(LINES, 0, -1):
         assert count_lines(input_file) == lines
         p = OneOffLinesPass()
-        manager.run_passes([p])
+        manager.run_passes([p], interleaving=False)
         assert count_lines(input_file) == lines - 1
     assert bug_dir_count() == 0
 
@@ -225,7 +225,7 @@ def test_succeed_after_n_invalid_results(input_file, manager):
     """Check that we still succeed even if the first few invocations were unsuccessful."""
     INVALID_N = 15
     p = NInvalidThenLinesPass(INVALID_N)
-    manager.run_passes([p])
+    manager.run_passes([p], interleaving=False)
     assert read_file(input_file) == ''
     assert bug_dir_count() == 0
 
@@ -234,7 +234,7 @@ def test_succeed_after_n_invalid_results(input_file, manager):
 def test_give_up_on_stuck_pass(input_file, manager):
     """Check that we quit if the pass doesn't improve for a long time."""
     p = AlwaysInvalidPass()
-    manager.run_passes([p])
+    manager.run_passes([p], interleaving=False)
     assert read_file(input_file) == INPUT_DATA
     # The "pass got stuck" report.
     assert bug_dir_count() == 1
@@ -243,7 +243,7 @@ def test_give_up_on_stuck_pass(input_file, manager):
 def test_halt_on_unaltered(input_file, manager):
     """Check that we quit if the pass keeps misbehaving."""
     p = AlwaysUnalteredPass()
-    manager.run_passes([p])
+    manager.run_passes([p], interleaving=False)
     assert read_file(input_file) == INPUT_DATA
     # This number of "failed to modify the variant" reports were to be created.
     assert bug_dir_count() == testing.TestManager.MAX_CRASH_DIRS + 1
@@ -252,7 +252,7 @@ def test_halt_on_unaltered(input_file, manager):
 def test_halt_on_unaltered_after_stop(input_file, manager):
     """Check that we quit after the pass' stop, even if it interleaved with a misbehave."""
     p = SlowUnalteredThenStoppingPass()
-    manager.run_passes([p])
+    manager.run_passes([p], interleaving=False)
     assert read_file(input_file) == INPUT_DATA
     # Whether the misbehave ("failed to modify the variant") is detected depends on timing.
     assert bug_dir_count() <= 1
@@ -264,7 +264,7 @@ def test_interleaving_letter_removals(input_file, manager):
     p2 = LetterRemovingPass('b')
     while True:
         value_before = read_file(input_file)
-        manager.run_passes([p1, p2])
+        manager.run_passes([p1, p2], interleaving=True)
         if read_file(input_file) == value_before:
             break
 
@@ -284,7 +284,7 @@ def test_interleaving_letter_removals_large(input_file, manager):
     p3 = LetterRemovingPass('c')
     while True:
         value_before = read_file(input_file)
-        manager.run_passes([p1, p2, p3])
+        manager.run_passes([p1, p2, p3], interleaving=True)
         if read_file(input_file) == value_before:
             break
 

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -601,6 +601,8 @@ class TestManager:
                 raise
 
     def run_passes(self, passes: List[AbstractPass], interleaving: bool):
+        assert len(passes) == 1 or interleaving
+
         if self.start_with_pass:
             current_pass_names = [str(c.pass_) for c in self.pass_contexts]
             if self.start_with_pass in current_pass_names:

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -255,6 +255,7 @@ class TestManager:
         self.orig_total_file_size = self.total_file_size
         self.cache = {}
         self.pass_contexts: List[PassContext] = []
+        self.interleaving: bool = False
         if not self.is_valid_test(self.test_script):
             raise InvalidInterestingnessTestError(self.test_script)
         self.jobs: List[Job] = []
@@ -599,7 +600,7 @@ class TestManager:
                 self.terminate_all(pool)
                 raise
 
-    def run_passes(self, passes):
+    def run_passes(self, passes: List[AbstractPass], interleaving: bool):
         if self.start_with_pass:
             current_pass_names = [str(c.pass_) for c in self.pass_contexts]
             if self.start_with_pass in current_pass_names:
@@ -610,6 +611,7 @@ class TestManager:
         self.pass_contexts = []
         for pass_ in passes:
             self.pass_contexts.append(PassContext.create(pass_))
+        self.interleaving = interleaving
         self.jobs = []
         m = Manager()
         self.pid_queue = m.Queue()
@@ -678,7 +680,8 @@ class TestManager:
 
                     # skip after N transformations if requested
                     skip_rest = self.skip_after_n_transforms and success_count >= self.skip_after_n_transforms
-                    if len(self.pass_contexts) == 1:  # max-transforms is only supported for non-interleaving passes
+                    if not self.interleaving:  # max-transforms is only supported for non-interleaving passes
+                        assert len(self.pass_contexts) == 1
                         if (
                             self.pass_contexts[0].pass_.max_transforms
                             and success_count >= self.pass_contexts[0].pass_.max_transforms


### PR DESCRIPTION
Receive an explicit flag telling whether we're executing an "interleaving" set of passes from the config. Previously, the code was checking "is there more than one pass", which isn't exactly the same.

This will start making difference once we introduce more interleaving-specific features, namely the folding (merging of concurrently discovered reductions).