### PR TITLE
Support non UTF-8 inputs

### DIFF
--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -476,43 +476,47 @@ def do_reduce(args):
         print(err)
     else:
         time_stop = time.monotonic()
-        with open(args.log_file, 'a') if args.log_file else nullcontext(sys.stderr) as fs:
-            fs.write('===< PASS statistics >===\n')
+        with open(args.log_file, 'ab') if args.log_file else nullcontext(sys.stderr.buffer) as fs:
+            fs.write(b'===< PASS statistics >===\n')
             fs.write(
-                '  %-60s %8s %8s %8s %8s %15s\n'
-                % (
-                    'pass name',
-                    'time (s)',
-                    'time (%)',
-                    'worked',
-                    'failed',
-                    'total executed',
-                )
+                (
+                    '  %-60s %8s %8s %8s %8s %15s\n'
+                    % (
+                        'pass name',
+                        'time (s)',
+                        'time (%)',
+                        'worked',
+                        'failed',
+                        'total executed',
+                    )
+                ).encode()
             )
 
             for pass_name, pass_data in pass_statistic.sorted_results:
                 fs.write(
-                    '  %-60s %8.2f %8.2f %8d %8d %15d\n'
-                    % (
-                        pass_name,
-                        pass_data.total_seconds,
-                        100.0 * pass_data.total_seconds / (time_stop - time_start),
-                        pass_data.worked,
-                        pass_data.failed,
-                        pass_data.totally_executed,
-                    )
+                    (
+                        '  %-60s %8.2f %8.2f %8d %8d %15d\n'
+                        % (
+                            pass_name,
+                            pass_data.total_seconds,
+                            100.0 * pass_data.total_seconds / (time_stop - time_start),
+                            pass_data.worked,
+                            pass_data.failed,
+                            pass_data.totally_executed,
+                        )
+                    ).encode()
                 )
-            fs.write('\n')
+            fs.write(b'\n')
 
             if not args.no_timing:
-                fs.write(f'Runtime: {round(time_stop - time_start)} seconds\n')
+                fs.write(f'Runtime: {round(time_stop - time_start)} seconds\n'.encode())
 
-            fs.write('Reduced test-cases:\n\n')
+            fs.write(b'Reduced test-cases:\n\n')
             for test_case in sorted(test_manager.test_cases):
-                if misc.is_readable_file(test_case):
-                    print(f'--- {test_case} ---')
-                    with open(test_case) as test_case_file:
-                        fs.write(test_case_file.read() + '\n')
+                print(f'--- {test_case} ---'.encode())
+                with open(test_case, 'rb') as test_case_file:
+                    fs.write(test_case_file.read())
+                    fs.write(b'\n')
             if script:
                 os.unlink(script.name)
 
@@ -530,7 +534,7 @@ def do_apply_hints(args):
         sys.exit('exactly one TEST_CASE must be supplied')
     bundle = load_hints(Path(args.hints_file), args.hint_begin_index, args.hint_end_index)
     new_data = apply_hints([bundle], Path(args.test_cases[0]))
-    print(new_data, end='')  # avoid adding an extra newline
+    sys.stdout.buffer.write(new_data)
 
 
 if __name__ == '__main__':

--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -23,7 +23,7 @@ if importlib.util.find_spec('cvise') is None:
 import chardet  # noqa: E402
 from cvise.cvise import CVise  # noqa: E402
 from cvise.passes.abstract import AbstractPass  # noqa: E402
-from cvise.utils import misc, statistics, testing  # noqa: E402
+from cvise.utils import statistics, testing  # noqa: E402
 from cvise.utils.error import CViseError  # noqa: E402
 from cvise.utils.error import MissingPassGroupsError  # noqa: E402
 from cvise.utils.externalprograms import find_external_programs  # noqa: E402

--- a/cvise/passes/blank.py
+++ b/cvise/passes/blank.py
@@ -6,8 +6,8 @@ from cvise.utils.hint import HintBundle
 
 class BlankPass(HintBasedPass):
     PATTERNS = {
-        'blankline': r'^\s*$',
-        'hashline': r'^#',
+        'blankline': rb'^\s*$',
+        'hashline': rb'^#',
     }
 
     def check_prerequisites(self):
@@ -15,7 +15,7 @@ class BlankPass(HintBasedPass):
 
     def generate_hints(self, test_case):
         hints = []
-        with open(test_case) as in_file:
+        with open(test_case, 'rb') as in_file:
             file_pos = 0
             for line in in_file.readlines():
                 end_pos = file_pos + len(line)

--- a/cvise/passes/comments.py
+++ b/cvise/passes/comments.py
@@ -9,7 +9,7 @@ class CommentsPass(HintBasedPass):
         return True
 
     def generate_hints(self, test_case):
-        with open(test_case) as in_file:
+        with open(test_case, 'rb') as in_file:
             prog = in_file.read()
 
         hints = []
@@ -18,11 +18,11 @@ class CommentsPass(HintBasedPass):
         # * first - "/*",
         # * then - any number of "*" that aren't followed by "/", or of any other characters;
         # * finally - "*/".
-        for m in re.finditer(r'/\*(?:\*(?!/)|[^*])*\*/', prog, flags=re.DOTALL):
+        for m in re.finditer(rb'/\*(?:\*(?!/)|[^*])*\*/', prog, flags=re.DOTALL):
             hints.append({'t': 0, 'p': [{'l': m.start(), 'r': m.end()}]})
 
         # Remove all single-line comments.
-        for m in re.finditer(r'//.*$', prog, flags=re.MULTILINE):
+        for m in re.finditer(rb'//.*$', prog, flags=re.MULTILINE):
             hints.append({'t': 1, 'p': [{'l': m.start(), 'r': m.end()}]})
 
         # The order must match the 't' indices above.

--- a/cvise/passes/hint_based.py
+++ b/cvise/passes/hint_based.py
@@ -147,7 +147,7 @@ class HintBasedPass(AbstractPass):
         hints_range_end = sub_state.binary_state.end()
         bundle = load_hints(state.tmp_dir / sub_state.hints_file_name, hints_range_begin, hints_range_end)
         new_data = apply_hints([bundle], Path(test_case))
-        Path(test_case).write_text(new_data)
+        Path(test_case).write_bytes(new_data)
         return (PassResult.OK, state)
 
     def advance(self, test_case, state):

--- a/cvise/passes/line_markers.py
+++ b/cvise/passes/line_markers.py
@@ -22,14 +22,14 @@ class LineMarkersPass(HintBasedPass):
     system header) and cannot be removed. Also the pass implementation, being a simple regexp, can have false positives.
     """
 
-    line_regex = re.compile('^\\s*#\\s*[0-9]+')
+    line_regex = re.compile(b'^\\s*#\\s*[0-9]+')
 
     def check_prerequisites(self):
         return True
 
     def generate_hints(self, test_case):
         hints = []
-        with open(test_case) as in_file:
+        with open(test_case, 'rb') as in_file:
             file_pos = 0
             for line in in_file.readlines():
                 end_pos = file_pos + len(line)

--- a/cvise/passes/lines.py
+++ b/cvise/passes/lines.py
@@ -19,7 +19,7 @@ class LinesPass(HintBasedPass):
     def generate_hints_for_text_lines(self, test_case: str) -> HintBundle:
         """Generate a hint per each line in the input as written."""
         hints = []
-        with open(test_case) as in_file:
+        with open(test_case, 'rb') as in_file:
             file_pos = 0
             for line in in_file:
                 end_pos = file_pos + len(line)
@@ -34,8 +34,8 @@ class LinesPass(HintBasedPass):
         nesting level specified by the arg integer."""
         hints = []
         cmd = [self.external_programs['topformflat_hints'], self.arg]
-        with open(test_case) as in_file:
-            with subprocess.Popen(cmd, stdin=in_file, stdout=subprocess.PIPE, text=True) as proc:
+        with open(test_case, 'rb') as in_file:
+            with subprocess.Popen(cmd, stdin=in_file, stdout=subprocess.PIPE) as proc:
                 for line in proc.stdout:
                     if not line.isspace():
                         hints.append(json.loads(line))

--- a/cvise/tests/test_blank.py
+++ b/cvise/tests/test_blank.py
@@ -24,7 +24,7 @@ def test_empty_lines_removal(tmp_path: Path, input_path: Path):
     p, state = init_pass(tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
 
-    assert 'abc\ndef\n' in all_transforms
+    assert b'abc\ndef\n' in all_transforms
 
 
 def test_whitespace_only_lines_removal(tmp_path: Path, input_path: Path):
@@ -32,7 +32,7 @@ def test_whitespace_only_lines_removal(tmp_path: Path, input_path: Path):
     p, state = init_pass(tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
 
-    assert ' abc \n' in all_transforms
+    assert b' abc \n' in all_transforms
 
 
 def test_hash_lines_removal(tmp_path: Path, input_path: Path):
@@ -40,7 +40,7 @@ def test_hash_lines_removal(tmp_path: Path, input_path: Path):
     p, state = init_pass(tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
 
-    assert 'bar#1\n' in all_transforms
+    assert b'bar#1\n' in all_transforms
 
 
 def test_no_different_type_removals(tmp_path: Path, input_path: Path):
@@ -53,6 +53,26 @@ def test_no_different_type_removals(tmp_path: Path, input_path: Path):
     p, state = init_pass(tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
 
-    assert '#x\n#y\nz\n' in all_transforms  # removal of empty lines
-    assert '\nz\n' in all_transforms  # removal of hash-lines
-    assert 'z\n' not in all_transforms  # no removal of both
+    assert b'#x\n#y\nz\n' in all_transforms  # removal of empty lines
+    assert b'\nz\n' in all_transforms  # removal of hash-lines
+    assert b'z\n' not in all_transforms  # no removal of both
+
+
+def test_non_utf8(tmp_path, input_path):
+    input_path.write_bytes(
+        b"""
+        // \xff
+
+        // \xee
+        """,
+    )
+    p, state = init_pass(tmp_path, input_path)
+    all_transforms = collect_all_transforms(p, state, input_path)
+
+    assert (
+        b"""
+        // \xff
+        // \xee
+        """
+        in all_transforms
+    )

--- a/cvise/tests/test_clanghints.py
+++ b/cvise/tests/test_clanghints.py
@@ -29,7 +29,7 @@ def test_class(tmp_path):
     all_transforms = collect_all_transforms(p, state, input_path)
 
     expected_path = get_data_path('remove-unused-function/class.output')
-    assert expected_path.read_text() in all_transforms
+    assert expected_path.read_bytes() in all_transforms
 
 
 def test_const(tmp_path):
@@ -37,8 +37,8 @@ def test_const(tmp_path):
     p, state = init_pass('remove-unused-function', tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
 
-    assert get_data_path('remove-unused-function/const.output').read_text() in all_transforms
-    assert get_data_path('remove-unused-function/const.output2').read_text() in all_transforms
+    assert get_data_path('remove-unused-function/const.output').read_bytes() in all_transforms
+    assert get_data_path('remove-unused-function/const.output2').read_bytes() in all_transforms
 
 
 def test_inline_ns(tmp_path):

--- a/cvise/tests/test_line_markers.py
+++ b/cvise/tests/test_line_markers.py
@@ -40,6 +40,24 @@ def test_all_iteration(tmp_path, input_path):
 
     all_transforms = collect_all_transforms(pass_, state, input_path)
 
-    assert "# 2 'bar.h'\nint x = 2;\n# 4 'x.h'" in all_transforms
-    assert "# 1 'foo.h'\nint x = 2;\n# 4 'x.h'" in all_transforms
-    assert "# 1 'foo.h'\n# 2 'bar.h'\nint x = 2;\n" in all_transforms
+    assert b"# 2 'bar.h'\nint x = 2;\n# 4 'x.h'" in all_transforms
+    assert b"# 1 'foo.h'\nint x = 2;\n# 4 'x.h'" in all_transforms
+    assert b"# 1 'foo.h'\n# 2 'bar.h'\nint x = 2;\n" in all_transforms
+
+
+def test_non_ascii(tmp_path, input_path):
+    input_path.write_bytes(
+        b"""
+        # 1 "Streichholzsch\xc3\xa4chtelchen.h";
+        char t[] = "nonutf\xff";
+        """,
+    )
+    pass_, state = init_pass(tmp_path, input_path)
+    (_, state) = pass_.transform(input_path, state, None)
+
+    assert (
+        input_path.read_bytes()
+        == b"""
+        char t[] = "nonutf\xff";
+        """
+    )

--- a/cvise/tests/test_lines.py
+++ b/cvise/tests/test_lines.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import pytest
 
 from cvise.passes.lines import LinesPass

--- a/cvise/tests/test_lines.py
+++ b/cvise/tests/test_lines.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import pytest
 
 from cvise.passes.lines import LinesPass
@@ -17,33 +18,23 @@ def init_pass(depth, tmp_dir, input_path):
     return pass_, state
 
 
-def read_file(path):
-    with open(path) as f:
-        return f.read()
-
-
-def write_file(path, data):
-    with open(path, 'w') as f:
-        f.write(data)
-
-
 def advance_until(pass_, state, input_path, predicate):
-    backup = read_file(input_path)
+    backup = input_path.read_bytes()
     while True:
         pass_.transform(input_path, state, process_event_notifier=None)
-        if predicate(read_file(input_path)):
+        if predicate(input_path.read_bytes()):
             return state
-        write_file(input_path, backup)
+        input_path.write_bytes(backup)
         state = pass_.advance(input_path, state)
         assert state is not None
 
 
-def is_valid_brace_sequence(s):
+def is_valid_brace_sequence(s: bytes) -> bool:
     balance = 0
     for c in s:
-        if c == '{':
+        if c == ord('{'):
             balance += 1
-        elif c == '}':
+        elif c == ord('}'):
             balance -= 1
         if balance < 0:
             return False
@@ -52,8 +43,7 @@ def is_valid_brace_sequence(s):
 
 def test_func_namespace_level0(tmp_path, input_path):
     """Test that arg=0 deletes top-level functions and namespaces."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """
         int f() {
           char x;
@@ -67,7 +57,7 @@ def test_func_namespace_level0(tmp_path, input_path):
 
     # removal of the namespace
     assert (
-        """
+        b"""
         int f() {
           char x;
         }
@@ -76,7 +66,7 @@ def test_func_namespace_level0(tmp_path, input_path):
     )
     # removal of f()
     assert (
-        """
+        b"""
         namespace foo {
         }
         """
@@ -89,8 +79,7 @@ def test_func_namespace_level0(tmp_path, input_path):
 
 def test_func_namespace_level1(tmp_path, input_path):
     """Test that arg=1 deletes code inside top-level functions and namespaces."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """
         int f() {
           char x;
@@ -106,7 +95,7 @@ def test_func_namespace_level1(tmp_path, input_path):
 
     # removal of code inside f()
     assert (
-        """
+        b"""
         int f() {
         }
         namespace foo {
@@ -118,7 +107,7 @@ def test_func_namespace_level1(tmp_path, input_path):
     )
     # removal of code inside foo
     assert (
-        """
+        b"""
         int f() {
           char x;
         }
@@ -129,7 +118,7 @@ def test_func_namespace_level1(tmp_path, input_path):
     )
     # removal of both
     assert (
-        """
+        b"""
         int f() {
         }
         namespace foo {
@@ -144,8 +133,7 @@ def test_func_namespace_level1(tmp_path, input_path):
 
 def test_multiline_func_signature_level0(tmp_path, input_path):
     """Test that arg=0 deletes a top-level function despite line breaks in the signature."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """
         template <class T>
         SomeVeryLongType
@@ -156,15 +144,14 @@ def test_multiline_func_signature_level0(tmp_path, input_path):
     p, state = init_pass('0', tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
 
-    assert '' in all_transforms
+    assert b'' in all_transforms
     # no attempts to partially remove the function
     assert len(all_transforms) == 1
 
 
 def test_multiline_func_signature_level1(tmp_path, input_path):
     """Test that arg=1 deletes a nested function despite line breaks in the signature."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """
         namespace {
           template <class T>
@@ -179,7 +166,7 @@ def test_multiline_func_signature_level1(tmp_path, input_path):
     all_transforms = collect_all_transforms(p, state, input_path)
 
     assert (
-        """
+        b"""
         namespace {
         }
         """
@@ -191,8 +178,7 @@ def test_multiline_func_signature_level1(tmp_path, input_path):
 
 def test_class_with_methods_level0(tmp_path, input_path):
     """Test that arg=0 deletes the whole class definition."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """
         class A {
           void f() {
@@ -207,14 +193,13 @@ def test_class_with_methods_level0(tmp_path, input_path):
     p, state = init_pass('0', tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
 
-    assert '' in all_transforms
+    assert b'' in all_transforms
     assert len(all_transforms) == 1
 
 
 def test_class_with_methods_level1(tmp_path, input_path):
     """Test that arg=1 deletes class methods."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """
         class A {
           void f() {
@@ -232,7 +217,7 @@ def test_class_with_methods_level1(tmp_path, input_path):
 
     # f() deleted
     assert (
-        """
+        b"""
         class A {
           int g() {
             return 42;
@@ -243,7 +228,7 @@ def test_class_with_methods_level1(tmp_path, input_path):
     )
     # g() deleted
     assert (
-        """
+        b"""
         class A {
           void f() {
             int first;
@@ -255,7 +240,7 @@ def test_class_with_methods_level1(tmp_path, input_path):
     )
     # both f() and g() deleted
     assert (
-        """
+        b"""
         class A {
         };
         """
@@ -268,8 +253,7 @@ def test_class_with_methods_level1(tmp_path, input_path):
 
 def test_class_with_methods_level2(tmp_path, input_path):
     """Test that arg=2 deletes statements in class methods."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """
         class A {
           void f() {
@@ -287,7 +271,7 @@ def test_class_with_methods_level2(tmp_path, input_path):
 
     # the first statement in f() deleted
     assert (
-        """
+        b"""
         class A {
           void f() {
             int second;
@@ -301,7 +285,7 @@ def test_class_with_methods_level2(tmp_path, input_path):
     )
     # the second statement in f() deleted
     assert (
-        """
+        b"""
         class A {
           void f() {
             int first;
@@ -315,7 +299,7 @@ def test_class_with_methods_level2(tmp_path, input_path):
     )
     # the statement in g() deleted
     assert (
-        """
+        b"""
         class A {
           void f() {
             int first;
@@ -329,7 +313,7 @@ def test_class_with_methods_level2(tmp_path, input_path):
     )
     # all statements in f() and g() deleted
     assert (
-        """
+        b"""
         class A {
           void f() {
           }
@@ -346,8 +330,7 @@ def test_class_with_methods_level2(tmp_path, input_path):
 
 def test_c_comment(tmp_path, input_path):
     """Test that a C comment is deleted as a whole."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """
         int x; /*
           some
@@ -360,13 +343,13 @@ def test_c_comment(tmp_path, input_path):
     all_transforms = collect_all_transforms(p, state, input_path)
 
     assert (
-        """
+        b"""
         int x;
         """
         in all_transforms
     )
     assert (
-        """ /*
+        b""" /*
           some
           comment
           */
@@ -376,13 +359,12 @@ def test_c_comment(tmp_path, input_path):
     )
     # no attempts to partially remove the comment
     for s in all_transforms:
-        assert ('/*' in s) == ('some' in s) == ('comment' in s) == ('*/' in s)
+        assert (b'/*' in s) == (b'some' in s) == (b'comment' in s) == (b'*/' in s)
 
 
 def test_cpp_comment(tmp_path, input_path):
     """Test that a C++ comment is deleted as a whole."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """
         int x; // some comment
         int y;""",
@@ -392,23 +374,22 @@ def test_cpp_comment(tmp_path, input_path):
 
     # no attempts to partially remove the comment
     assert (
-        """
+        b"""
         int x;"""
         in all_transforms
     )
     assert (
-        """ // some comment
+        b""" // some comment
         int y;"""
         in all_transforms
     )
-    assert '' in all_transforms
+    assert b'' in all_transforms
     assert len(all_transforms) == 3
 
 
 def test_eof_with_non_recognized_chunk_end(tmp_path, input_path):
     """Test the file terminating with a text that wouldn't be recognized as chunk end."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """
         #define FOO }
         FOO
@@ -419,7 +400,7 @@ def test_eof_with_non_recognized_chunk_end(tmp_path, input_path):
 
     # FOO was attempted to be deleted
     assert (
-        """
+        b"""
         #define FOO }
 """
         in all_transforms
@@ -428,8 +409,7 @@ def test_eof_with_non_recognized_chunk_end(tmp_path, input_path):
 
 def test_macro_level0(tmp_path, input_path):
     """Test removal of preprocessor macros with arg=0."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """#ifndef FOO
         #define FOO
         int x;
@@ -444,7 +424,7 @@ def test_macro_level0(tmp_path, input_path):
 
     # "#ifndef FOO" deleted
     assert (
-        """
+        b"""
         #define FOO
         int x;
         FOO
@@ -456,7 +436,7 @@ def test_macro_level0(tmp_path, input_path):
     )
     # "#define FOO" deleted
     assert (
-        """#ifndef FOO
+        b"""#ifndef FOO
         int x;
         FOO
         #define BAR \\
@@ -467,7 +447,7 @@ def test_macro_level0(tmp_path, input_path):
     )
     # "int x" deleted
     assert (
-        """#ifndef FOO
+        b"""#ifndef FOO
         #define FOO
 
         FOO
@@ -479,7 +459,7 @@ def test_macro_level0(tmp_path, input_path):
     )
     # FOO usage deleted
     assert (
-        """#ifndef FOO
+        b"""#ifndef FOO
         #define FOO
         int x;
         #define BAR \\
@@ -490,7 +470,7 @@ def test_macro_level0(tmp_path, input_path):
     )
     # "#define BAR" deleted
     assert (
-        """#ifndef FOO
+        b"""#ifndef FOO
         #define FOO
         int x;
         FOO
@@ -500,7 +480,7 @@ def test_macro_level0(tmp_path, input_path):
     )
     # "int y" deleted
     assert (
-        """#ifndef FOO
+        b"""#ifndef FOO
         #define FOO
         int x;
         FOO
@@ -514,8 +494,7 @@ def test_macro_level0(tmp_path, input_path):
 
 def test_nested_macro_level0(tmp_path, input_path):
     """Test removal of preprocessor macros, placed inside a curly brace block, with arg=0."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """
         class A {
         #define AFIELD foo
@@ -527,14 +506,13 @@ def test_nested_macro_level0(tmp_path, input_path):
     all_transforms = collect_all_transforms(p, state, input_path)
 
     # The macro is removed together with the outer block.
-    assert '' in all_transforms
+    assert b'' in all_transforms
     assert len(all_transforms) == 1
 
 
 def test_nested_macro_level1(tmp_path, input_path):
     """Test removal of preprocessor macros, placed inside a curly brace block, with arg=1."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """
         class A {
         #define AFIELD foo
@@ -548,7 +526,7 @@ def test_nested_macro_level1(tmp_path, input_path):
 
     # "#define AFIELD" deleted
     assert (
-        """
+        b"""
         class A {
           AFIELD
         #undef AFIELD
@@ -558,7 +536,7 @@ def test_nested_macro_level1(tmp_path, input_path):
     )
     # AFIELD usage deleted
     assert (
-        """
+        b"""
         class A {
         #define AFIELD foo
 
@@ -569,7 +547,7 @@ def test_nested_macro_level1(tmp_path, input_path):
     )
     # "#undef AFIELD" deleted
     assert (
-        """
+        b"""
         class A {
         #define AFIELD foo
           AFIELD
@@ -581,8 +559,7 @@ def test_nested_macro_level1(tmp_path, input_path):
 
 def test_hash_character_not_macro_start(tmp_path, input_path):
     """Test hash characters aren't mistakenly treated as macro/block start."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """
         #define STR(x)  #x
         #define FOO(a,b)  a ## b
@@ -594,7 +571,7 @@ def test_hash_character_not_macro_start(tmp_path, input_path):
 
     # "#define STR" removed
     assert (
-        """
+        b"""
         #define FOO(a,b)  a ## b
         char s[] = "#1";
         """
@@ -602,7 +579,7 @@ def test_hash_character_not_macro_start(tmp_path, input_path):
     )
     # "#define FOO" removed
     assert (
-        """
+        b"""
         #define STR(x)  #x
         char s[] = "#1";
         """
@@ -610,7 +587,7 @@ def test_hash_character_not_macro_start(tmp_path, input_path):
     )
     # "char s" removed
     assert (
-        """
+        b"""
         #define STR(x)  #x
         #define FOO(a,b)  a ## b
 
@@ -623,8 +600,7 @@ def test_transform_deletes_lines_range(tmp_path, input_path):
     """Test various combinations of line deletion are attempted.
 
     This verifies the code performs the binary search or some similar strategy."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """
         A;
         B;
@@ -641,7 +617,7 @@ def test_transform_deletes_lines_range(tmp_path, input_path):
 
     # deletion of a half:
     assert (
-        """
+        b"""
         A;
         B;
         C;
@@ -650,7 +626,7 @@ def test_transform_deletes_lines_range(tmp_path, input_path):
         in all_transforms
     )
     assert (
-        """
+        b"""
         E;
         F;
         G;
@@ -660,7 +636,7 @@ def test_transform_deletes_lines_range(tmp_path, input_path):
     )
     # deletion of a quarter:
     assert (
-        """
+        b"""
         C;
         D;
         E;
@@ -671,7 +647,7 @@ def test_transform_deletes_lines_range(tmp_path, input_path):
         in all_transforms
     )
     assert (
-        """
+        b"""
         A;
         B;
         E;
@@ -682,7 +658,7 @@ def test_transform_deletes_lines_range(tmp_path, input_path):
         in all_transforms
     )
     assert (
-        """
+        b"""
         A;
         B;
         C;
@@ -693,7 +669,7 @@ def test_transform_deletes_lines_range(tmp_path, input_path):
         in all_transforms
     )
     assert (
-        """
+        b"""
         A;
         B;
         C;
@@ -707,8 +683,7 @@ def test_transform_deletes_lines_range(tmp_path, input_path):
 
 def test_advance_on_success(tmp_path, input_path):
     """Test the scenario where successful advancements are interleaved with unsuccessful transforms."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """
         foo;
         bar;
@@ -718,16 +693,16 @@ def test_advance_on_success(tmp_path, input_path):
     p, state = init_pass('0', tmp_path, input_path)
     # Cut 'foo' first, pretending that all previous transforms (e.g., deletion of the whole text) didn't pass the
     # interestingness test.
-    state = advance_until(p, state, input_path, lambda s: 'bar' in s and 'baz' in s)
+    state = advance_until(p, state, input_path, lambda s: b'bar' in s and b'baz' in s)
     p.advance_on_success(input_path, state)
     # Cut 'baz' now, pretending that all transforms in between (e.g, deletion of "bar;") didn't pass the
     # interestingness test.
-    state = advance_until(p, state, input_path, lambda s: 'bar' in s)
+    state = advance_until(p, state, input_path, lambda s: b'bar' in s)
     p.advance_on_success(input_path, state)
 
     assert (
-        read_file(input_path)
-        == """
+        input_path.read_bytes()
+        == b"""
         bar;
         """
     )
@@ -735,8 +710,7 @@ def test_advance_on_success(tmp_path, input_path):
 
 def test_arg_none(tmp_path, input_path):
     """Test that arg=None deletes individual lines as-is."""
-    write_file(
-        input_path,
+    input_path.write_text(
         """
         int f() {
         }
@@ -748,7 +722,7 @@ def test_arg_none(tmp_path, input_path):
     all_transforms = collect_all_transforms(p, state, input_path)
 
     assert (
-        """
+        b"""
         }
 
         int x = 1;
@@ -756,7 +730,7 @@ def test_arg_none(tmp_path, input_path):
         in all_transforms
     )
     assert (
-        """
+        b"""
         int f() {
 
         int x = 1;
@@ -764,7 +738,7 @@ def test_arg_none(tmp_path, input_path):
         in all_transforms
     )
     assert (
-        """
+        b"""
         int f() {
         }
         int x = 1;
@@ -772,10 +746,35 @@ def test_arg_none(tmp_path, input_path):
         in all_transforms
     )
     assert (
-        """
+        b"""
         int f() {
         }
 
+        """
+        in all_transforms
+    )
+
+
+@pytest.mark.parametrize('pass_arg', [0, 'None'])
+def test_non_ascii(tmp_path, input_path, pass_arg):
+    input_path.write_bytes(
+        b"""
+        char *s = "Streichholzsch\xc3\xa4chtelchen";
+        char t[] = "nonutf\xff";
+        """,
+    )
+    p, state = init_pass(str(pass_arg), tmp_path, input_path)
+    all_transforms = collect_all_transforms(p, state, input_path)
+
+    assert (
+        b"""
+        char *s = "Streichholzsch\xc3\xa4chtelchen";
+        """
+        in all_transforms
+    )
+    assert (
+        b"""
+        char t[] = "nonutf\xff";
         """
         in all_transforms
     )

--- a/cvise/tests/testabstract.py
+++ b/cvise/tests/testabstract.py
@@ -1,6 +1,6 @@
 import jsonschema
 from pathlib import Path
-from typing import Union
+from typing import Sequence, Union
 
 from cvise.passes.abstract import AbstractPass, PassResult, ProcessEventNotifier
 from cvise.passes.hint_based import HintState
@@ -17,13 +17,13 @@ def iterate_pass(current_pass, path, **kwargs):
             state = current_pass.advance(path, state)
 
 
-def collect_all_transforms(pass_: AbstractPass, state, input_path: Path):
+def collect_all_transforms(pass_: AbstractPass, state, input_path: Path) -> Sequence[bytes]:
     all_outputs = set()
-    backup = input_path.read_text()
+    backup = input_path.read_bytes()
     while state is not None:
         pass_.transform(input_path, state, process_event_notifier=None)
-        all_outputs.add(input_path.read_text())
-        input_path.write_text(backup)
+        all_outputs.add(input_path.read_bytes())
+        input_path.write_bytes(backup)
         state = pass_.advance(input_path, state)
     return all_outputs
 

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -91,7 +91,7 @@ HINT_SCHEMA_STRICT['additionalProperties'] = False
 HINT_SCHEMA_STRICT['properties']['p']['items'] = HINT_PATCH_SCHEMA_STRICT
 
 
-def apply_hints(bundles: List[HintBundle], file: Path) -> str:
+def apply_hints(bundles: List[HintBundle], file: Path) -> bytes:
     """Edits the file applying the specified hints to its contents."""
     patches = []
     for bundle in bundles:
@@ -102,10 +102,10 @@ def apply_hints(bundles: List[HintBundle], file: Path) -> str:
                 patches.append(p)
     merged_patches = merge_overlapping_patches(patches)
 
-    with open(file) as f:
+    with open(file, 'rb') as f:
         orig_data = f.read()
 
-    new_data = ''
+    new_data = b''
     start_pos = 0
     for p in merged_patches:
         left: int = p['l']
@@ -119,7 +119,7 @@ def apply_hints(bundles: List[HintBundle], file: Path) -> str:
         start_pos = right
         # Insert the replacement value, if provided.
         if 'v' in p:
-            new_data += bundle.vocabulary[p['v']]
+            new_data += bundle.vocabulary[p['v']].encode()
     # Add the unmodified chunk after the last patch end.
     new_data += orig_data[start_pos:]
     return new_data

--- a/cvise/utils/misc.py
+++ b/cvise/utils/misc.py
@@ -3,15 +3,6 @@ import tempfile
 from contextlib import contextmanager
 
 
-def is_readable_file(filename):
-    try:
-        with open(filename) as f:
-            f.read()
-        return True
-    except UnicodeDecodeError:
-        return False
-
-
 # TODO: use tempfile.NamedTemporaryFile(delete_on_close=False) since Python 3.12 is the oldest supported release
 @contextmanager
 def CloseableTemporaryFile(mode='w+b', dir=None):

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -28,7 +28,6 @@ from cvise.utils.error import InvalidInterestingnessTestError
 from cvise.utils.error import InvalidTestCaseError
 from cvise.utils.error import PassBugError
 from cvise.utils.error import ZeroSizeError
-from cvise.utils.misc import is_readable_file
 from cvise.utils.readkey import KeyLogger
 import pebble
 import psutil
@@ -63,7 +62,12 @@ class InitEnvironment:
     job_timeout: int
 
     def run(self):
-        return self.pass_new(self.test_case, tmp_dir=self.tmp_dir, job_timeout=self.job_timeout)
+        try:
+            return self.pass_new(self.test_case, tmp_dir=self.tmp_dir, job_timeout=self.job_timeout)
+        except UnicodeDecodeError:
+            # most likely the pass is incompatible with non-UTF files - abort it
+            logging.debug('Skipping pass due to a unicode issue')
+            return None
 
 
 class TestEnvironment:
@@ -127,6 +131,11 @@ class TestEnvironment:
 
             # run test script
             self.exitcode = self.run_test(False)
+            return self
+        except UnicodeDecodeError:
+            # most likely the pass is incompatible with non-UTF files - terminate it
+            logging.debug('Skipping pass due to a unicode issue')
+            self.result = PassResult.STOP
             return self
         except OSError:
             # this can happen when we clean up temporary files for cancelled processes
@@ -312,9 +321,8 @@ class TestManager:
     def get_line_count(files):
         lines = 0
         for file in files:
-            if is_readable_file(file):
-                with open(file) as f:
-                    lines += len([line for line in f.readlines() if line and not line.isspace()])
+            with open(file, 'rb') as f:
+                lines += len([line for line in f.readlines() if line and not line.isspace()])
         return lines
 
     def backup_test_cases(self):
@@ -386,15 +394,19 @@ class TestManager:
 
     @staticmethod
     def diff_files(orig_file, changed_file):
-        with open(orig_file) as f:
+        with open(orig_file, 'rb') as f:
             orig_file_lines = f.readlines()
 
-        with open(changed_file) as f:
+        with open(changed_file, 'rb') as f:
             changed_file_lines = f.readlines()
 
-        diffed_lines = difflib.unified_diff(orig_file_lines, changed_file_lines, str(orig_file), str(changed_file))
+        diffed_lines = difflib.diff_bytes(
+            difflib.unified_diff, orig_file_lines, changed_file_lines, bytes(orig_file), bytes(changed_file)
+        )
+        # Drop invalid UTF sequences from the diff, to make it easy to log.
+        str_lines = [s.decode('utf-8', 'ignore') for s in diffed_lines]
 
-        return ''.join(diffed_lines)
+        return ''.join(str_lines)
 
     def check_sanity(self):
         logging.debug('perform sanity check... ')
@@ -709,7 +721,7 @@ class TestManager:
         if self.print_diff:
             diff_str = self.diff_files(self.current_test_case, test_env.test_case_path)
             if self.use_colordiff:
-                diff_str = subprocess.check_output('colordiff', shell=True, encoding='utf8', input=diff_str)
+                diff_str = subprocess.check_output('colordiff', shell=True, input=diff_str)
             logging.info(diff_str)
 
         try:

--- a/delta/topformflat.l
+++ b/delta/topformflat.l
@@ -44,6 +44,8 @@ int whitespace_end_pos = -1;
 %option noyywrap
 /* dsw: don't define yyunput() */
 %option nounput
+/* support all characters, including UTF-8 */
+%option 8bit
 
 /* start condition for strings */
 %x STRING


### PR DESCRIPTION
Accept test cases that aren't valid UTF-8. While unusual in modern programming, non-UTF-8 files do still occur (e.g., in tests of text parsing libraries).

This commit adds support of non-UTF-8 reductions into the following passes: blank, comments, clanghints, line_markers, lines. Other passes will be silently skipped on Unicode errors. Also make the "--print-diff" logic support non-UTF-8 files too.

This should address most of #59.