### PR TITLE
interleaving: Enable by default

### DIFF
--- a/cvise/CMakeLists.txt
+++ b/cvise/CMakeLists.txt
@@ -65,6 +65,7 @@ endfunction(configure_one_file)
 set(SOURCE_FILES
   "__init__.py"
   "pass_groups/all.json"
+  "pass_groups/no-interleaving.json"
   "pass_groups/opencl-120.json"
   "pass_groups/delta.json"
   "pass_groups/binary.json"

--- a/cvise/pass_groups/no-interleaving.json
+++ b/cvise/pass_groups/no-interleaving.json
@@ -1,20 +1,4 @@
-{"interleaving_first": [
-    {"pass": "comments", "c": true },
-    {"pass": "line_markers", "c": true },
-    {"pass": "blank"},
-    {"pass": "lines", "arg": "0" },
-    {"pass": "lines", "arg": "1" },
-    {"pass": "lines", "arg": "2" },
-    {"pass": "lines", "arg": "3" },
-    {"pass": "lines", "arg": "4" },
-    {"pass": "lines", "arg": "6" },
-    {"pass": "lines", "arg": "8" },
-    {"pass": "lines", "arg": "10" },
-    {"pass": "lines", "arg": "None" },
-    {"pass": "clanghints", "arg": "replace-function-def-with-decl", "c": true },
-    {"pass": "clanghints", "arg": "remove-unused-function", "c": true }
- ],
- "first": [
+{"first": [
     {"pass": "includes", "c": true },
     {"pass": "unifdef", "exclude": ["windows"], "c": true },
     {"pass": "comments", "c": true },


### PR DESCRIPTION
Add an interleaving category into the all.json config - this means C-Vise will use the new logic with running different passes concurrently by default. In case of problems or performance issues with it, the user can fall back to "--pass-group no-interleaving" (this config is the old all.json before this commit).

For now, we only use the "interleaving_first" category, which means going through all reduction candidates once - without looping until all passes are exhausted. We'll reevaluate this later once more performance improvements get into the "interleaving" code path and more passes are migrated to be compatible with it.