### PR TITLE
Fix .sh and folding temp files not cleared on exception

### DIFF
--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -754,6 +754,8 @@ class TestManager:
             self.remove_roots()
         except KeyboardInterrupt:
             logging.info('Exiting now ...')
+            # Clean temporary files for all jobs and passes.
+            self.release_all_jobs()
             self.remove_roots()
             sys.exit(1)
 

--- a/tests/test_cvise.py
+++ b/tests/test_cvise.py
@@ -8,18 +8,27 @@ import subprocess
 import time
 
 
-def start_cvise(arguments):
+SUBPROCESS_TMPDIR = 'tmpdir'
+
+
+def start_cvise(arguments, tmp_path: Path):
     current = os.path.dirname(__file__)
     binary = os.path.join(current, '../cvise-cli.py')
     cmd = [binary] + arguments
-    return subprocess.Popen(cmd, stdout=subprocess.PIPE, encoding='utf8')
+
+    new_tmpdir = tmp_path / SUBPROCESS_TMPDIR
+    new_tmpdir.mkdir()
+    new_env = os.environ.copy()
+    new_env['TMPDIR'] = str(new_tmpdir)
+
+    return subprocess.Popen(cmd, stdout=subprocess.PIPE, encoding='utf8', env=new_env)
 
 
-def check_cvise(testcase, arguments, expected):
+def check_cvise(testcase, arguments, expected, tmp_path: Path):
     current = os.path.dirname(__file__)
     shutil.copy(os.path.join(current, 'sources', testcase), '.')
     os.chmod(testcase, 0o644)
-    proc = start_cvise([testcase] + arguments)
+    proc = start_cvise([testcase] + arguments, tmp_path)
     proc.communicate()
     assert proc.returncode == 0
 
@@ -27,6 +36,7 @@ def check_cvise(testcase, arguments, expected):
         content = f.read()
     assert content in expected
     assert stat.filemode(os.stat(testcase).st_mode) == '-rw-r--r--'
+    assert_subprocess_tmpdir_empty(tmp_path)
 
 
 def wait_until_file_created(path: Path):
@@ -34,24 +44,31 @@ def wait_until_file_created(path: Path):
         time.sleep(0.1)
 
 
-def test_simple_reduction():
+def assert_subprocess_tmpdir_empty(tmp_path: Path) -> None:
+    assert list((tmp_path / SUBPROCESS_TMPDIR).iterdir()) == []
+
+
+def test_simple_reduction(tmp_path: Path):
     check_cvise(
         'blocksort-part.c',
         ['-c', r"gcc -c blocksort-part.c && grep '\<nextHi\>' blocksort-part.c"],
         ['#define nextHi'],
+        tmp_path,
     )
 
 
-def test_simple_reduction_no_interleaving_config():
+def test_simple_reduction_no_interleaving_config(tmp_path: Path):
     check_cvise(
         'blocksort-part.c',
         ['-c', r"gcc -c blocksort-part.c && grep '\<nextHi\>' blocksort-part.c", '--pass-group', 'no-interleaving'],
         ['#define nextHi'],
+        tmp_path,
     )
 
 
 @pytest.mark.skipif(os.name != 'posix', reason='requires POSIX for command-line tools')
-def test_ctrl_c(tmp_path: Path):
+@pytest.mark.parametrize('additional_delay', [0, 1, 10])
+def test_ctrl_c(tmp_path: Path, additional_delay: int):
     """Test that Control-C is handled quickly, without waiting for jobs to finish."""
     MAX_SHUTDOWN = 10  # in seconds; tolerance to prevent flakiness (normally it's a fraction of a second)
     JOB_SLOWNESS = MAX_SHUTDOWN * 2  # make a single job slower than the thresholds
@@ -64,10 +81,13 @@ def test_ctrl_c(tmp_path: Path):
             '-c',
             f'gcc -c blocksort-part.c && touch {flag_file} && sleep {JOB_SLOWNESS}',
             '--skip-interestingness-test-check',
-        ]
+        ],
+        tmp_path,
     )
     # to make the test cover the interesting scenario, we wait until C-Vise starts at least one job
     wait_until_file_created(flag_file)
+    # extra wait for more variance in test scenarios
+    time.sleep(additional_delay)
 
     proc.send_signal(signal.SIGINT)
     try:
@@ -76,6 +96,7 @@ def test_ctrl_c(tmp_path: Path):
         # C-Vise has not quit on time - kill it and fail the test
         proc.kill()
         raise
+    assert_subprocess_tmpdir_empty(tmp_path)
 
 
 def test_interleaving_lines_passes(tmp_path: Path):
@@ -104,7 +125,9 @@ def test_interleaving_lines_passes(tmp_path: Path):
     shutil.copy(testcase_path, '.')
     copy_path = Path(testcase_path.name)
 
-    proc = start_cvise(['-c', 'gcc -c test.c && grep foo test.c', '--pass-group-file', config_path, testcase_path.name])
+    proc = start_cvise(
+        ['-c', 'gcc -c test.c && grep foo test.c', '--pass-group-file', config_path, testcase_path.name], tmp_path
+    )
     proc.communicate()
     assert proc.returncode == 0
     assert (
@@ -114,6 +137,7 @@ def test_interleaving_lines_passes(tmp_path: Path):
         }
         """
     )
+    assert_subprocess_tmpdir_empty(tmp_path)
 
 
 def test_apply_hints(tmp_path: Path):
@@ -132,11 +156,13 @@ def test_apply_hints(tmp_path: Path):
     input_path.write_text('abcd')
 
     proc = start_cvise(
-        ['--action=apply-hints', '--hints-file', hints_path, '--hint-begin-index=1', '--hint-end-index=3', input_path]
+        ['--action=apply-hints', '--hints-file', hints_path, '--hint-begin-index=1', '--hint-end-index=3', input_path],
+        tmp_path,
     )
     stdout, _ = proc.communicate()
     assert proc.returncode == 0
     assert stdout == 'ad'
+    assert_subprocess_tmpdir_empty(tmp_path)
 
 
 def test_non_ascii(tmp_path: Path):
@@ -150,9 +176,10 @@ def test_non_ascii(tmp_path: Path):
     copy_path = Path(testcase_path.name)
 
     # Also enable diff logging to check it doesn't break on non-unicode.
-    proc = start_cvise(['-c', 'gcc -c test.c && grep foo test.c', testcase_path.name, '--print-diff'])
+    proc = start_cvise(['-c', 'gcc -c test.c && grep foo test.c', testcase_path.name, '--print-diff'], tmp_path)
     proc.communicate()
 
     assert proc.returncode == 0
     # The reduced result may or may not include the trailing line break - this depends on random ordering factors.
     assert copy_path.read_text() in ('int foo;', 'int foo;\n')
+    assert_subprocess_tmpdir_empty(tmp_path)


### PR DESCRIPTION
Fix two cases when temporary files wouldn't be cleared on C-Vise shutdown:

1. The .sh script created when the "-c" command-line option is used.
2. Temp dirs for the recently added folding jobs in interleaving passes.

Add tests that check TMPDIR is empty on exit.