### PR TITLE
cli: Send file name log to intended output

### DIFF
--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -514,7 +514,7 @@ def do_reduce(args):
 
                 fs.write(b'Reduced test-cases:\n\n')
                 for test_case in sorted(test_manager.test_cases):
-                    print(f'--- {test_case} ---'.encode())
+                    fs.write(f'--- {test_case} ---'.encode())
                     with open(test_case, 'rb') as test_case_file:
                         fs.write(test_case_file.read())
                         fs.write(b'\n')


### PR DESCRIPTION
Print the "--- \<testcase\> ---" line into the same output as all other precending&following logs - either stderr or the log file. It seems like it was an oversight to send only this log to stdout.

(We touched this code in #244, but the discrepancy was in the code before that change.)