### PR TITLE
interleaving: Concurrently execute advance_on_success

### DIFF
--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -888,7 +888,7 @@ class TestManager:
         ctx = self.pass_contexts[pass_id]
         assert ctx.can_init_now()
 
-        # Either initialize the pass from scract, or advance from the previous state.
+        # Either initialize the pass from scratch, or advance from the previous state.
         if ctx.state is None:
             env = InitEnvironment(
                 pass_new=ctx.pass_.new,

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -55,7 +55,7 @@ def rmfolder(name):
 
 @dataclass
 class InitEnvironment:
-    """Holds data for executing a Pass' new() method in a worker."""
+    """Holds data for executing a Pass new() method in a worker."""
 
     pass_new: Callable
     test_case: Path
@@ -73,7 +73,7 @@ class InitEnvironment:
 
 @dataclass
 class AdvanceOnSuccessEnvironment:
-    """Holds data for executing a Pass' advance_on_success() method in a worker."""
+    """Holds data for executing a Pass advance_on_success() method in a worker."""
 
     pass_advance_on_success: Callable
     test_case: Path
@@ -87,7 +87,7 @@ class AdvanceOnSuccessEnvironment:
 
 
 class TestEnvironment:
-    """Holds data for running a Pass' transform() method and the interestingness test in a worker.
+    """Holds data for running a Pass transform() method and the interestingness test in a worker.
 
     The transform call is optional - in that case, the interestingness test is simply executed for the unchanged input
     (this is useful for implementing the "sanity check" of the input on the C-Vise startup).
@@ -224,15 +224,15 @@ class PassContext:
         )
 
     def can_init_now(self) -> bool:
-        """Whether the pass' new() method can be scheduled."""
+        """Whether the pass new() method can be scheduled."""
         return not self.defunct and self.stage == PassStage.BEFORE_INIT
 
     def can_transform_now(self) -> bool:
-        """Whether the pass' transform() method can be scheduled."""
+        """Whether the pass transform() method can be scheduled."""
         return not self.defunct and self.stage == PassStage.ENUMERATING and self.state is not None
 
     def can_start_job_now(self) -> bool:
-        """Whether any of the pass' methods can be scheduled."""
+        """Whether any of the pass methods can be scheduled."""
         return self.can_init_now() or self.can_transform_now()
 
 

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -56,6 +56,7 @@ def rmfolder(name):
 @dataclass
 class InitEnvironment:
     """Holds data for executing a Pass' new() method in a worker."""
+
     pass_new: Callable
     test_case: Path
     tmp_dir: Path
@@ -73,13 +74,16 @@ class InitEnvironment:
 @dataclass
 class AdvanceOnSuccessEnvironment:
     """Holds data for executing a Pass' advance_on_success() method in a worker."""
+
     pass_advance_on_success: Callable
     test_case: Path
     pass_previous_state: Any
     job_timeout: int
 
     def run(self) -> Any:
-        return self.pass_advance_on_success(self.test_case, state=self.pass_previous_state, job_timeout=self.job_timeout)
+        return self.pass_advance_on_success(
+            self.test_case, state=self.pass_previous_state, job_timeout=self.job_timeout
+        )
 
 
 class TestEnvironment:


### PR DESCRIPTION
Each time we commit to a reduction, schedule all passes' advance_on_success() methods to be executed in workers in parallel, as opposed to running them sequentially.

This significantly improves the performance of the "interleaving" mode, since we previously were spending 20-40% of wall clock time in those single-job advance_on_success() calls for heavy inputs.

Example measurements on a 64-core machine for the "gcc-94937" reproducer:
* before: reduced 54.4% after 5 min, 78.7% after 10 min.
* after: reduced 58.1% after 5 min, 85.2% after 10 min.