### PR TITLE
Override child processes' temp dir

### DIFF
--- a/cvise/passes/abstract.py
+++ b/cvise/passes/abstract.py
@@ -122,7 +122,7 @@ class ProcessEventNotifier:
     def __init__(self, pid_queue):
         self.pid_queue = pid_queue
 
-    def run_process(self, cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False):
+    def run_process(self, cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False, env=None):
         if shell:
             assert isinstance(cmd, str)
         proc = subprocess.Popen(
@@ -132,6 +132,7 @@ class ProcessEventNotifier:
             universal_newlines=True,
             encoding='utf8',
             shell=shell,
+            env=env,
         )
         if self.pid_queue:
             self.pid_queue.put(ProcessEvent(proc.pid, ProcessEventType.STARTED))

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -153,7 +153,7 @@ class TestEnvironment:
             # get cluttered with files it might leave undeleted (the process might do this because of an oversight in
             # the interestingness test, or because C-Vise abruptly kills our job without a chance for a proper cleanup).
             with tempfile.TemporaryDirectory(dir=self.folder, prefix='overridetmp') as tmp_override:
-                env = override_tmpdir_env(os.environ.copy(), tmp_override)
+                env = override_tmpdir_env(os.environ.copy(), Path(tmp_override))
                 stdout, stderr, returncode = ProcessEventNotifier(self.pid_queue).run_process(
                     str(self.test_script), shell=True, env=env
                 )


### PR DESCRIPTION
When executing an interestingness test, make it use a custom temp dir, located inside the job's temporary folder, instead of the default location (like /tmp/ on a typical POSIX system). This allows C-Vise to clean up all temporary files it might've created without cluttering the default location.

Examples of problematic cases which this commit attempts to solve:

* The interestingness script launches GCC which creates a temporary `.s` file; meanwhile it's normally removed on GCC process exit, it doesn't happen when C-Vise kills cancelled jobs via SIGKILL.
* The interestingness script launches Clang without `-fno-crash-diagnostics`; once Clang crashes, it writes a the crash reproducer file to the temporary directory.

This fixes #260 (hopefully).