### PR TITLE
hints: More informative logs from ClangHints

### DIFF
--- a/cvise/passes/clanghints.py
+++ b/cvise/passes/clanghints.py
@@ -27,6 +27,10 @@ class ClangState(HintState):
         return wrapped
 
 
+class ClangDeltaError(Exception):
+    pass
+
+
 class ClangHintsPass(HintBasedPass):
     """A pass that performs reduction using the hints produced by the clang_delta tool.
 
@@ -49,9 +53,14 @@ class ClangHintsPass(HintBasedPass):
         std_choices = [self.user_clang_delta_std] if self.user_clang_delta_std else CLANG_STD_CHOICES
         best_std = None
         best_bundle: Union[HintBundle, None] = None
+        last_error: Union[ClangDeltaError, None] = None
         for std in std_choices:
             start = time.monotonic()
-            bundle = self.generate_hints_for_standard(test_case, std, job_timeout)
+            try:
+                bundle = self.generate_hints_for_standard(test_case, std, job_timeout)
+            except ClangDeltaError as e:
+                last_error = e
+                continue
             took = time.monotonic() - start
             # prefer newer standard if the # of instances is equal
             if best_bundle is None or len(bundle.hints) >= len(best_bundle.hints):
@@ -60,9 +69,17 @@ class ClangHintsPass(HintBasedPass):
             logging.debug(
                 'available transformation opportunities for %s: %d, took: %.2f s' % (std, len(bundle.hints), took)
             )
-        assert best_bundle is not None
-        logging.info('using C++ standard: %s with %d transformation opportunities' % (best_std, len(best_bundle.hints)))
 
+        if best_bundle is None:
+            logging.warning('%s', last_error)
+            return None
+
+        logging.info(
+            'clang_delta %s using C++ standard: %s with %d transformation opportunities',
+            self.arg,
+            best_std,
+            len(best_bundle.hints),
+        )
         # Let the parent class complete the initialization, but create our own state to remember the chosen standard.
         hint_state = self.new_from_hints(best_bundle, tmp_dir)
         return ClangState.wrap(hint_state, best_std)
@@ -75,7 +92,11 @@ class ClangHintsPass(HintBasedPass):
     def advance_on_success(self, test_case, state, job_timeout, *args, **kwargs):
         # Keep using the same standard as the one chosen in new() - repeating the choose procedure on every successful
         # reduction would be too costly.
-        hints = self.generate_hints_for_standard(test_case, state.clang_std, job_timeout)
+        try:
+            hints = self.generate_hints_for_standard(test_case, state.clang_std, job_timeout)
+        except ClangDeltaError as e:
+            logging.warning('%s', e)
+            return None
         new_state = self.advance_on_success_from_hints(hints, state)
         return ClangState.wrap(new_state, state.clang_std)
 
@@ -93,15 +114,15 @@ class ClangHintsPass(HintBasedPass):
         try:
             proc = subprocess.run(cmd, text=True, capture_output=True, timeout=timeout)
         except subprocess.TimeoutExpired:
-            logging.warning('clang_delta (--std=%s) %ds timeout reached', std, timeout)
-            return HintBundle(hints=[])
+            raise ClangDeltaError(f'clang_delta (--transformation={self.arg} --std={std}) {timeout}s timeout reached')
         except subprocess.SubprocessError as e:
-            logging.warning('clang_delta (--std=%s) failed: %s', std, e)
-            return HintBundle(hints=[])
+            raise ClangDeltaError(f'clang_delta (--transformation={self.arg} --std={std}) failed: {e}')
 
         if proc.returncode != 0:
-            logging.warning(
-                'clang_delta (--std=%s) failed with exit code %d: %s', std, proc.returncode, proc.stderr.strip()
+            stderr = proc.stderr.strip()
+            delim = ': ' if stderr else ''
+            raise ClangDeltaError(
+                f'clang_delta (--transformation={self.arg} --std={std}) failed with exit code {proc.returncode}{delim}{stderr}'
             )
 
         # When reading, gracefully handle EOF because the tool might've failed with no output.


### PR DESCRIPTION
Include the transformation name (like "remove-unused-function") into the logs - it's otherwise unclear how to distinguish between different ClangHints within an interleaving group.

Don't print warning logs about clang_delta failures as long as at least one of the --std= alternative succeeds. These warnings are misleading for the users, but it's normal that, e.g., a modern C++ program fails to compile in the --std=c++98 mode.