### PR TITLE
test_manager: Don't override Pebble sleep unit

### DIFF
--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -33,8 +33,6 @@ from cvise.utils.readkey import KeyLogger
 import pebble
 import psutil
 
-# change default Pebble sleep unit for faster response
-pebble.common.SLEEP_UNIT = 0.01
 MAX_PASS_INCREASEMENT_THRESHOLD = 3
 
 


### PR DESCRIPTION
This was documented as a measure to increase the responsiveness, but according to my measurements it only slows down C-Vise: e.g., simple reductions finish in ~113 sec instead of ~86 sec (30% slowdown). Pebble seems to use proper synchronization primitives that don't require tweaking timeouts for quick processing.

Presumably the slowdown is caused by the increased thread congestion, which with Python's Global Interpreter Lock decreases the main process' throughput.