### PR TITLE
tree-sitter: Build rule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,7 @@ add_subdirectory(clang_delta)
 add_subdirectory(clex)
 add_subdirectory(cvise)
 add_subdirectory(delta)
+add_subdirectory(tree-sitter)
 
 # Copy top-level cvise script
 configure_file(

--- a/tree-sitter/CMakeLists.txt
+++ b/tree-sitter/CMakeLists.txt
@@ -1,0 +1,11 @@
+## -*- mode: CMake -*-
+
+cmake_minimum_required(VERSION 3.14)
+
+project(tree-sitter)
+
+add_library(tree-sitter STATIC lib/src/lib.c)
+target_include_directories(tree-sitter
+  PRIVATE lib/src
+  PUBLIC lib/include
+)

--- a/tree-sitter/CMakeLists.txt
+++ b/tree-sitter/CMakeLists.txt
@@ -9,3 +9,4 @@ target_include_directories(tree-sitter
   PRIVATE lib/src
   PUBLIC lib/include
 )
+target_compile_options(tree-sitter PRIVATE -std=gnu99 -no-pedantic)

--- a/tree-sitter/CMakeLists.txt
+++ b/tree-sitter/CMakeLists.txt
@@ -9,4 +9,4 @@ target_include_directories(tree-sitter
   PRIVATE lib/src
   PUBLIC lib/include
 )
-target_compile_options(tree-sitter PRIVATE -std=gnu99 -no-pedantic)
+target_compile_options(tree-sitter PRIVATE -std=gnu99 -Wno-pedantic)


### PR DESCRIPTION
Add a handwritten CMake source file.

We don't use upstream's existing build scripts (Tree-sitter uses Makefile), since it's nontrivial to integrate it seamlessly into the CMake project, and also the build story for our purposes (a static library) is quite simple.