### PR TITLE
tree-sitter-cpp: Build rule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
     OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # XXX figure out how to get "-std=c++17 -fno-rtti" from LLVM.  That's how we
   # get those options in the Automake path...
-  set(COMMON_FLAGS "-Wall -Wextra -Werror -pedantic -Wno-unused-parameter")
+  set(COMMON_FLAGS "-Wall -Wextra -Werror -Wno-unused-parameter")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COMMON_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_FLAGS} -std=c++17 -fno-rtti -fno-strict-aliasing")
   if(SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,9 @@ add_definitions("-DHAVE_CONFIG_H")
 
 ###############################################################################
 
+# Use static linking for libraries in subdirectories.
+option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
+
 # Use option `-fvisibility-inlines-hidden` if the C++ compiler supports it.
 # See LLVM file `share/llvm/cmake/HandleLLVMOptions.cmake`.
 #
@@ -221,6 +224,7 @@ add_subdirectory(clex)
 add_subdirectory(cvise)
 add_subdirectory(delta)
 add_subdirectory(tree-sitter)
+add_subdirectory(tree-sitter-cpp)
 
 # Copy top-level cvise script
 configure_file(

--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -671,6 +671,12 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
   target_link_libraries(clang_delta Version)
 endif()
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+    OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
+endif()
+
 if(MSVC)
   set(msvc_warning_flags
     # Disabled warnings.

--- a/clex/CMakeLists.txt
+++ b/clex/CMakeLists.txt
@@ -12,6 +12,12 @@ cmake_minimum_required(VERSION 3.14)
 
 # find_package(FLEX) is done by the topmost "CMakeLists.txt" file.
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+    OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
+endif()
+
 ###############################################################################
 
 project(clex)

--- a/delta/CMakeLists.txt
+++ b/delta/CMakeLists.txt
@@ -12,6 +12,12 @@ cmake_minimum_required(VERSION 3.14)
 
 # find_package(FLEX) is done by the topmost "CMakeLists.txt" file.
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+    OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
+endif()
+
 ###############################################################################
 
 project(topformflat)

--- a/tree-sitter/CMakeLists.txt
+++ b/tree-sitter/CMakeLists.txt
@@ -9,4 +9,4 @@ target_include_directories(tree-sitter
   PRIVATE lib/src
   PUBLIC lib/include
 )
-target_compile_options(tree-sitter PRIVATE -std=gnu99 -Wno-pedantic)
+target_compile_options(tree-sitter PRIVATE -std=gnu99)


### PR DESCRIPTION
Trigger building the Tree-sitter C++ grammar.

We simply reuse the CMake source file from the upstream. The only tweak is disabling dynamic library creation, which the upstream CMake sets to "on" by default.

On the C-Vise side, we stop applying "-pedantic" unilaterally, since it doesn't work for Tree-sitter subdirectories.