### PR TITLE
clangbinarysearch: Fix TypeError due to byte-str mixup

### DIFF
--- a/cvise/passes/clangbinarysearch.py
+++ b/cvise/passes/clangbinarysearch.py
@@ -87,7 +87,7 @@ class ClangBinarySearchPass(AbstractPass):
             return int(m.group(1))
 
     def parse_stderr(self, state, stderr):
-        for line in stderr.split('\n'):
+        for line in stderr.split(b'\n'):
             if line.startswith(b'Available transformation instances:'):
                 real_num_instances = int(line.decode().split(':')[1])
                 state.real_num_instances = real_num_instances


### PR DESCRIPTION
Fix the regression introduced in #265:

```
  File "\cvise/utils/testing.py", line 151, in run
    (result, self.state) = self.transform(
                           ~~~~~~~~~~~~~~^
        str(self.test_case_path), self.state, ProcessEventNotifier(self.pid_queue)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "\cvise/passes/clangbinarysearch.py", line 117, in transform
    self.parse_stderr(state, stderr)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "\cvise/passes/clangbinarysearch.py", line 90, in parse_stderr
    for line in stderr.split('\n'):
                ~~~~~~~~~~~~^^^^^^
  TypeError: a bytes-like object is required, not 'str'
```

This pass has only minor importance currently, being gradually superseded by ClangHints, still as long as it's still present we should fix the error.