### PR TITLE
interleaving: Reinit finished passes once in a while

### DIFF
--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -663,7 +663,7 @@ class TestManager:
                 self.report_pass_bug(job, 'pass error')
                 return PassCheckingOutcome.STOP
 
-        if not self.no_give_up and test_env.order > self.GIVEUP_CONSTANT:
+        if not self.no_give_up and test_env.order - self.current_batch_start_order > self.GIVEUP_CONSTANT:
             if not self.giveup_reported:
                 self.report_pass_bug(job, 'pass got stuck')
                 self.giveup_reported = True

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -711,9 +711,11 @@ class TestManager:
                     # Unfinished initializations from the last run will need to be restarted.
                     if ctx.stage == PassStage.IN_INIT:
                         ctx.stage = PassStage.BEFORE_INIT
-                    # Previously finished passes are eligible for reinitialization.
+                    # Previously finished passes are eligible for reinitialization (used for "interleaving" mode only -
+                    # in the old single-pass mode we're expected to return to let subsequent passes work).
                     if (
-                        ctx.stage == PassStage.ENUMERATING
+                        self.interleaving
+                        and ctx.stage == PassStage.ENUMERATING
                         and ctx.state is None
                         and pass_id not in self.pass_reinit_queue
                     ):


### PR DESCRIPTION
After a pass finished enumerating all of its state, reinitialize it again
if we made reductions via other passes (in the interleaving mode).

This significantly improves the reduction pace in its mid-term stage,
when some passes already went through all of the candidates once
but there's still a couple of passes that continue making successful
reductions. For example, `LinesPass` is likely to finish before `rm-tok`
(as there's more tokens that curly brace pairs), however removing
some token can make some curly-brace-surrounded block
removable too - this is where the reinitialization of `LinesPass`
would help discovering this sooner, within the same batch of jobs
in run_passes().

We just need to make sure we don't do reinits too often, since for
some passes they're mostly useless (think of `CommentsPass` after
all comments removed), and even for other passes only occasionally
useful. Our choice is - don't dedicate more than 1% of jobs to this.

Empirical measurements on our test dataset: C-Vise running time
improvement around 20% (varying between 0% and 75%).