### PR TITLE
clang_delta: Skip non-dep typedefs in replace-dependent-typedef

### DIFF
--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -353,6 +353,8 @@ set(SOURCE_FILES
   "/tests/replace-dependent-typedef/test1.output"
   "/tests/replace-dependent-typedef/test1.output2"
   "/tests/replace-dependent-typedef/test1.output3"
+  "/tests/replace-dependent-typedef/test2.cc"
+  "/tests/replace-dependent-typedef/test2.output"
   "/tests/replace-derived-class/replace-derived1.cpp"
   "/tests/replace-derived-class/replace-derived1.output"
   "/tests/replace-derived-class/replace-derived2.cpp"

--- a/clang_delta/tests/replace-dependent-typedef/test2.cc
+++ b/clang_delta/tests/replace-dependent-typedef/test2.cc
@@ -1,0 +1,19 @@
+template <typename T>
+struct A {
+  struct Inner;
+  // This shouldn't be treated as an instance:
+  typedef A::Inner Foo;
+};
+
+template <class T> struct S { typedef T type; };
+
+struct B {
+  struct Inner;
+};
+
+template <typename T>
+struct C {
+  typedef typename S<T>::type::Inner Bar;
+};
+
+typedef C<B>::Bar D;

--- a/clang_delta/tests/replace-dependent-typedef/test2.output
+++ b/clang_delta/tests/replace-dependent-typedef/test2.output
@@ -1,0 +1,19 @@
+template <typename T>
+struct A {
+  struct Inner;
+  // This shouldn't be treated as an instance:
+  typedef A::Inner Foo;
+};
+
+template <class T> struct S { typedef T type; };
+
+struct B {
+  struct Inner;
+};
+
+template <typename T>
+struct C {
+  typedef typename S<T>::type::Inner Bar;
+};
+
+typedef B::Inner D;

--- a/clang_delta/tests/test_clang_delta.py
+++ b/clang_delta/tests/test_clang_delta.py
@@ -1069,6 +1069,17 @@ class TestClangDelta(unittest.TestCase):
             'replace-dependent-typedef/test1.output3',
         )
 
+    def test_replace_derived_class_replace_dependent_typedef_2(self):
+        self.check_query_instances(
+            'replace-dependent-typedef/test2.cc',
+            '--query-instances=replace-dependent-typedef',
+            'Available transformation instances: 1',
+        )
+        self.check_clang_delta(
+            'replace-dependent-typedef/test2.cc',
+            '--transformation=replace-dependent-typedef --counter=1',
+        )
+
     def test_replace_derived_class_replace_derived1(self):
         self.check_clang_delta(
             'replace-derived-class/replace-derived1.cpp',


### PR DESCRIPTION
Only consider typedefs that depend on other typedefs in replace-dependent-typedef.

This prevents the pass from reporting a success when no actual change has been made, like in the case when a typedef belongs to and refers to a template struct (where multiple possible string representations may confuse the checks).