### PR TITLE
tree-sitter: Add ReplaceFunctionDefWithDecl pass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,7 @@ add_subdirectory(cvise)
 add_subdirectory(delta)
 add_subdirectory(tree-sitter)
 add_subdirectory(tree-sitter-cpp)
+add_subdirectory(treesitter_delta)
 
 # Copy top-level cvise script
 configure_file(

--- a/cvise/CMakeLists.txt
+++ b/cvise/CMakeLists.txt
@@ -91,6 +91,7 @@ set(SOURCE_FILES
   "passes/peep.py"
   "passes/special.py"
   "passes/ternary.py"
+  "passes/treesitter.py"
   "passes/unifdef.py"
   "tests/__init__.py"
   "tests/testabstract.py"

--- a/cvise/cvise.py
+++ b/cvise/cvise.py
@@ -24,6 +24,7 @@ from cvise.passes.lines import LinesPass
 from cvise.passes.peep import PeepPass
 from cvise.passes.special import SpecialPass
 from cvise.passes.ternary import TernaryPass
+from cvise.passes.treesitter import TreeSitterPass
 from cvise.passes.unifdef import UnIfDefPass
 from cvise.utils import keyboard_interrupt_monitor
 from cvise.utils.error import CViseError, PassOptionError
@@ -88,6 +89,7 @@ class CVise:
         'peep': PeepPass,
         'special': SpecialPass,
         'ternary': TernaryPass,
+        'treesitter': TreeSitterPass,
         'unifdef': UnIfDefPass,
     }
 

--- a/cvise/pass_groups/all.json
+++ b/cvise/pass_groups/all.json
@@ -13,6 +13,7 @@
     {"pass": "lines", "arg": "None" },
     {"pass": "clanghints", "arg": "replace-function-def-with-decl", "c": true },
     {"pass": "clanghints", "arg": "remove-unused-function", "c": true },
+    {"pass": "treesitter", "c": true },
     {"pass": "clexhints", "arg": "rm-toks-1-to-4"},
     {"pass": "clexhints", "arg": "rm-toks-5-to-8"},
     {"pass": "clexhints", "arg": "rm-toks-9-to-12"},

--- a/cvise/utils/externalprograms.py
+++ b/cvise/utils/externalprograms.py
@@ -11,6 +11,7 @@ def find_external_programs():
         'clang_delta': 'clang_delta',
         'clex': 'clex',
         'topformflat_hints': 'delta',
+        'treesitter_delta': 'treesitter_delta',
         'unifdef': None,
         'gcov-dump': None,
     }

--- a/treesitter_delta/CMakeLists.txt
+++ b/treesitter_delta/CMakeLists.txt
@@ -1,0 +1,18 @@
+## -*- mode: CMake -*-
+
+cmake_minimum_required(VERSION 3.14)
+
+project(treesitter_delta)
+
+add_executable(treesitter_delta
+    Main.cpp
+    ReplaceFunctionDefWithDecl.cpp
+)
+target_link_libraries(treesitter_delta
+    tree-sitter
+    tree-sitter-cpp
+)
+
+install(TARGETS treesitter_delta
+  DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/${cvise_PACKAGE}/"
+  )

--- a/treesitter_delta/HintDefs.h
+++ b/treesitter_delta/HintDefs.h
@@ -1,0 +1,13 @@
+#ifndef HINT_DEFS_H
+#define HINT_DEFS_H
+
+// The hints vocabulary.
+inline constexpr const char *HintsVocabulary[] = {
+    "replace-function-def-with-decl",
+    ";",
+};
+// The indices must match the order in HintsVocabulary.
+constexpr int ReplaceFuncDefWithDeclVocabIdx = 0;
+constexpr int SemicolonVocabIdx = 1;
+
+#endif

--- a/treesitter_delta/Main.cpp
+++ b/treesitter_delta/Main.cpp
@@ -1,0 +1,80 @@
+#include "HintDefs.h"
+#include "Parsers.h"
+#include "ReplaceFunctionDefWithDecl.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <utility>
+
+#include <tree_sitter/api.h>
+
+static void printHintsVocabulary() {
+  std::cout << '[';
+  for (size_t I = 0; I < std::size(HintsVocabulary); ++I) {
+    if (I > 0)
+      std::cout << ',';
+    // For simplicity, we assume no character needs escaping for JSON (always
+    // true for replacement strings in clang_delta).
+    std::cout << '"' << HintsVocabulary[I] << '"';
+  }
+  std::cout << "]\n";
+}
+
+static bool readFile(const std::string &Path, std::string &Contents) {
+  std::error_code Error;
+  auto Size = std::filesystem::file_size(Path, Error);
+  if (Error) {
+    std::cerr << "Failed to obtain size of file " << Path << " : "
+              << Error.message() << "\n";
+    return false;
+  }
+  Contents.resize(Size);
+  std::ifstream File(Path, std::ios::binary);
+  if (File.fail()) {
+    std::cerr << "Failed to read file " << Path << "\n";
+    return false;
+  }
+  File.read(Contents.data(), Size);
+  auto ActuallyRead = File.gcount();
+  Contents.resize(ActuallyRead);
+  return true;
+}
+
+int main(int argc, char *argv[]) {
+  std::ios::sync_with_stdio(false); // speed up C++ I/O streams
+
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " input/file/path\n";
+    return -1;
+  }
+  const std::string InputPath = argv[1];
+
+  // Prepare the common parsing state.
+  std::unique_ptr<TSParser, decltype(&ts_parser_delete)> Parser(
+      ts_parser_new(), ts_parser_delete);
+  ts_parser_set_language(Parser.get(), tree_sitter_cpp());
+  FuncDefWithDeclReplacer funcDefWithDeclReplacer;
+
+  // Parse the input.
+  std::string Contents;
+  if (!readFile(InputPath, Contents)) {
+    // The error details are logged by the function.
+    return 1;
+  }
+  std::unique_ptr<TSTree, decltype(&ts_tree_delete)> Tree(
+      ts_parser_parse_string(Parser.get(), /*old_tree=*/nullptr,
+                             Contents.c_str(), Contents.length()),
+      ts_tree_delete);
+  if (!Tree) {
+    std::cerr << "Failed to parse " << InputPath << "\n";
+    return 1;
+  }
+
+  // Run heuristics and emit hints.
+  printHintsVocabulary();
+  funcDefWithDeclReplacer.processParsedFile(*Tree);
+}

--- a/treesitter_delta/Parsers.h
+++ b/treesitter_delta/Parsers.h
@@ -1,0 +1,9 @@
+#ifndef PARSERS_H
+#define PARSERS_H
+
+#include <tree_sitter/api.h>
+
+// Exposed by the tree-sitter-cpp library.
+extern "C" const TSLanguage *tree_sitter_cpp();
+
+#endif

--- a/treesitter_delta/ReplaceFunctionDefWithDecl.cpp
+++ b/treesitter_delta/ReplaceFunctionDefWithDecl.cpp
@@ -1,0 +1,122 @@
+#include "ReplaceFunctionDefWithDecl.h"
+
+#include "HintDefs.h"
+#include "Parsers.h"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <tree_sitter/api.h>
+
+// The captures here must match constants in getMatchCaptures().
+constexpr char QueryStr[] = R"(
+  (
+    function_definition
+    declarator: (
+      function_declarator
+      declarator: (
+        qualified_identifier
+      )? @capture0
+    )
+    (field_initializer_list)? @capture1
+    body: (_) @capture2
+  ) @capture3
+)";
+
+static void getMatchCaptures(const TSQueryMatch &Match, TSNode &QualId,
+                             TSNode &InitList, TSNode &Body, TSNode &FuncDef) {
+  // The capture count and indices must match those specified in QueryStr.
+  std::array<TSNode, 4> Captures{}; // zero-initialize to recognize null nodes
+  for (int I = 0; I < Match.capture_count; ++I)
+    Captures.at(Match.captures[I].index) = Match.captures[I].node;
+  QualId = Captures[0];
+  InitList = Captures[1];
+  Body = Captures[2];
+  FuncDef = Captures[3];
+}
+
+static TSNode walkUpTemplateDecls(const TSNode &FuncDef) {
+  TSNode Ancestor = FuncDef;
+  for (;;) {
+    TSNode Parent = ts_node_parent(Ancestor);
+    if (ts_node_is_null(Parent) ||
+        ts_node_type(Parent) != std::string("template_declaration")) {
+      break;
+    }
+    Ancestor = Parent;
+  }
+  return Ancestor;
+}
+
+FuncDefWithDeclReplacer::FuncDefWithDeclReplacer()
+    : Query(nullptr, ts_query_delete) {
+  uint32_t ErrorOffset = 0;
+  TSQueryError ErrorType = TSQueryErrorNone;
+  Query.reset(ts_query_new(tree_sitter_cpp(), QueryStr, std::size(QueryStr) - 1,
+                           &ErrorOffset, &ErrorType));
+  if (!Query) {
+    std::cerr << "Failed to init Tree-sitter query: error " << ErrorType
+              << " offset " << ErrorOffset << "\n";
+    std::exit(-1);
+  }
+}
+
+FuncDefWithDeclReplacer::~FuncDefWithDeclReplacer() = default;
+
+void FuncDefWithDeclReplacer::processParsedFile(TSTree &Tree) {
+  std::unique_ptr<TSQueryCursor, decltype(&ts_query_cursor_delete)> Cursor(
+      ts_query_cursor_new(), ts_query_cursor_delete);
+  ts_query_cursor_exec(Cursor.get(), Query.get(), ts_tree_root_node(&Tree));
+
+  std::vector<Instance> AllInst;
+  TSQueryMatch Match;
+  while (ts_query_cursor_next_match(Cursor.get(), &Match)) {
+    TSNode QualId, InitList, Body, FuncDef;
+    getMatchCaptures(Match, QualId, InitList, Body, FuncDef);
+
+    // In the basic case, we replace the function body with a semicolon.
+    Instance Inst{
+        .StartByte = ts_node_start_byte(Body),
+        .EndByte = ts_node_end_byte(Body),
+        .WriteSemicolon = true,
+    };
+    if (!ts_node_is_null(QualId)) {
+      // An out-of-line declaration of a member has to be deleted completely.
+      Inst.StartByte = ts_node_start_byte(walkUpTemplateDecls(FuncDef));
+      Inst.WriteSemicolon = false;
+    } else if (!ts_node_is_null(InitList)) {
+      // In case of a constructor, initializer lists have to be deleted as well.
+      Inst.StartByte = ts_node_start_byte(InitList);
+    }
+    assert(Inst.StartByte < Inst.EndByte);
+
+    // Delete overlapping segments: leave only the most detailed matches. This
+    // is to combat the cases when Tree-sitter mistakenly perceives a
+    // class/namespace as a function (usually caused by macros).
+    while (!AllInst.empty() && overlaps(AllInst.back(), Inst))
+      AllInst.pop_back();
+    AllInst.push_back(Inst);
+  }
+
+  for (const auto &Inst : AllInst)
+    printAsHint(Inst);
+}
+
+bool FuncDefWithDeclReplacer::overlaps(const Instance &A, const Instance &B) {
+  return std::max(A.StartByte, B.StartByte) < std::min(A.EndByte, B.EndByte);
+}
+
+void FuncDefWithDeclReplacer::printAsHint(const Instance &Inst) {
+  std::cout << "{\"t\":" << ReplaceFuncDefWithDeclVocabIdx
+            << ",\"p\":[{\"l\":" << Inst.StartByte << ",\"r\":" << Inst.EndByte;
+  if (Inst.WriteSemicolon)
+    std::cout << ",\"v\":" << SemicolonVocabIdx;
+  std::cout << "}]}\n";
+}

--- a/treesitter_delta/ReplaceFunctionDefWithDecl.h
+++ b/treesitter_delta/ReplaceFunctionDefWithDecl.h
@@ -1,0 +1,30 @@
+#ifndef REPLACE_FUNCTION_FUNC_DEF_WITH_DECL_H
+#define REPLACE_FUNCTION_FUNC_DEF_WITH_DECL_H
+
+#include <tree_sitter/api.h>
+
+#include <cstdint>
+#include <memory>
+
+// Emits hints that deletes function bodies (either replacing them with
+// semicolons or deleting the whole definition altogether).
+class FuncDefWithDeclReplacer {
+public:
+  FuncDefWithDeclReplacer();
+  ~FuncDefWithDeclReplacer();
+  void processParsedFile(TSTree &Tree);
+
+private:
+  struct Instance {
+    uint32_t StartByte = 0;
+    uint32_t EndByte = 0;
+    bool WriteSemicolon = false;
+  };
+
+  static bool overlaps(const Instance &A, const Instance &B);
+  static void printAsHint(const Instance &Inst);
+
+  std::unique_ptr<TSQuery, decltype(&ts_query_delete)> Query;
+};
+
+#endif


### PR DESCRIPTION
Implement a Tree-sitter parser based pass that replaces function definitions with declarations - either replacing function bodies with a semicolon or, in case of out-of-line members, deleting the whole definition. Constructor initializer lists are another special case.

Note: meanwhile this new pass effectively duplicates the existing clang_delta "replace-function-def-with-decl" heuristic, the new pass is faster, doesn't require the "-std=" guesswork and, most importantly, can be easily reused for multi-file reproducers (unlike Clang, Tree-sitter doesn't require #include search paths or any other compilation parameters).