### PR TITLE
Stats show size improvement for each pass

### DIFF
--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -481,9 +481,10 @@ def do_reduce(args):
                 fs.write(b'===< PASS statistics >===\n')
                 fs.write(
                     (
-                        '  %-60s %8s %8s %8s %8s %15s\n'
+                        '  %-60s %14s %8s %8s %8s %8s %15s\n'
                         % (
                             'pass name',
+                            'bytes reduced',
                             'time (s)',
                             'time (%)',
                             'worked',
@@ -496,9 +497,10 @@ def do_reduce(args):
                 for pass_name, pass_data in pass_statistic.sorted_results:
                     fs.write(
                         (
-                            '  %-60s %8.2f %8.2f %8d %8d %15d\n'
+                            '  %-60s %14d %8.2f %8.2f %8d %8d %15d\n'
                             % (
                                 pass_name,
+                                -pass_data.total_size_delta,
                                 pass_data.total_seconds,
                                 100.0 * pass_data.total_seconds / (time_stop - time_start),
                                 pass_data.worked,

--- a/cvise/utils/statistics.py
+++ b/cvise/utils/statistics.py
@@ -11,6 +11,7 @@ class SinglePassStatistic:
         self.worked = 0
         self.failed = 0
         self.totally_executed = 0
+        self.total_size_delta = 0
 
 
 class PassStatistic:
@@ -51,11 +52,15 @@ class PassStatistic:
         stat = self.get_stats(pass_)
         stat.failed += 1
 
+    def add_committed_success(self, pass_name: Union[str, None], size_delta: int):
+        stat = self.stats[pass_name] if pass_name is not None else self.folding_stats
+        stat.total_size_delta += size_delta
+
     @property
     def sorted_results(self):
         def sort_statistics(item):
             pass_name, pass_data = item
-            return (-pass_data.total_seconds, pass_name)
+            return (pass_data.total_size_delta, pass_name)
 
         regular_results = sorted(self.stats.items(), key=sort_statistics)
         folding_results = []


### PR DESCRIPTION
Measure how many bytes were removed from the test case using each individual pass. Sort the printed statistics by this criteria (instead of the total time spent on a pass).

This gives a better understanding of which passes work well and which don't - especially in the first half of the reduction, when inputs are big and it's important to quickly prune big chunks. However, one should be cautious because the new statistic doesn't give high score to passes which are naturally small-reducers (like "rm-toks") despite being very crucial for the end result.