### PR TITLE
cli: Add missing newline after the file name log

### DIFF
--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -514,7 +514,7 @@ def do_reduce(args):
 
                 fs.write(b'Reduced test-cases:\n\n')
                 for test_case in sorted(test_manager.test_cases):
-                    fs.write(f'--- {test_case} ---'.encode())
+                    fs.write(f'--- {test_case} ---\n'.encode())
                     with open(test_case, 'rb') as test_case_file:
                         fs.write(test_case_file.read())
                         fs.write(b'\n')


### PR DESCRIPTION
There was a small mistake in #256, resulting in a missing line break after the "--- {test_case} ---" line.