### PR TITLE
test_manager: Make extra dir errors non-fatal

### DIFF
--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -572,9 +572,17 @@ class TestManager:
     def save_extra_dir(self, test_case_path):
         extra_dir = self.get_extra_dir(self.EXTRA_DIR_PREFIX, self.MAX_EXTRA_DIRS)
         if extra_dir is not None:
-            os.mkdir(extra_dir)
-            shutil.move(test_case_path, extra_dir)
-            logging.info(f'Created extra directory {extra_dir} for you to look at later')
+            try:
+                os.mkdir(extra_dir)
+                shutil.move(test_case_path, extra_dir)
+            except (IOError, OSError) as e:
+                logging.warning('Failed to create extra directory %s: %s', extra_dir, e)
+                # Gracefully handle exceptions here - storing "extra" dirs is not critical for the reduction use case,
+                # and an exception can occur simply due to child processes of the interestingness test creating/deleting
+                # files in its work dir. Just make sure to delete the half-created extra dir.
+                rmfolder(extra_dir)
+            else:
+                logging.info(f'Created extra directory {extra_dir} for you to look at later')
 
     def process_done_futures(self) -> None:
         jobs_to_remove = []


### PR DESCRIPTION
We shouldn't abort the whole C-Vise process just because we failed to copy some failed/timed-out job to an "extra" dir. Especially because the errors here can happen flakily, just because we didn't kill some child process that continued messing up with the work dir.

To give a specific example of an error in our stress-testing of C-Vise:

  Traceback (most recent call last):
  File "cvise-cli.py", line 545, in <module>
    main()
    ~~~~^^
  File "cvise-cli.py", line 355, in main
    do_reduce(args)
    ~~~~~~~~~^^^^^^
  File "cvise-cli.py", line 474, in do_reduce
    reducer.reduce(pass_group, skip_initial=args.skip_initial_passes)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "cvise/cvise.py", line 208, in reduce
    self._run_pass_category(passes, category)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "cvise/cvise.py", line 222, in _run_pass_category
    self._run_passes(passes, category.interleaving, check_threshold=False)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "cvise/cvise.py", line 243, in _run_passes
    self.test_manager.run_passes(available_passes, interleaving)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "cvise/utils/testing.py", line 811, in run_passes
    self.run_parallel_tests()
    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "cvise/utils/testing.py", line 736, in run_parallel_tests
    self.process_done_futures()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "cvise/utils/testing.py", line 590, in process_done_futures
    self.handle_timed_out_job(job)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "cvise/utils/testing.py", line 605, in handle_timed_out_job
    self.save_extra_dir(job.temporary_folder)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "cvise/utils/testing.py", line 578, in save_extra_dir
    shutil.move(test_case_path, extra_dir)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/shutil.py", line 872, in move
    copytree(src, real_dst, copy_function=copy_function,
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             symlinks=True)
             ^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/shutil.py", line 593, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
                     ignore=ignore, copy_function=copy_function,
                     ignore_dangling_symlinks=ignore_dangling_symlinks,
                     dirs_exist_ok=dirs_exist_ok)
  File "/usr/lib/python3.13/shutil.py", line 547, in _copytree
    raise Error(errors)
  shutil.Error: [('/tmp/cvise-folding-k2x7l0fx/overridetmpmslkra3m/repro.cpp.tmp', 'cvise_extra_0202/cvise-folding-k2x7l0fx/overridetmpmslkra3m/repro.cpp.tmp', "[Errno 2] No such file or directory: '/tmp/cvise-folding-k2x7l0fx/overridetmpmslkra3m/repro.cpp.tmp'")]