### PR TITLE
tree-sitter, tree-sitter-cpp: Don't install into system location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,8 +223,8 @@ add_subdirectory(clang_delta)
 add_subdirectory(clex)
 add_subdirectory(cvise)
 add_subdirectory(delta)
-add_subdirectory(tree-sitter)
-add_subdirectory(tree-sitter-cpp)
+add_subdirectory(tree-sitter EXCLUDE_FROM_ALL)
+add_subdirectory(tree-sitter-cpp EXCLUDE_FROM_ALL)
 add_subdirectory(treesitter_delta)
 
 # Copy top-level cvise script


### PR DESCRIPTION
Don't execute by default all CMake rules in tree-sitter and tree-sitter-cpp - instead, only those rules will be executed that are depended by something else (currently only treesitter_delta).

This fixes the problem that installing C-Vise would result in installing tree-sitter-cpp public .h/.so files into system-wide locations. This fixes #284.