### PR TITLE
Make State objects immutable and hashable

### DIFF
--- a/cvise/passes/abstract.py
+++ b/cvise/passes/abstract.py
@@ -95,7 +95,7 @@ class BinaryState:
         return isinstance(other, BinaryState) and self._key() == other._key()
 
     def __hash__(self):
-        return hash(self.key())
+        return hash(self._key())
 
     def _key(self):
         return (self.instances, self.chunk, self.index)

--- a/cvise/tests/test_folding.py
+++ b/cvise/tests/test_folding.py
@@ -1,13 +1,17 @@
 from pathlib import Path
 
+from cvise.passes.abstract import BinaryState
 from cvise.passes.hint_based import HintState, PerTypeHintState
 from cvise.utils.folding import FoldingManager
 
 
 def create_stub_hint_state(type: str) -> HintState:
     fake_path = Path()
+    underlying_state = BinaryState.create(instances=1)
     return HintState(
-        tmp_dir=fake_path, per_type_states=[PerTypeHintState(type=type, hints_file_name=fake_path, underlying_state=0)]
+        tmp_dir=fake_path,
+        per_type_states=(PerTypeHintState(type=type, hints_file_name=fake_path, underlying_state=underlying_state),),
+        ptr=0,
     )
 
 
@@ -20,7 +24,7 @@ def test_folding_two():
 
     fold = mgr.maybe_prepare_folding_job(job_order=100)
     assert fold is not None
-    assert fold.sub_states == [state1, state2]
+    assert fold.sub_states == (state1, state2)
 
 
 def test_folding_many():
@@ -32,7 +36,7 @@ def test_folding_many():
 
     fold = mgr.maybe_prepare_folding_job(job_order=N + 1)
     assert fold is not None
-    assert fold.sub_states == states
+    assert fold.sub_states == tuple(states)
 
 
 def test_no_folding_zero_candidates():

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -28,7 +28,7 @@ from cvise.utils.error import InvalidInterestingnessTestError
 from cvise.utils.error import InvalidTestCaseError
 from cvise.utils.error import PassBugError
 from cvise.utils.error import ZeroSizeError
-from cvise.utils.folding import FoldingManager, FoldingState
+from cvise.utils.folding import FoldingManager, FoldingStateIn, FoldingStateOut
 from cvise.utils.readkey import KeyLogger
 import pebble
 import psutil
@@ -884,7 +884,7 @@ class TestManager:
             ) from None
 
         # Update global stats.
-        if isinstance(self.success_candidate.pass_state, FoldingState):
+        if isinstance(self.success_candidate.pass_state, FoldingStateOut):
             self.pass_statistic.add_committed_success(None, self.success_candidate.size_delta)
             for pass_name, size_delta in self.success_candidate.pass_state.statistics.size_delta_per_pass.items():
                 self.pass_statistic.add_committed_success(pass_name, size_delta)
@@ -926,7 +926,7 @@ class TestManager:
         if len(self.test_cases) > 1:
             notes.append(str(new_test_case.name))
         if len(self.pass_contexts) > 1:
-            if isinstance(self.success_candidate.pass_state, FoldingState):
+            if isinstance(self.success_candidate.pass_state, FoldingStateOut):
                 pass_name = ' + '.join(self.success_candidate.pass_state.statistics.get_passes_ordered_by_delta())
             else:
                 pass_name = repr(self.success_candidate.pass_)
@@ -1057,7 +1057,7 @@ class TestManager:
         self.order += 1
         ctx.state = ctx.pass_.advance(self.current_test_case, ctx.state)
 
-    def schedule_fold(self, pool: pebble.ProcessPool, folding_state: FoldingState) -> None:
+    def schedule_fold(self, pool: pebble.ProcessPool, folding_state: FoldingStateIn) -> None:
         assert self.interleaving
 
         folder = Path(tempfile.mkdtemp(prefix=self.TEMP_PREFIX + 'folding-'))


### PR DESCRIPTION
Change a few "state" classes to let them be used for comparison and for hashing containers.

This refactoring should have no functional effect, but it's a prerequisite for a follow-up change where state comparisons will be necessary.