### PR TITLE
Refactor code to use pathlib for paths

### DIFF
--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -448,7 +448,7 @@ def do_reduce(args):
             args.interestingness_test,
             args.timeout,
             args.save_temps,
-            args.test_cases,
+            [Path(s) for s in args.test_cases],
             args.n,
             args.no_cache,
             args.skip_key_off,

--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -445,7 +445,7 @@ def do_reduce(args):
     try:
         test_manager = testing.TestManager(
             pass_statistic,
-            args.interestingness_test,
+            Path(args.interestingness_test),
             args.timeout,
             args.save_temps,
             [Path(s) for s in args.test_cases],

--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -425,13 +425,13 @@ def do_reduce(args):
 
     if args.to_utf8:
         for test_case in args.test_cases:
-            with open(test_case, 'rb') as fd:
-                encoding = chardet.detect(fd.read())['encoding']
-                if encoding not in ('ascii', 'utf-8'):
-                    logging.info(f'Converting {test_case} file ({encoding} encoding) to UTF-8')
-                    data = open(test_case, encoding=encoding).read()
-                    with open(test_case, 'w') as w:
-                        w.write(data)
+            test_case_path = Path(test_case)
+            encoding = chardet.detect(test_case_path.read_bytes())['encoding']
+            if encoding not in ('ascii', 'utf-8'):
+                logging.info(f'Converting {test_case} file ({encoding} encoding) to UTF-8')
+                with open(test_case, encoding=encoding) as f:
+                    data = f.read()
+                test_case_path.write_text(data)
 
     script = None
     if args.commands:

--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -517,9 +517,8 @@ def do_reduce(args):
                 fs.write(b'Reduced test-cases:\n\n')
                 for test_case in sorted(test_manager.test_cases):
                     fs.write(f'--- {test_case} ---\n'.encode())
-                    with open(test_case, 'rb') as test_case_file:
-                        fs.write(test_case_file.read())
-                        fs.write(b'\n')
+                    fs.write(test_case.read_bytes())
+                    fs.write(b'\n')
     finally:
         if script:
             os.unlink(script.name)

--- a/cvise/passes/abstract.py
+++ b/cvise/passes/abstract.py
@@ -2,6 +2,7 @@ import copy
 from dataclasses import dataclass
 from enum import auto, Enum, unique
 import logging
+from pathlib import Path
 import random
 import shutil
 import subprocess
@@ -171,16 +172,16 @@ class AbstractPass:
     def check_prerequisites(self):
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'check_prerequisites'!")
 
-    def new(self, test_case, tmp_dir, job_timeout):
+    def new(self, test_case: Path, tmp_dir, job_timeout):
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'new'!")
 
-    def advance(self, test_case, state):
+    def advance(self, test_case: Path, state):
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'advance'!")
 
-    def advance_on_success(self, test_case, state, succeeded_state, job_timeout, **kwargs):
+    def advance_on_success(self, test_case: Path, state, succeeded_state, job_timeout, **kwargs):
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'advance_on_success'!")
 
-    def transform(self, test_case, state, process_event_notifier):
+    def transform(self, test_case: Path, state, process_event_notifier):
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'transform'!")
 
 

--- a/cvise/passes/abstract.py
+++ b/cvise/passes/abstract.py
@@ -172,7 +172,7 @@ class AbstractPass:
     def check_prerequisites(self):
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'check_prerequisites'!")
 
-    def new(self, test_case: Path, tmp_dir, job_timeout):
+    def new(self, test_case: Path, tmp_dir: Path, job_timeout):
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'new'!")
 
     def advance(self, test_case: Path, state):

--- a/cvise/passes/balanced.py
+++ b/cvise/passes/balanced.py
@@ -1,5 +1,6 @@
 from enum import Enum, auto, unique
 from dataclasses import dataclass
+from pathlib import Path
 import re
 from typing import List, Union
 
@@ -28,7 +29,7 @@ class BalancedPass(HintBasedPass):
     def check_prerequisites(self):
         return True
 
-    def generate_hints(self, test_case):
+    def generate_hints(self, test_case: Path):
         config = self.__get_config()
         open_ch = ord(config.search.value[0])
         close_ch = ord(config.search.value[1])
@@ -37,8 +38,7 @@ class BalancedPass(HintBasedPass):
             assert config.to_delete == Deletion.ALL
             vocabulary.append(config.replacement)
 
-        with open(test_case, 'rb') as in_file:
-            contents = in_file.read()
+        contents = test_case.read_bytes()
         prefixes = (
             [m.span() for m in re.finditer(config.search_prefix.encode(), contents)] if config.search_prefix else []
         )

--- a/cvise/passes/blank.py
+++ b/cvise/passes/blank.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import re
 
 from cvise.passes.hint_based import HintBasedPass
@@ -13,7 +14,7 @@ class BlankPass(HintBasedPass):
     def check_prerequisites(self):
         return True
 
-    def generate_hints(self, test_case):
+    def generate_hints(self, test_case: Path):
         hints = []
         with open(test_case, 'rb') as in_file:
             file_pos = 0

--- a/cvise/passes/clanghints.py
+++ b/cvise/passes/clanghints.py
@@ -49,7 +49,7 @@ class ClangHintsPass(HintBasedPass):
     def check_prerequisites(self):
         return self.check_external_program('clang_delta')
 
-    def new(self, test_case: Path, tmp_dir, job_timeout, *args, **kwargs):
+    def new(self, test_case: Path, tmp_dir: Path, job_timeout, *args, **kwargs):
         # Choose the best standard unless the user provided one.
         std_choices = [self.user_clang_delta_std] if self.user_clang_delta_std else CLANG_STD_CHOICES
         best_std = None

--- a/cvise/passes/clanghints.py
+++ b/cvise/passes/clanghints.py
@@ -1,5 +1,6 @@
 import logging
 import msgspec
+from pathlib import Path
 import shlex
 import subprocess
 import time
@@ -48,7 +49,7 @@ class ClangHintsPass(HintBasedPass):
     def check_prerequisites(self):
         return self.check_external_program('clang_delta')
 
-    def new(self, test_case, tmp_dir, job_timeout, *args, **kwargs):
+    def new(self, test_case: Path, tmp_dir, job_timeout, *args, **kwargs):
         # Choose the best standard unless the user provided one.
         std_choices = [self.user_clang_delta_std] if self.user_clang_delta_std else CLANG_STD_CHOICES
         best_std = None
@@ -84,12 +85,12 @@ class ClangHintsPass(HintBasedPass):
         hint_state = self.new_from_hints(best_bundle, tmp_dir)
         return ClangState.wrap(hint_state, best_std)
 
-    def advance(self, test_case, state):
+    def advance(self, test_case: Path, state):
         new_state = super().advance(test_case, state)
         # Re-attach the remembered standard.
         return ClangState.wrap(new_state, state.clang_std)
 
-    def advance_on_success(self, test_case, state, job_timeout, *args, **kwargs):
+    def advance_on_success(self, test_case: Path, state, job_timeout, *args, **kwargs):
         # Keep using the same standard as the one chosen in new() - repeating the choose procedure on every successful
         # reduction would be too costly.
         try:
@@ -100,13 +101,13 @@ class ClangHintsPass(HintBasedPass):
         new_state = self.advance_on_success_from_hints(hints, state)
         return ClangState.wrap(new_state, state.clang_std)
 
-    def generate_hints_for_standard(self, test_case: str, std: str, timeout: int) -> HintBundle:
+    def generate_hints_for_standard(self, test_case: Path, std: str, timeout: int) -> HintBundle:
         cmd = [
             self.external_programs['clang_delta'],
             f'--transformation={self.arg}',
             f'--std={std}',
             '--generate-hints',
-            test_case,
+            str(test_case),
         ]
 
         logging.debug(shlex.join(str(s) for s in cmd))

--- a/cvise/passes/clex.py
+++ b/cvise/passes/clex.py
@@ -1,35 +1,29 @@
-import os
-import shutil
+from pathlib import Path
 
 from cvise.passes.abstract import AbstractPass, PassResult
-from cvise.utils.misc import CloseableTemporaryFile
 
 
 class ClexPass(AbstractPass):
     def check_prerequisites(self):
         return self.check_external_program('clex')
 
-    def new(self, test_case, *args, **kwargs):
+    def new(self, test_case: Path, *args, **kwargs):
         return 0
 
-    def advance(self, test_case, state):
+    def advance(self, test_case: Path, state):
         return state + 1
 
-    def advance_on_success(self, test_case, state, *args, **kwargs):
+    def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return state
 
-    def transform(self, test_case, state, process_event_notifier):
-        tmp = os.path.dirname(test_case)
-        with CloseableTemporaryFile(mode='w', dir=tmp) as tmp_file:
-            cmd = [self.external_programs['clex'], str(self.arg), str(state), test_case]
-            stdout, _stderr, returncode = process_event_notifier.run_process(cmd)
-            if returncode == 51:
-                tmp_file.write(stdout.decode())
-                tmp_file.close()
-                shutil.copy(tmp_file.name, test_case)
-                return (PassResult.OK, state)
-            else:
-                return (
-                    PassResult.STOP if returncode == 71 else PassResult.ERROR,
-                    state,
-                )
+    def transform(self, test_case: Path, state, process_event_notifier):
+        cmd = [self.external_programs['clex'], str(self.arg), str(state), str(test_case)]
+        stdout, _stderr, returncode = process_event_notifier.run_process(cmd)
+        if returncode == 51:
+            test_case.write_bytes(stdout)
+            return (PassResult.OK, state)
+        else:
+            return (
+                PassResult.STOP if returncode == 71 else PassResult.ERROR,
+                state,
+            )

--- a/cvise/passes/clexhints.py
+++ b/cvise/passes/clexhints.py
@@ -1,4 +1,5 @@
 import msgspec
+from pathlib import Path
 import re
 import subprocess
 
@@ -13,7 +14,7 @@ class ClexHintsPass(HintBasedPass):
     def check_prerequisites(self):
         return self.check_external_program('clex')
 
-    def generate_hints(self, test_case):
+    def generate_hints(self, test_case: Path):
         if self.arg.startswith('rm-toks-'):
             # Note that we don't pass the number of tokens to the parser - its job is just to find each token's
             # boundaries; the number is used for constructing the SubsegmentState instead.

--- a/cvise/passes/comments.py
+++ b/cvise/passes/comments.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import re
 
 from cvise.passes.hint_based import HintBasedPass
@@ -8,10 +9,8 @@ class CommentsPass(HintBasedPass):
     def check_prerequisites(self):
         return True
 
-    def generate_hints(self, test_case):
-        with open(test_case, 'rb') as in_file:
-            prog = in_file.read()
-
+    def generate_hints(self, test_case: Path):
+        prog = test_case.read_bytes()
         hints = []
 
         # Remove all multiline comments - the pattern is:

--- a/cvise/passes/hint_based.py
+++ b/cvise/passes/hint_based.py
@@ -141,7 +141,7 @@ class HintBasedPass(AbstractPass):
         """
         return BinaryState.create(instances=hint_count)
 
-    def new(self, test_case: Path, tmp_dir, *args, **kwargs):
+    def new(self, test_case: Path, tmp_dir: Path, *args, **kwargs):
         hints = self.generate_hints(test_case)
         return self.new_from_hints(hints, tmp_dir)
 

--- a/cvise/passes/hint_based.py
+++ b/cvise/passes/hint_based.py
@@ -141,11 +141,11 @@ class HintBasedPass(AbstractPass):
         """
         return BinaryState.create(instances=hint_count)
 
-    def new(self, test_case, tmp_dir, *args, **kwargs):
+    def new(self, test_case: Path, tmp_dir, *args, **kwargs):
         hints = self.generate_hints(test_case)
         return self.new_from_hints(hints, tmp_dir)
 
-    def transform(self, test_case, state: HintState, *args, **kwargs):
+    def transform(self, test_case: Path, state: HintState, *args, **kwargs):
         self.load_and_apply_hints(test_case, [state])
         return PassResult.OK, state
 
@@ -160,13 +160,13 @@ class HintBasedPass(AbstractPass):
                 load_hints(state.tmp_dir / sub_state.hints_file_name, hints_range_begin, hints_range_end)
             )
         new_data, stats = apply_hints(hint_bundles, test_case)
-        Path(test_case).write_bytes(new_data)
+        test_case.write_bytes(new_data)
         return stats
 
-    def advance(self, test_case, state):
+    def advance(self, test_case: Path, state):
         return state.advance()
 
-    def advance_on_success(self, test_case, state, *args, **kwargs):
+    def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         hints = self.generate_hints(test_case)
         return self.advance_on_success_from_hints(hints, state)
 

--- a/cvise/passes/ifs.py
+++ b/cvise/passes/ifs.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 import re
 import tempfile

--- a/cvise/passes/ifs.py
+++ b/cvise/passes/ifs.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import re
 import tempfile
 
@@ -32,13 +33,13 @@ class IfPass(AbstractPass):
                         in_multiline = True
         return count
 
-    def new(self, test_case, *args, **kwargs):
+    def new(self, test_case: Path, *args, **kwargs):
         bs = BinaryState.create(self.__count_instances(test_case))
         if bs:
             bs.value = 0
         return bs
 
-    def advance(self, test_case, state):
+    def advance(self, test_case: Path, state):
         if state.value == 0:
             state = state.copy()
             state.value = 1
@@ -48,12 +49,11 @@ class IfPass(AbstractPass):
                 state.value = 0
         return state
 
-    def advance_on_success(self, test_case, state, *args, **kwargs):
+    def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return state.advance_on_success(self.__count_instances(test_case))
 
-    def transform(self, test_case, state, process_event_notifier):
-        tmp = os.path.dirname(test_case)
-        with tempfile.NamedTemporaryFile(mode='w+', delete=False, dir=tmp) as tmp_file:
+    def transform(self, test_case: Path, state, process_event_notifier):
+        with tempfile.NamedTemporaryFile(mode='w+', delete=False, dir=test_case.parent) as tmp_file:
             with open(test_case) as in_file:
                 i = 0
                 in_multiline = False
@@ -79,7 +79,7 @@ class IfPass(AbstractPass):
             '2',
             '-k',
             '-o',
-            test_case,
+            str(test_case),
             tmp_file.name,
         ]
         _stdout, _stderr, returncode = process_event_notifier.run_process(cmd)

--- a/cvise/passes/ifs.py
+++ b/cvise/passes/ifs.py
@@ -15,7 +15,7 @@ class IfPass(AbstractPass):
     def __macro_continues(line):
         return line.rstrip().endswith('\\')
 
-    def __count_instances(self, test_case):
+    def __count_instances(self, test_case: Path):
         count = 0
         in_multiline = False
         with open(test_case) as in_file:

--- a/cvise/passes/includeincludes.py
+++ b/cvise/passes/includeincludes.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import re
 import shutil
 import tempfile
@@ -10,19 +11,18 @@ class IncludeIncludesPass(AbstractPass):
     def check_prerequisites(self):
         return True
 
-    def new(self, test_case, *args, **kwargs):
+    def new(self, test_case: Path, *args, **kwargs):
         return 1
 
-    def advance(self, test_case, state):
+    def advance(self, test_case: Path, state):
         return state + 1
 
-    def advance_on_success(self, test_case, state, *args, **kwargs):
+    def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return state
 
-    def transform(self, test_case, state, process_event_notifier):
+    def transform(self, test_case: Path, state, process_event_notifier):
         with open(test_case) as in_file:
-            tmp = os.path.dirname(test_case)
-            with tempfile.NamedTemporaryFile(mode='w+', delete=False, dir=tmp) as tmp_file:
+            with tempfile.NamedTemporaryFile(mode='w+', delete=False, dir=test_case.parent) as tmp_file:
                 includes = 0
                 matched = False
 

--- a/cvise/passes/includes.py
+++ b/cvise/passes/includes.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import re
 import shutil
 import tempfile
@@ -10,18 +11,17 @@ class IncludesPass(AbstractPass):
     def check_prerequisites(self):
         return True
 
-    def new(self, test_case, *args, **kwargs):
+    def new(self, test_case: Path, *args, **kwargs):
         return 1
 
-    def advance(self, test_case, state):
+    def advance(self, test_case: Path, state):
         return state + 1
 
-    def advance_on_success(self, test_case, state, *args, **kwargs):
+    def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return state
 
-    def transform(self, test_case, state, process_event_notifier):
-        tmp = os.path.dirname(test_case)
-        with tempfile.NamedTemporaryFile(mode='w+', delete=False, dir=tmp) as tmp_file:
+    def transform(self, test_case: Path, state, process_event_notifier):
+        with tempfile.NamedTemporaryFile(mode='w+', delete=False, dir=test_case.parent) as tmp_file:
             with open(test_case) as in_file:
                 includes = 0
                 matched = False

--- a/cvise/passes/indent.py
+++ b/cvise/passes/indent.py
@@ -18,12 +18,10 @@ class IndentPass(AbstractPass):
         return state + 1
 
     def transform(self, test_case: Path, state, process_event_notifier):
-        with open(test_case) as in_file:
-            old = in_file.read()
-
         if state != 0:
             return (PassResult.STOP, state)
 
+        old = test_case.read_text()
         cmd = [self.external_programs['clang-format'], '-i']
 
         if self.arg == 'regular':
@@ -37,9 +35,7 @@ class IndentPass(AbstractPass):
         if returncode != 0:
             return (PassResult.ERROR, state)
 
-        with open(test_case) as in_file:
-            new = in_file.read()
-
+        new = test_case.read_text()
         if old == new:
             return (PassResult.STOP, state)
         else:

--- a/cvise/passes/indent.py
+++ b/cvise/passes/indent.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from cvise.passes.abstract import AbstractPass, PassResult
 from cvise.utils.error import UnknownArgumentError
 
@@ -6,16 +8,16 @@ class IndentPass(AbstractPass):
     def check_prerequisites(self):
         return self.check_external_program('clang-format')
 
-    def new(self, test_case, *args, **kwargs):
+    def new(self, test_case: Path, *args, **kwargs):
         return 0
 
-    def advance(self, test_case, state):
+    def advance(self, test_case: Path, state):
         return state + 1
 
-    def advance_on_success(self, test_case, state, *args, **kwargs):
+    def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return state + 1
 
-    def transform(self, test_case, state, process_event_notifier):
+    def transform(self, test_case: Path, state, process_event_notifier):
         with open(test_case) as in_file:
             old = in_file.read()
 
@@ -25,9 +27,9 @@ class IndentPass(AbstractPass):
         cmd = [self.external_programs['clang-format'], '-i']
 
         if self.arg == 'regular':
-            cmd.extend(['-style', '{SpacesInAngles: true}', test_case])
+            cmd.extend(['-style', '{SpacesInAngles: true}', str(test_case)])
         elif self.arg == 'final':
-            cmd.append(test_case)
+            cmd.append(str(test_case))
         else:
             raise UnknownArgumentError(self.__class__.__name__, self.arg)
 

--- a/cvise/passes/line_markers.py
+++ b/cvise/passes/line_markers.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import re
 
 from cvise.passes.hint_based import HintBasedPass
@@ -27,7 +28,7 @@ class LineMarkersPass(HintBasedPass):
     def check_prerequisites(self):
         return True
 
-    def generate_hints(self, test_case):
+    def generate_hints(self, test_case: Path):
         hints = []
         with open(test_case, 'rb') as in_file:
             file_pos = 0

--- a/cvise/passes/lines.py
+++ b/cvise/passes/lines.py
@@ -1,4 +1,5 @@
 import msgspec
+from pathlib import Path
 import subprocess
 
 from cvise.passes.hint_based import HintBasedPass
@@ -9,14 +10,14 @@ class LinesPass(HintBasedPass):
     def check_prerequisites(self):
         return self.check_external_program('topformflat_hints')
 
-    def generate_hints(self, test_case):
+    def generate_hints(self, test_case: Path):
         if self.arg == 'None':
             # None means no topformflat
             return self.generate_hints_for_text_lines(test_case)
         else:
             return self.generate_topformflat_hints(test_case)
 
-    def generate_hints_for_text_lines(self, test_case: str) -> HintBundle:
+    def generate_hints_for_text_lines(self, test_case: Path) -> HintBundle:
         """Generate a hint per each line in the input as written."""
         hints = []
         with open(test_case, 'rb') as in_file:
@@ -27,7 +28,7 @@ class LinesPass(HintBasedPass):
                 file_pos = end_pos
         return HintBundle(hints=hints)
 
-    def generate_topformflat_hints(self, test_case: str) -> HintBundle:
+    def generate_topformflat_hints(self, test_case: Path) -> HintBundle:
         """Generate hints via the modified topformflat tool.
 
         A single hint here is, roughly, a curly brace surrounded block at the

--- a/cvise/passes/peep.py
+++ b/cvise/passes/peep.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import re
 
 from cvise.passes.abstract import AbstractPass, PassResult
@@ -174,10 +175,10 @@ class PeepPass(AbstractPass):
     def check_prerequisites(self):
         return True
 
-    def new(self, test_case, *args, **kwargs):
+    def new(self, test_case: Path, *args, **kwargs):
         return {'pos': 0, 'regex': 0}
 
-    def advance(self, test_case, state):
+    def advance(self, test_case: Path, state):
         new_state = state.copy()
 
         if self.arg == 'a':
@@ -202,10 +203,10 @@ class PeepPass(AbstractPass):
 
         return new_state
 
-    def advance_on_success(self, test_case, state, *args, **kwargs):
+    def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return state
 
-    def transform(self, test_case, state, process_event_notifier):
+    def transform(self, test_case: Path, state, process_event_notifier):
         with open(test_case) as in_file:
             prog = in_file.read()
             prog2 = prog

--- a/cvise/passes/peep.py
+++ b/cvise/passes/peep.py
@@ -196,10 +196,9 @@ class PeepPass(AbstractPass):
             new_state['regex'] = 0
             new_state['pos'] += 1
 
-        with open(test_case) as in_file:
-            length = len(in_file.read())
-            if new_state['pos'] >= length:
-                return None
+        length = len(test_case.read_text())
+        if new_state['pos'] >= length:
+            return None
 
         return new_state
 
@@ -207,9 +206,8 @@ class PeepPass(AbstractPass):
         return state
 
     def transform(self, test_case: Path, state, process_event_notifier):
-        with open(test_case) as in_file:
-            prog = in_file.read()
-            prog2 = prog
+        prog = test_case.read_text()
+        prog2 = prog
 
         if state['pos'] > len(prog):
             return (PassResult.STOP, state)
@@ -225,9 +223,7 @@ class PeepPass(AbstractPass):
                 prog2 = prog2[0 : m['all'][0]] + replace + prog2[m['all'][1] :]
 
                 if prog != prog2:
-                    with open(test_case, 'w') as out_file:
-                        out_file.write(prog2)
-
+                    test_case.write_text(prog2)
                     return (PassResult.OK, state)
         elif self.arg == 'b':
             item = self.delimited_regexes_to_replace[state['regex']]
@@ -252,9 +248,7 @@ class PeepPass(AbstractPass):
                 prog2 = prog2[0 : m['delim1'][1]] + replace + prog2[m['delim2'][0] :]
 
                 if prog != prog2:
-                    with open(test_case, 'w') as out_file:
-                        out_file.write(prog2)
-
+                    test_case.write_text(prog2)
                     return (PassResult.OK, state)
         elif self.arg == 'c':
             search = [
@@ -275,9 +269,7 @@ class PeepPass(AbstractPass):
                 prog2 = prog2[0 : m['all'][0]] + body + prog2[m['all'][1] :]
 
                 if prog != prog2:
-                    with open(test_case, 'w') as out_file:
-                        out_file.write(prog2)
-
+                    test_case.write_text(prog2)
                     return (PassResult.OK, state)
         else:
             raise UnknownArgumentError(self.__class__.__name__, self.arg)

--- a/cvise/passes/special.py
+++ b/cvise/passes/special.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import re
 
 from cvise.passes.abstract import AbstractPass, PassResult
@@ -34,7 +35,7 @@ class SpecialPass(AbstractPass):
 
         return config
 
-    def __get_next_match(self, test_case, pos):
+    def __get_next_match(self, test_case: Path, pos):
         with open(test_case) as in_file:
             prog = in_file.read()
 
@@ -44,7 +45,7 @@ class SpecialPass(AbstractPass):
 
         return m
 
-    def new(self, test_case, *args, **kwargs):
+    def new(self, test_case: Path, *args, **kwargs):
         config = self.__get_config()
         with open(test_case) as in_file:
             prog = in_file.read()
@@ -54,17 +55,17 @@ class SpecialPass(AbstractPass):
                 return None
             return {'modifications': modifications, 'index': 0}
 
-    def advance(self, test_case, state):
+    def advance(self, test_case: Path, state):
         state = state.copy()
         state['index'] += 1
         if state['index'] >= len(state['modifications']):
             return None
         return state
 
-    def advance_on_success(self, test_case, state, *args, **kwargs):
+    def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return self.new(test_case)
 
-    def transform(self, test_case, state, process_event_notifier):
+    def transform(self, test_case: Path, state, process_event_notifier):
         with open(test_case) as in_file:
             data = in_file.read()
             index = state['index']

--- a/cvise/passes/ternary.py
+++ b/cvise/passes/ternary.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from cvise.passes.abstract import AbstractPass, PassResult
 from cvise.utils import nestedmatcher
 from cvise.utils.error import UnknownArgumentError
@@ -25,7 +27,7 @@ class TernaryPass(AbstractPass):
     def check_prerequisites(self):
         return True
 
-    def __get_next_match(self, test_case, pos):
+    def __get_next_match(self, test_case: Path, pos):
         with open(test_case) as in_file:
             prog = in_file.read()
 
@@ -33,19 +35,18 @@ class TernaryPass(AbstractPass):
 
         return m
 
-    def new(self, test_case, *args, **kwargs):
+    def new(self, test_case: Path, *args, **kwargs):
         return self.__get_next_match(test_case, pos=0)
 
-    def advance(self, test_case, state):
+    def advance(self, test_case: Path, state):
         return self.__get_next_match(test_case, pos=state['all'][0] + 1)
 
-    def advance_on_success(self, test_case, state, *args, **kwargs):
+    def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return self.__get_next_match(test_case, pos=state['all'][0])
 
-    def transform(self, test_case, state, process_event_notifier):
-        with open(test_case) as in_file:
-            prog = in_file.read()
-            prog2 = prog
+    def transform(self, test_case: Path, state, process_event_notifier):
+        prog = test_case.read_text()
+        prog2 = prog
 
         while True:
             if state is None:
@@ -61,9 +62,7 @@ class TernaryPass(AbstractPass):
                 )
 
                 if prog != prog2:
-                    with open(test_case, 'w') as out_file:
-                        out_file.write(prog2)
-
+                    test_case.write_text(prog2)
                     return (PassResult.OK, state)
                 else:
                     state = self.advance(test_case, state)

--- a/cvise/passes/ternary.py
+++ b/cvise/passes/ternary.py
@@ -28,11 +28,8 @@ class TernaryPass(AbstractPass):
         return True
 
     def __get_next_match(self, test_case: Path, pos):
-        with open(test_case) as in_file:
-            prog = in_file.read()
-
+        prog = test_case.read_text()
         m = nestedmatcher.search(self.parts, prog, pos=pos)
-
         return m
 
     def new(self, test_case: Path, *args, **kwargs):

--- a/cvise/passes/treesitter.py
+++ b/cvise/passes/treesitter.py
@@ -1,4 +1,5 @@
 import msgspec
+from pathlib import Path
 import subprocess
 
 from cvise.passes.hint_based import HintBasedPass
@@ -11,11 +12,11 @@ class TreeSitterPass(HintBasedPass):
     def check_prerequisites(self):
         return self.check_external_program('treesitter_delta')
 
-    def generate_hints(self, test_case):
+    def generate_hints(self, test_case: Path):
         cmd = [
             self.external_programs['treesitter_delta'],
             self.arg,
-            test_case,
+            str(test_case),
         ]
         proc = subprocess.run(cmd, text=True, capture_output=True)
 

--- a/cvise/passes/unifdef.py
+++ b/cvise/passes/unifdef.py
@@ -1,5 +1,4 @@
 import filecmp
-import os
 from pathlib import Path
 import shutil
 import subprocess
@@ -36,13 +35,14 @@ class UnIfDefPass(AbstractPass):
         deflist = sorted(defs.keys())
 
         with tempfile.NamedTemporaryFile(mode='w+', delete=False, dir=test_case.parent) as tmp_file:
+            tmp_path = Path(tmp_file.name)
             tmp_file.close()
             while True:
                 du = '-D' if state % 2 == 0 else '-U'
                 n_index = int(state / 2)
 
                 if n_index >= len(deflist):
-                    os.unlink(tmp_file.name)
+                    tmp_path.unlink()
                     return (PassResult.STOP, state)
 
                 def_ = deflist[n_index]
@@ -61,9 +61,9 @@ class UnIfDefPass(AbstractPass):
                 if returncode != 0:
                     return (PassResult.ERROR, state)
 
-                if filecmp.cmp(test_case, Path(tmp_file.name), shallow=False):
+                if filecmp.cmp(test_case, tmp_path, shallow=False):
                     state += 1
                     continue
 
-                shutil.move(Path(tmp_file.name), test_case)
+                shutil.move(tmp_path, test_case)
                 return (PassResult.OK, state)

--- a/cvise/tests/test_balanced.py
+++ b/cvise/tests/test_balanced.py
@@ -9,169 +9,121 @@ from cvise.tests.testabstract import collect_all_transforms
 
 class BalancedParensTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir_ = self.enterContext(tempfile.TemporaryDirectory())
+        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = BalancedPass('parens')
 
     def test_parens_no_match(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This is a simple test!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This is a simple test!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         assert state is None
 
-        tmp_path.unlink()
-
     def test_parens_simple(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This is a (simple) test!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This is a (simple) test!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'This is a  test!\n')
 
     def test_parens_nested_outer(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This (is a (simple) test)!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This (is a (simple) test)!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'This !\n')
 
     def test_parens_nested_inner(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This (is a (simple) test)!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This (is a (simple) test)!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         # Transform failed
-        state = self.pass_.advance(tmp_path, state)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.advance(self.input_path, state)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'This (is a  test)!\n')
 
 
 class BalancedParensOnlyTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir_ = self.enterContext(tempfile.TemporaryDirectory())
+        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = BalancedPass('parens-only')
 
     def test_parens_no_match(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This is a simple test!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This is a simple test!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         assert state is None
 
-        tmp_path.unlink()
-
     def test_parens_simple(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This is a (simple) test!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This is a (simple) test!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'This is a simple test!\n')
 
     def test_parens_nested_outer(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This (is a (simple) test)!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This (is a (simple) test)!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
-        all_transforms = collect_all_transforms(self.pass_, state, tmp_path)
-
-        tmp_path.unlink()
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
+        all_transforms = collect_all_transforms(self.pass_, state, self.input_path)
 
         self.assertIn(b'This is a (simple) test!\n', all_transforms)
         self.assertIn(b'This is a (simple) test!\n', all_transforms)
         self.assertIn(b'This is a simple test!\n', all_transforms)
 
     def test_parens_nested_inner(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This (is a (simple) test)!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This (is a (simple) test)!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         # Transform failed
-        state = self.pass_.advance(tmp_path, state)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.advance(self.input_path, state)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'This (is a simple test)!\n')
 
     def test_parens_nested_both(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This (is a (simple) test)!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This (is a (simple) test)!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
-        all_transforms = collect_all_transforms(self.pass_, state, tmp_path)
-
-        tmp_path.unlink()
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
+        all_transforms = collect_all_transforms(self.pass_, state, self.input_path)
 
         self.assertIn(b'This (is a simple test)!\n', all_transforms)
         self.assertIn(b'This is a (simple) test!\n', all_transforms)
         self.assertIn(b'This is a simple test!\n', all_transforms)
 
     def test_parens_nested_all(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('(This) (is a (((more)) complex) test)!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('(This) (is a (((more)) complex) test)!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
-        (result, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
+        (result, state) = self.pass_.transform(self.input_path, state, None)
 
         iteration = 0
 
         while result == PassResult.OK:
-            state = self.pass_.advance_on_success(tmp_path, state)
+            state = self.pass_.advance_on_success(self.input_path, state)
             if state is None:
                 break
-            (result, state) = self.pass_.transform(tmp_path, state, None)
+            (result, state) = self.pass_.transform(self.input_path, state, None)
             iteration += 1
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'This is a more complex test!\n')
 
     def test_parens_nested_no_success(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('(This) (is a (((more)) complex) test)!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('(This) (is a (((more)) complex) test)!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
-        all_transforms = collect_all_transforms(self.pass_, state, tmp_path)
-
-        tmp_path.unlink()
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
+        all_transforms = collect_all_transforms(self.pass_, state, self.input_path)
 
         self.assertIn(b'This (is a (((more)) complex) test)!\n', all_transforms)
         self.assertIn(b'(This) (is a ((more) complex) test)!\n', all_transforms)
@@ -182,85 +134,59 @@ class BalancedParensOnlyTestCase(unittest.TestCase):
 
 class BalancedParensInsideTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir_ = self.enterContext(tempfile.TemporaryDirectory())
+        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = BalancedPass('parens-inside')
 
     def test_parens_no_match(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This is a simple test!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This is a simple test!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         assert state is None
 
-        tmp_path.unlink()
-
     def test_parens_simple(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This is a (simple) test!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This is a (simple) test!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'This is a () test!\n')
 
     def test_parens_nested_outer(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This (is a (simple) test)!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This (is a (simple) test)!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'This ()!\n')
 
     def test_parens_nested_inner(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This (is a (simple) test)!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This (is a (simple) test)!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         # Transform failed
-        state = self.pass_.advance(tmp_path, state)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.advance(self.input_path, state)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'This (is a () test)!\n')
 
     def test_parens_nested_both(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This (is a (simple) test)!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This (is a (simple) test)!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
-        all_transforms = collect_all_transforms(self.pass_, state, tmp_path)
-
-        tmp_path.unlink()
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
+        all_transforms = collect_all_transforms(self.pass_, state, self.input_path)
 
         self.assertIn(b'This (is a () test)!\n', all_transforms)
         self.assertIn(b'This ()!\n', all_transforms)
 
     def test_parens_nested_all(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('(This) (is a (((more)) complex) test)!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('(This) (is a (((more)) complex) test)!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
-        all_transforms = collect_all_transforms(self.pass_, state, tmp_path)
-
-        tmp_path.unlink()
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
+        all_transforms = collect_all_transforms(self.pass_, state, self.input_path)
 
         self.assertIn(b'() (is a (((more)) complex) test)!\n', all_transforms)
         self.assertIn(b'(This) (is a ((()) complex) test)!\n', all_transforms)
@@ -270,14 +196,10 @@ class BalancedParensInsideTestCase(unittest.TestCase):
         self.assertIn(b'() ()!\n', all_transforms)
 
     def test_parens_nested_no_success(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('(This) (is a (((more)) complex) test)!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('(This) (is a (((more)) complex) test)!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
-        all_transforms = collect_all_transforms(self.pass_, state, tmp_path)
-
-        tmp_path.unlink()
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
+        all_transforms = collect_all_transforms(self.pass_, state, self.input_path)
 
         self.assertIn(b'() (is a (((more)) complex) test)!\n', all_transforms)
         self.assertIn(b'(This) (is a ((()) complex) test)!\n', all_transforms)
@@ -289,72 +211,52 @@ class BalancedParensInsideTestCase(unittest.TestCase):
 
 class BalancedParensToZeroTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir_ = self.enterContext(tempfile.TemporaryDirectory())
+        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = BalancedPass('parens-to-zero')
 
     def test_no_match(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This is a simple test!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This is a simple test!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         assert state is None
 
-        tmp_path.unlink()
-
     def test_simple(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('int x = (10 + y) / 2;\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('int x = (10 + y) / 2;\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'int x = 0 / 2;\n')
 
 
 class BalancedCurly3TestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir_ = self.enterContext(tempfile.TemporaryDirectory())
+        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = BalancedPass('curly3')
 
     def test_no_match(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This is a simple test!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This is a simple test!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         assert state is None
 
-        tmp_path.unlink()
-
     def test_simple(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('A a = { x, y };\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('A a = { x, y };\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'A a ;\n')
 
     def test_nested(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('={  = {}};\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('={  = {}};\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
-        all_transforms = collect_all_transforms(self.pass_, state, tmp_path)
-
-        tmp_path.unlink()
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
+        all_transforms = collect_all_transforms(self.pass_, state, self.input_path)
 
         self.assertIn(b'={  };\n', all_transforms)
         self.assertIn(b';\n', all_transforms)

--- a/cvise/tests/test_balanced.py
+++ b/cvise/tests/test_balanced.py
@@ -16,53 +16,54 @@ class BalancedParensTestCase(unittest.TestCase):
     def test_parens_no_match(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This is a simple test!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
         assert state is None
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
     def test_parens_simple(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This is a (simple) test!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'This is a  test!\n')
 
     def test_parens_nested_outer(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This (is a (simple) test)!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'This !\n')
 
     def test_parens_nested_inner(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This (is a (simple) test)!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
         # Transform failed
         state = self.pass_.advance(tmp_file.name, state)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'This (is a  test)!\n')
 
@@ -75,34 +76,36 @@ class BalancedParensOnlyTestCase(unittest.TestCase):
     def test_parens_no_match(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This is a simple test!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
         assert state is None
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
     def test_parens_simple(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This is a (simple) test!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'This is a simple test!\n')
 
     def test_parens_nested_outer(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This (is a (simple) test)!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
-        all_transforms = collect_all_transforms(self.pass_, state, Path(tmp_file.name))
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        all_transforms = collect_all_transforms(self.pass_, state, tmp_path)
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertIn(b'This is a (simple) test!\n', all_transforms)
         self.assertIn(b'This is a (simple) test!\n', all_transforms)
@@ -111,27 +114,28 @@ class BalancedParensOnlyTestCase(unittest.TestCase):
     def test_parens_nested_inner(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This (is a (simple) test)!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
         # Transform failed
         state = self.pass_.advance(tmp_file.name, state)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'This (is a simple test)!\n')
 
     def test_parens_nested_both(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This (is a (simple) test)!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
-        all_transforms = collect_all_transforms(self.pass_, state, Path(tmp_file.name))
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        all_transforms = collect_all_transforms(self.pass_, state, tmp_path)
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertIn(b'This (is a simple test)!\n', all_transforms)
         self.assertIn(b'This is a (simple) test!\n', all_transforms)
@@ -140,9 +144,10 @@ class BalancedParensOnlyTestCase(unittest.TestCase):
     def test_parens_nested_all(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('(This) (is a (((more)) complex) test)!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
-        (result, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        (result, state) = self.pass_.transform(tmp_path, state, None)
 
         iteration = 0
 
@@ -150,24 +155,24 @@ class BalancedParensOnlyTestCase(unittest.TestCase):
             state = self.pass_.advance_on_success(tmp_file.name, state)
             if state is None:
                 break
-            (result, state) = self.pass_.transform(tmp_file.name, state, None)
+            (result, state) = self.pass_.transform(tmp_path, state, None)
             iteration += 1
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'This is a more complex test!\n')
 
     def test_parens_nested_no_success(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('(This) (is a (((more)) complex) test)!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
-        all_transforms = collect_all_transforms(self.pass_, state, Path(tmp_file.name))
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        all_transforms = collect_all_transforms(self.pass_, state, tmp_path)
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertIn(b'This (is a (((more)) complex) test)!\n', all_transforms)
         self.assertIn(b'(This) (is a ((more) complex) test)!\n', all_transforms)
@@ -184,64 +189,66 @@ class BalancedParensInsideTestCase(unittest.TestCase):
     def test_parens_no_match(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This is a simple test!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
         assert state is None
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
     def test_parens_simple(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This is a (simple) test!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'This is a () test!\n')
 
     def test_parens_nested_outer(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This (is a (simple) test)!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'This ()!\n')
 
     def test_parens_nested_inner(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This (is a (simple) test)!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
         # Transform failed
         state = self.pass_.advance(tmp_file.name, state)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'This (is a () test)!\n')
 
     def test_parens_nested_both(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This (is a (simple) test)!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
-        all_transforms = collect_all_transforms(self.pass_, state, Path(tmp_file.name))
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        all_transforms = collect_all_transforms(self.pass_, state, tmp_path)
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertIn(b'This (is a () test)!\n', all_transforms)
         self.assertIn(b'This ()!\n', all_transforms)
@@ -249,11 +256,12 @@ class BalancedParensInsideTestCase(unittest.TestCase):
     def test_parens_nested_all(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('(This) (is a (((more)) complex) test)!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
-        all_transforms = collect_all_transforms(self.pass_, state, Path(tmp_file.name))
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        all_transforms = collect_all_transforms(self.pass_, state, tmp_path)
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertIn(b'() (is a (((more)) complex) test)!\n', all_transforms)
         self.assertIn(b'(This) (is a ((()) complex) test)!\n', all_transforms)
@@ -265,11 +273,12 @@ class BalancedParensInsideTestCase(unittest.TestCase):
     def test_parens_nested_no_success(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('(This) (is a (((more)) complex) test)!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
-        all_transforms = collect_all_transforms(self.pass_, state, Path(tmp_file.name))
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        all_transforms = collect_all_transforms(self.pass_, state, tmp_path)
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertIn(b'() (is a (((more)) complex) test)!\n', all_transforms)
         self.assertIn(b'(This) (is a ((()) complex) test)!\n', all_transforms)
@@ -287,23 +296,24 @@ class BalancedParensToZeroTestCase(unittest.TestCase):
     def test_no_match(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This is a simple test!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
         assert state is None
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
     def test_simple(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('int x = (10 + y) / 2;\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'int x = 0 / 2;\n')
 
@@ -316,34 +326,36 @@ class BalancedCurly3TestCase(unittest.TestCase):
     def test_no_match(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This is a simple test!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
         assert state is None
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
     def test_simple(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('A a = { x, y };\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'A a ;\n')
 
     def test_nested(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('={  = {}};\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
-        all_transforms = collect_all_transforms(self.pass_, state, Path(tmp_file.name))
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        all_transforms = collect_all_transforms(self.pass_, state, tmp_path)
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertIn(b'={  };\n', all_transforms)
         self.assertIn(b';\n', all_transforms)

--- a/cvise/tests/test_balanced.py
+++ b/cvise/tests/test_balanced.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 import tempfile
 import unittest
@@ -58,7 +57,7 @@ class BalancedParensTestCase(unittest.TestCase):
 
         state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
         # Transform failed
-        state = self.pass_.advance(tmp_file.name, state)
+        state = self.pass_.advance(tmp_path, state)
         (_, state) = self.pass_.transform(tmp_path, state, None)
 
         variant = tmp_path.read_text()
@@ -118,7 +117,7 @@ class BalancedParensOnlyTestCase(unittest.TestCase):
 
         state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
         # Transform failed
-        state = self.pass_.advance(tmp_file.name, state)
+        state = self.pass_.advance(tmp_path, state)
         (_, state) = self.pass_.transform(tmp_path, state, None)
 
         variant = tmp_path.read_text()
@@ -152,7 +151,7 @@ class BalancedParensOnlyTestCase(unittest.TestCase):
         iteration = 0
 
         while result == PassResult.OK:
-            state = self.pass_.advance_on_success(tmp_file.name, state)
+            state = self.pass_.advance_on_success(tmp_path, state)
             if state is None:
                 break
             (result, state) = self.pass_.transform(tmp_path, state, None)
@@ -231,7 +230,7 @@ class BalancedParensInsideTestCase(unittest.TestCase):
 
         state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
         # Transform failed
-        state = self.pass_.advance(tmp_file.name, state)
+        state = self.pass_.advance(tmp_path, state)
         (_, state) = self.pass_.transform(tmp_path, state, None)
 
         variant = tmp_path.read_text()

--- a/cvise/tests/test_blank.py
+++ b/cvise/tests/test_blank.py
@@ -58,7 +58,7 @@ def test_no_different_type_removals(tmp_path: Path, input_path: Path):
     assert b'z\n' not in all_transforms  # no removal of both
 
 
-def test_non_utf8(tmp_path, input_path):
+def test_non_utf8(tmp_path: Path, input_path: Path):
     input_path.write_bytes(
         b"""
         // \xff

--- a/cvise/tests/test_clanghints.py
+++ b/cvise/tests/test_clanghints.py
@@ -5,17 +5,18 @@ tests in clang_delta/tests/test_clang_delta.py."""
 
 from pathlib import Path
 import subprocess
+from typing import Any, Tuple
 
 from cvise.passes.clanghints import ClangHintsPass
 from cvise.tests.testabstract import collect_all_transforms, validate_stored_hints
 from cvise.utils.externalprograms import find_external_programs
 
 
-def get_data_path(testcase):
+def get_data_path(testcase: str) -> Path:
     return Path(__file__).parent.parent.parent / 'clang_delta' / 'tests' / testcase
 
 
-def init_pass(transformation, tmp_dir, input_path):
+def init_pass(transformation: str, tmp_dir: Path, input_path: Path) -> Tuple[ClangHintsPass, Any]:
     pass_ = ClangHintsPass(transformation, find_external_programs())
     pass_.user_clang_delta_std = None
     state = pass_.new(input_path, tmp_dir=tmp_dir, job_timeout=100)
@@ -23,7 +24,7 @@ def init_pass(transformation, tmp_dir, input_path):
     return pass_, state
 
 
-def test_class(tmp_path):
+def test_class(tmp_path: Path):
     input_path = get_data_path('remove-unused-function/class.cc')
     p, state = init_pass('remove-unused-function', tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
@@ -32,7 +33,7 @@ def test_class(tmp_path):
     assert expected_path.read_bytes() in all_transforms
 
 
-def test_const(tmp_path):
+def test_const(tmp_path: Path):
     input_path = get_data_path('remove-unused-function/const.cc')
     p, state = init_pass('remove-unused-function', tmp_path, input_path)
     all_transforms = collect_all_transforms(p, state, input_path)
@@ -41,14 +42,14 @@ def test_const(tmp_path):
     assert get_data_path('remove-unused-function/const.output2').read_bytes() in all_transforms
 
 
-def test_inline_ns(tmp_path):
+def test_inline_ns(tmp_path: Path):
     input_path = get_data_path('remove-unused-function/inline_ns.cc')
     p, state = init_pass('remove-unused-function', tmp_path, input_path)
 
     assert state is None
 
 
-def test_malformed_code(tmp_path):
+def test_malformed_code(tmp_path: Path):
     input_path = tmp_path / 'input.cc'
     input_path.write_text('!?badbadbad@#')
     p, state = init_pass('remove-unused-function', tmp_path, input_path)
@@ -56,7 +57,7 @@ def test_malformed_code(tmp_path):
     assert state is None
 
 
-def test_clang_delta_crash(tmp_path, monkeypatch):
+def test_clang_delta_crash(tmp_path: Path, monkeypatch):
     """Test the case of clang_delta crashing.
 
     We simulate this by patching the subprocess API to return a nonzero exit code and an empty output."""
@@ -72,7 +73,7 @@ def test_clang_delta_crash(tmp_path, monkeypatch):
     assert state is None
 
 
-def test_clang_delta_timeout(tmp_path, monkeypatch):
+def test_clang_delta_timeout(tmp_path: Path, monkeypatch):
     """Test the case of clang_delta timing out.
 
     We simulate this by patching the subprocess API to raise a timeout error."""

--- a/cvise/tests/test_clexhints.py
+++ b/cvise/tests/test_clexhints.py
@@ -1,4 +1,6 @@
+from pathlib import Path
 import pytest
+from typing import Any, List, Tuple
 
 from cvise.passes.abstract import SubsegmentState
 from cvise.passes.clexhints import ClexHintsPass
@@ -104,18 +106,18 @@ TOKENS_REMOVED_8 = [
 
 
 @pytest.fixture
-def input_path(tmp_path):
+def input_path(tmp_path: Path) -> Path:
     return tmp_path / 'input.cc'
 
 
-def init_pass(arg, tmp_dir, input_path):
+def init_pass(arg, tmp_dir: Path, input_path: Path) -> Tuple[ClexHintsPass, Any]:
     pass_ = ClexHintsPass(arg, find_external_programs())
     state = pass_.new(input_path, tmp_dir=tmp_dir)
     validate_stored_hints(state)
     return pass_, state
 
 
-def test_rm_toks_1(tmp_path, input_path):
+def test_rm_toks_1(tmp_path: Path, input_path: Path):
     """Test that the "rm-toks" pass with parameter "1" deletes individual tokens."""
     input_path.write_text(INPUT)
     p, state = init_pass('rm-toks-1-to-1', tmp_path, input_path)
@@ -124,7 +126,7 @@ def test_rm_toks_1(tmp_path, input_path):
     assert set(TOKENS_REMOVED_1) == all_transforms
 
 
-def test_rm_toks_2(tmp_path, input_path):
+def test_rm_toks_2(tmp_path: Path, input_path: Path):
     """Test that the "rm-toks" pass with parameter "2" additionally deletes pairs of consecutive tokens."""
     input_path.write_text(INPUT)
     p, state = init_pass('rm-toks-2-to-2', tmp_path, input_path)
@@ -133,7 +135,7 @@ def test_rm_toks_2(tmp_path, input_path):
     assert set(TOKENS_REMOVED_2) == all_transforms
 
 
-def test_rm_toks_1_to_2(tmp_path, input_path):
+def test_rm_toks_1_to_2(tmp_path: Path, input_path: Path):
     """Test that the "rm-toks" pass with parameter "1 to 2" additionally deletes pairs of consecutive tokens."""
     input_path.write_text(INPUT)
     p, state = init_pass('rm-toks-1-to-2', tmp_path, input_path)
@@ -142,7 +144,7 @@ def test_rm_toks_1_to_2(tmp_path, input_path):
     assert set(TOKENS_REMOVED_1) | set(TOKENS_REMOVED_2) == all_transforms
 
 
-def test_rm_toks_16_shorter(tmp_path, input_path):
+def test_rm_toks_16_shorter(tmp_path: Path, input_path: Path):
     """Test that the "rm-toks" pass with parameter "1 to 16" removes all tokens when there's less than 16 of them."""
     input_path.write_text(INPUT)
     p, state = init_pass('rm-toks-1-to-16', tmp_path, input_path)
@@ -153,7 +155,7 @@ def test_rm_toks_16_shorter(tmp_path, input_path):
     assert set(TOKENS_REMOVED_1) <= all_transforms
 
 
-def collect_all_advances(s):
+def collect_all_advances(s: Any) -> List[Any]:
     observed = []
     while s is not None:
         observed.append((s.index, s.end()))

--- a/cvise/tests/test_comments.py
+++ b/cvise/tests/test_comments.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import tempfile
 import unittest
 
@@ -15,84 +16,84 @@ class CommentsTestCase(unittest.TestCase):
     def test_block(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This /* contains *** /* two */ /*comments*/!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
         validate_stored_hints(state)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'This  !\n')
 
     def test_line(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('This ///contains //two\n //comments\n!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
         validate_stored_hints(state)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'This \n \n!\n')
 
     def test_success(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('/*This*/ ///contains //two\n //comments\n!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
         validate_stored_hints(state)
-        (result, state) = self.pass_.transform(tmp_file.name, state, None)
+        (result, state) = self.pass_.transform(tmp_path, state, None)
 
         while result == PassResult.OK and state is not None:
-            state = self.pass_.advance_on_success(tmp_file.name, state)
+            state = self.pass_.advance_on_success(tmp_path, state)
             if state is None:
                 break
-            (result, state) = self.pass_.transform(tmp_file.name, state, None)
+            (result, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, ' \n \n!\n')
 
     def test_no_success(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('/*This*/ ///contains //two\n //comments\n!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
         validate_stored_hints(state)
-        (result, state) = self.pass_.transform(tmp_file.name, state, None)
+        (result, state) = self.pass_.transform(tmp_path, state, None)
 
         while result == PassResult.OK and state is not None:
-            with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-                tmp_file.write('/*This*/ ///contains //two\n //comments\n!\n')
+            tmp_path.write_text('/*This*/ ///contains //two\n //comments\n!\n')
 
-            state = self.pass_.advance(tmp_file.name, state)
+            state = self.pass_.advance(tmp_path, state)
             if state is None:
                 break
-            (result, state) = self.pass_.transform(tmp_file.name, state, None)
+            (result, state) = self.pass_.transform(tmp_path, state, None)
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
     def test_non_ascii(self):
         with tempfile.NamedTemporaryFile(mode='wb', delete=False) as tmp_file:
             tmp_file.write(b'int x;\n// Streichholzsch\xc3\xa4chtelchen\nchar t[] = "nonutf\xff";\n// \xff\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
         validate_stored_hints(state)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name, 'rb') as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_bytes()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, b'int x;\n\nchar t[] = "nonutf\xff";\n\n')

--- a/cvise/tests/test_comments.py
+++ b/cvise/tests/test_comments.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 import tempfile
 import unittest

--- a/cvise/tests/test_comments.py
+++ b/cvise/tests/test_comments.py
@@ -9,90 +9,67 @@ from cvise.tests.testabstract import validate_stored_hints
 
 class CommentsTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir_ = self.enterContext(tempfile.TemporaryDirectory())
+        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = CommentsPass()
 
     def test_block(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This /* contains *** /* two */ /*comments*/!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This /* contains *** /* two */ /*comments*/!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         validate_stored_hints(state)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'This  !\n')
 
     def test_line(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('This ///contains //two\n //comments\n!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('This ///contains //two\n //comments\n!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         validate_stored_hints(state)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'This \n \n!\n')
 
     def test_success(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('/*This*/ ///contains //two\n //comments\n!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('/*This*/ ///contains //two\n //comments\n!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         validate_stored_hints(state)
-        (result, state) = self.pass_.transform(tmp_path, state, None)
+        (result, state) = self.pass_.transform(self.input_path, state, None)
 
         while result == PassResult.OK and state is not None:
-            state = self.pass_.advance_on_success(tmp_path, state)
+            state = self.pass_.advance_on_success(self.input_path, state)
             if state is None:
                 break
-            (result, state) = self.pass_.transform(tmp_path, state, None)
+            (result, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, ' \n \n!\n')
 
     def test_no_success(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('/*This*/ ///contains //two\n //comments\n!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('/*This*/ ///contains //two\n //comments\n!\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         validate_stored_hints(state)
-        (result, state) = self.pass_.transform(tmp_path, state, None)
+        (result, state) = self.pass_.transform(self.input_path, state, None)
 
         while result == PassResult.OK and state is not None:
-            tmp_path.write_text('/*This*/ ///contains //two\n //comments\n!\n')
+            self.input_path.write_text('/*This*/ ///contains //two\n //comments\n!\n')
 
-            state = self.pass_.advance(tmp_path, state)
+            state = self.pass_.advance(self.input_path, state)
             if state is None:
                 break
-            (result, state) = self.pass_.transform(tmp_path, state, None)
-
-        tmp_path.unlink()
+            (result, state) = self.pass_.transform(self.input_path, state, None)
 
     def test_non_ascii(self):
-        with tempfile.NamedTemporaryFile(mode='wb', delete=False) as tmp_file:
-            tmp_file.write(b'int x;\n// Streichholzsch\xc3\xa4chtelchen\nchar t[] = "nonutf\xff";\n// \xff\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_bytes(b'int x;\n// Streichholzsch\xc3\xa4chtelchen\nchar t[] = "nonutf\xff";\n// \xff\n')
 
-        state = self.pass_.new(tmp_path, tmp_dir=self.tmp_dir_)
+        state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         validate_stored_hints(state)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_bytes()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_bytes()
         self.assertEqual(variant, b'int x;\n\nchar t[] = "nonutf\xff";\n\n')

--- a/cvise/tests/test_hint.py
+++ b/cvise/tests/test_hint.py
@@ -7,7 +7,7 @@ from cvise.utils.hint import apply_hints, HintBundle, load_hints, store_hints, H
 
 
 @pytest.fixture
-def tmp_file(tmp_path) -> Path:
+def tmp_file(tmp_path: Path) -> Path:
     return tmp_path / 'file.txt'
 
 

--- a/cvise/tests/test_hint.py
+++ b/cvise/tests/test_hint.py
@@ -1,21 +1,22 @@
 import json
 import jsonschema
+from pathlib import Path
 import pytest
 
 from cvise.utils.hint import apply_hints, HintBundle, load_hints, store_hints, HINT_SCHEMA
 
 
 @pytest.fixture
-def tmp_file(tmp_path):
+def tmp_file(tmp_path) -> Path:
     return tmp_path / 'file.txt'
 
 
 @pytest.fixture
-def tmp_hints_file(tmp_path):
+def tmp_hints_file(tmp_path: Path) -> Path:
     return tmp_path / 'hints.zst'
 
 
-def test_apply_hints_delete_prefix(tmp_file):
+def test_apply_hints_delete_prefix(tmp_file: Path):
     tmp_file.write_text('Foo bar')
     hint = {'p': [{'l': 0, 'r': 4}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
@@ -26,7 +27,7 @@ def test_apply_hints_delete_prefix(tmp_file):
     assert new_data == b'bar'
 
 
-def test_apply_hints_delete_suffix(tmp_file):
+def test_apply_hints_delete_suffix(tmp_file: Path):
     tmp_file.write_text('Foo bar')
     hint = {'p': [{'l': 3, 'r': 7}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
@@ -37,7 +38,7 @@ def test_apply_hints_delete_suffix(tmp_file):
     assert new_data == b'Foo'
 
 
-def test_apply_hints_delete_middle(tmp_file):
+def test_apply_hints_delete_middle(tmp_file: Path):
     tmp_file.write_text('Foo bar baz')
     hint = {'p': [{'l': 3, 'r': 7}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
@@ -48,7 +49,7 @@ def test_apply_hints_delete_middle(tmp_file):
     assert new_data == b'Foo baz'
 
 
-def test_apply_hints_delete_middle_multiple(tmp_file):
+def test_apply_hints_delete_middle_multiple(tmp_file: Path):
     tmp_file.write_text('Foo bar baz')
     hint1 = {'p': [{'l': 3, 'r': 4}]}
     hint2 = {'p': [{'l': 7, 'r': 8}]}
@@ -62,7 +63,7 @@ def test_apply_hints_delete_middle_multiple(tmp_file):
     assert new_data == b'Foobarbaz'
 
 
-def test_apply_hints_delete_all(tmp_file):
+def test_apply_hints_delete_all(tmp_file: Path):
     tmp_file.write_text('Foo bar')
     hint = {'p': [{'l': 0, 'r': 7}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
@@ -73,7 +74,7 @@ def test_apply_hints_delete_all(tmp_file):
     assert new_data == b''
 
 
-def test_apply_hints_delete_touching(tmp_file):
+def test_apply_hints_delete_touching(tmp_file: Path):
     tmp_file.write_text('Foo bar baz')
     # It's essentially the deletion of [3..7).
     hint1 = {'p': [{'l': 3, 'r': 4}]}
@@ -89,7 +90,7 @@ def test_apply_hints_delete_touching(tmp_file):
     assert new_data == b'Foo baz'
 
 
-def test_apply_hints_delete_overlapping(tmp_file):
+def test_apply_hints_delete_overlapping(tmp_file: Path):
     tmp_file.write_text('Foo bar baz')
     # It's essentially the deletion of [3..7).
     hint1 = {'p': [{'l': 3, 'r': 6}]}
@@ -104,7 +105,7 @@ def test_apply_hints_delete_overlapping(tmp_file):
     assert new_data == b'Foo baz'
 
 
-def test_apply_hints_delete_nested(tmp_file):
+def test_apply_hints_delete_nested(tmp_file: Path):
     tmp_file.write_text('Foo bar baz')
     hint1 = {'p': [{'l': 4, 'r': 6}]}
     hint2 = {'p': [{'l': 3, 'r': 7}]}
@@ -118,7 +119,7 @@ def test_apply_hints_delete_nested(tmp_file):
     assert new_data == b'Foo baz'
 
 
-def test_apply_hints_replace_with_shorter(tmp_file):
+def test_apply_hints_replace_with_shorter(tmp_file: Path):
     """Test a hint replacing a fragment with a shorter value."""
     tmp_file.write_text('Foo foobarbaz baz')
     vocab = ['xyz']
@@ -131,7 +132,7 @@ def test_apply_hints_replace_with_shorter(tmp_file):
     assert new_data == b'Foo xyz baz'
 
 
-def test_apply_hints_replace_with_longer(tmp_file):
+def test_apply_hints_replace_with_longer(tmp_file: Path):
     """Test a hint replacing a fragment with a longer value."""
     tmp_file.write_text('Foo x baz')
     vocab = ['z', 'abacaba']
@@ -144,7 +145,7 @@ def test_apply_hints_replace_with_longer(tmp_file):
     assert new_data == b'Foo abacaba baz'
 
 
-def test_apply_hints_replacement_inside_deletion(tmp_file):
+def test_apply_hints_replacement_inside_deletion(tmp_file: Path):
     """Test that a replacement is a no-op if happening inside a to-be-deleted fragment."""
     tmp_file.write_text('Foo bar baz')
     vocab = ['x']
@@ -160,7 +161,7 @@ def test_apply_hints_replacement_inside_deletion(tmp_file):
     assert new_data == b'Foo  baz'
 
 
-def test_apply_hints_deletion_inside_replacement(tmp_file):
+def test_apply_hints_deletion_inside_replacement(tmp_file: Path):
     """Test that a deletion is a no-op if happening inside a to-be-replaced fragment."""
     tmp_file.write_text('Foo bar baz')
     vocab = ['some']
@@ -176,7 +177,7 @@ def test_apply_hints_deletion_inside_replacement(tmp_file):
     assert new_data == b'Foo some baz'
 
 
-def test_apply_hints_replacement_of_deleted_prefix(tmp_file):
+def test_apply_hints_replacement_of_deleted_prefix(tmp_file: Path):
     """Test that a deletion takes precedence over a replacement of the same substring's prefix.
 
     This covers the specific implementation detail of conflict resolution, beyond the simple rule "the leftmost hint
@@ -195,7 +196,7 @@ def test_apply_hints_replacement_of_deleted_prefix(tmp_file):
     assert new_data == b'Foo  baz'
 
 
-def test_apply_hints_replacement_and_deletion_touching(tmp_file):
+def test_apply_hints_replacement_and_deletion_touching(tmp_file: Path):
     """Test that deletions and replacements in touching, but not overlapping, fragments are applied independently."""
     tmp_file.write_text('Foo bar baz')
     vocab = ['some']
@@ -212,7 +213,7 @@ def test_apply_hints_replacement_and_deletion_touching(tmp_file):
     assert new_data == b'Foo somebaz'
 
 
-def test_apply_hints_overlapping_replacements(tmp_file):
+def test_apply_hints_overlapping_replacements(tmp_file: Path):
     """Test overlapping replacements are handled gracefully.
 
     As there's no ideal solution for this kind of merge conflict, the main goal is to verify the implementation doesn't
@@ -231,7 +232,7 @@ def test_apply_hints_overlapping_replacements(tmp_file):
     assert new_data == b'afoo'
 
 
-def test_apply_hints_multiple_bundles(tmp_file):
+def test_apply_hints_multiple_bundles(tmp_file: Path):
     tmp_file.write_text('foobar')
     hint02 = {'p': [{'l': 0, 'r': 2}]}
     hint13 = {'p': [{'l': 1, 'r': 3}]}
@@ -247,7 +248,7 @@ def test_apply_hints_multiple_bundles(tmp_file):
     assert new_data == b'ar'
 
 
-def test_apply_hints_utf8(tmp_file):
+def test_apply_hints_utf8(tmp_file: Path):
     tmp_file.write_text('Brötchen 🍴')
     hint1 = {'p': [{'l': 0, 'r': 1}, {'l': 5, 'r': 7}]}
     hint2 = {'p': [{'l': 10, 'r': 14}]}
@@ -264,7 +265,7 @@ def test_apply_hints_utf8(tmp_file):
     assert result2 == 'Brötchen '.encode()
 
 
-def test_apply_hints_non_unicode(tmp_file):
+def test_apply_hints_non_unicode(tmp_file: Path):
     tmp_file.write_bytes(b'\0F\xffoo')
     hint = {'p': [{'l': 2, 'r': 3}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
@@ -275,7 +276,7 @@ def test_apply_hints_non_unicode(tmp_file):
     assert new_data == b'\0Foo'
 
 
-def test_apply_hints_statistics(tmp_file):
+def test_apply_hints_statistics(tmp_file: Path):
     tmp_file.write_text('Foo bar baz')
     hint03 = {'p': [{'l': 0, 'r': 3}]}
     hint07 = {'p': [{'l': 0, 'r': 7}]}
@@ -305,7 +306,7 @@ def test_store_load_hints(tmp_hints_file):
     assert load_hints(tmp_hints_file, 1, 2) == HintBundle(vocabulary=vocab, hints=[hint2])
 
 
-def test_hints_storage_compression(tmp_file):
+def test_hints_storage_compression(tmp_file: Path):
     COUNT = 10000
     hints = [{'p': [{'l': i, 'r': i + 1}]} for i in range(COUNT)]
     bundle = HintBundle(hints=hints)

--- a/cvise/tests/test_ifs.py
+++ b/cvise/tests/test_ifs.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 import tempfile
 from typing import Any

--- a/cvise/tests/test_ints.py
+++ b/cvise/tests/test_ints.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import tempfile
 import unittest
 
@@ -13,36 +13,36 @@ class IntsATestCase(unittest.TestCase):
     def test_a(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('Compute 123L + 0x456 + 0789!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'Compute 123L + 0x56 + 0789!\n')
 
     def test_success_a(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('Compute 123L + 0x456 + 0789!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name)
-        (result, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path)
+        (result, state) = self.pass_.transform(tmp_path, state, None)
 
         iteration = 1
         while result == PassResult.OK and iteration < 10:
-            state = self.pass_.advance_on_success(tmp_file.name, state)
+            state = self.pass_.advance_on_success(tmp_path, state)
             if state is None:
                 break
-            (result, state) = self.pass_.transform(tmp_file.name, state, None)
+            (result, state) = self.pass_.transform(tmp_path, state, None)
             iteration += 1
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(iteration, 4)
         self.assertEqual(variant, 'Compute 3L + 0x6 + 0789!\n')
@@ -50,23 +50,23 @@ class IntsATestCase(unittest.TestCase):
     def test_no_success_a(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('Compute 123L + 0x456 + 0789!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name)
-        (result, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path)
+        (result, state) = self.pass_.transform(tmp_path, state, None)
 
         iteration = 1
 
         while result == PassResult.OK and iteration < 10:
-            with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-                tmp_file.write('Compute 123L + 0x456 + 0789!\n')
+            tmp_path.write_text('Compute 123L + 0x456 + 0789!\n')
 
-            state = self.pass_.advance(tmp_file.name, state)
+            state = self.pass_.advance(tmp_path, state)
             if state is None:
                 break
-            (result, state) = self.pass_.transform(tmp_file.name, state, None)
+            (result, state) = self.pass_.transform(tmp_path, state, None)
             iteration += 1
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(iteration, 2)
 
@@ -78,14 +78,14 @@ class IntsBTestCase(unittest.TestCase):
     def test_b(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('Compute 123L + 0x456 + 0789!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'Compute 123L + 456 + 0789!\n')
 
@@ -97,14 +97,14 @@ class IntsCTestCase(unittest.TestCase):
     def test_c(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('Compute 123L + 0x456 + 0789!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'Compute 123 + 0x456 + 0789!\n')
 
@@ -116,13 +116,13 @@ class IntsDTestCase(unittest.TestCase):
     def test_d(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('Compute 123L + 0x456 + 0789!\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'Compute 123L + 1110 + 0789!\n')

--- a/cvise/tests/test_line_markers.py
+++ b/cvise/tests/test_line_markers.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import pytest
 
 from cvise.passes.line_markers import LineMarkersPass
@@ -5,18 +6,18 @@ from cvise.tests.testabstract import collect_all_transforms, validate_stored_hin
 
 
 @pytest.fixture
-def input_path(tmp_path):
+def input_path(tmp_path: Path):
     return tmp_path / 'input.cc'
 
 
-def init_pass(tmp_path, input_path):
+def init_pass(tmp_path: Path, input_path: Path):
     pass_ = LineMarkersPass()
     state = pass_.new(input_path, tmp_dir=tmp_path)
     validate_stored_hints(state)
     return pass_, state
 
 
-def test_all(tmp_path, input_path):
+def test_all(tmp_path: Path, input_path: Path):
     input_path.write_text("# 1 'foo.h'\n# 2 'bar.h'\n#4   'x.h'")
     pass_, state = init_pass(tmp_path, input_path)
 
@@ -25,7 +26,7 @@ def test_all(tmp_path, input_path):
     assert input_path.read_text() == ''
 
 
-def test_only_last(tmp_path, input_path):
+def test_only_last(tmp_path: Path, input_path: Path):
     input_path.write_text("# 1 'foo.h'\n# 2 'bar.h'\n#4   'x.h\nint x = 2;")
     pass_, state = init_pass(tmp_path, input_path)
 
@@ -34,7 +35,7 @@ def test_only_last(tmp_path, input_path):
     assert input_path.read_text() == 'int x = 2;'
 
 
-def test_all_iteration(tmp_path, input_path):
+def test_all_iteration(tmp_path: Path, input_path: Path):
     input_path.write_text("# 1 'foo.h'\n# 2 'bar.h'\nint x = 2;\n# 4 'x.h'")
     pass_, state = init_pass(tmp_path, input_path)
 
@@ -45,7 +46,7 @@ def test_all_iteration(tmp_path, input_path):
     assert b"# 1 'foo.h'\n# 2 'bar.h'\nint x = 2;\n" in all_transforms
 
 
-def test_non_ascii(tmp_path, input_path):
+def test_non_ascii(tmp_path: Path, input_path: Path):
     input_path.write_bytes(
         b"""
         # 1 "Streichholzsch\xc3\xa4chtelchen.h";

--- a/cvise/tests/test_lines.py
+++ b/cvise/tests/test_lines.py
@@ -1,4 +1,6 @@
+from pathlib import Path
 import pytest
+from typing import Any, Tuple
 
 from cvise.passes.lines import LinesPass
 from cvise.tests.testabstract import collect_all_transforms, validate_stored_hints
@@ -6,18 +8,18 @@ from cvise.utils.externalprograms import find_external_programs
 
 
 @pytest.fixture
-def input_path(tmp_path):
+def input_path(tmp_path: Path) -> Path:
     return tmp_path / 'input.cc'
 
 
-def init_pass(depth, tmp_dir, input_path):
+def init_pass(depth, tmp_dir: Path, input_path: Path) -> Tuple[LinesPass, Any]:
     pass_ = LinesPass(depth, find_external_programs())
     state = pass_.new(input_path, tmp_dir=tmp_dir)
     validate_stored_hints(state)
     return pass_, state
 
 
-def advance_until(pass_, state, input_path, predicate):
+def advance_until(pass_, state, input_path: Path, predicate):
     backup = input_path.read_bytes()
     while True:
         pass_.transform(input_path, state, process_event_notifier=None)
@@ -40,7 +42,7 @@ def is_valid_brace_sequence(s: bytes) -> bool:
     return balance == 0
 
 
-def test_func_namespace_level0(tmp_path, input_path):
+def test_func_namespace_level0(tmp_path: Path, input_path: Path):
     """Test that arg=0 deletes top-level functions and namespaces."""
     input_path.write_text(
         """
@@ -76,7 +78,7 @@ def test_func_namespace_level0(tmp_path, input_path):
         assert is_valid_brace_sequence(s)
 
 
-def test_func_namespace_level1(tmp_path, input_path):
+def test_func_namespace_level1(tmp_path: Path, input_path: Path):
     """Test that arg=1 deletes code inside top-level functions and namespaces."""
     input_path.write_text(
         """
@@ -130,7 +132,7 @@ def test_func_namespace_level1(tmp_path, input_path):
         assert is_valid_brace_sequence(s)
 
 
-def test_multiline_func_signature_level0(tmp_path, input_path):
+def test_multiline_func_signature_level0(tmp_path: Path, input_path: Path):
     """Test that arg=0 deletes a top-level function despite line breaks in the signature."""
     input_path.write_text(
         """
@@ -148,7 +150,7 @@ def test_multiline_func_signature_level0(tmp_path, input_path):
     assert len(all_transforms) == 1
 
 
-def test_multiline_func_signature_level1(tmp_path, input_path):
+def test_multiline_func_signature_level1(tmp_path: Path, input_path: Path):
     """Test that arg=1 deletes a nested function despite line breaks in the signature."""
     input_path.write_text(
         """
@@ -175,7 +177,7 @@ def test_multiline_func_signature_level1(tmp_path, input_path):
     assert len(all_transforms) == 1
 
 
-def test_class_with_methods_level0(tmp_path, input_path):
+def test_class_with_methods_level0(tmp_path: Path, input_path: Path):
     """Test that arg=0 deletes the whole class definition."""
     input_path.write_text(
         """
@@ -196,7 +198,7 @@ def test_class_with_methods_level0(tmp_path, input_path):
     assert len(all_transforms) == 1
 
 
-def test_class_with_methods_level1(tmp_path, input_path):
+def test_class_with_methods_level1(tmp_path: Path, input_path: Path):
     """Test that arg=1 deletes class methods."""
     input_path.write_text(
         """
@@ -250,7 +252,7 @@ def test_class_with_methods_level1(tmp_path, input_path):
         assert is_valid_brace_sequence(s)
 
 
-def test_class_with_methods_level2(tmp_path, input_path):
+def test_class_with_methods_level2(tmp_path: Path, input_path: Path):
     """Test that arg=2 deletes statements in class methods."""
     input_path.write_text(
         """
@@ -327,7 +329,7 @@ def test_class_with_methods_level2(tmp_path, input_path):
         assert is_valid_brace_sequence(s)
 
 
-def test_c_comment(tmp_path, input_path):
+def test_c_comment(tmp_path: Path, input_path: Path):
     """Test that a C comment is deleted as a whole."""
     input_path.write_text(
         """
@@ -361,7 +363,7 @@ def test_c_comment(tmp_path, input_path):
         assert (b'/*' in s) == (b'some' in s) == (b'comment' in s) == (b'*/' in s)
 
 
-def test_cpp_comment(tmp_path, input_path):
+def test_cpp_comment(tmp_path: Path, input_path: Path):
     """Test that a C++ comment is deleted as a whole."""
     input_path.write_text(
         """
@@ -386,7 +388,7 @@ def test_cpp_comment(tmp_path, input_path):
     assert len(all_transforms) == 3
 
 
-def test_eof_with_non_recognized_chunk_end(tmp_path, input_path):
+def test_eof_with_non_recognized_chunk_end(tmp_path: Path, input_path: Path):
     """Test the file terminating with a text that wouldn't be recognized as chunk end."""
     input_path.write_text(
         """
@@ -406,7 +408,7 @@ def test_eof_with_non_recognized_chunk_end(tmp_path, input_path):
     )
 
 
-def test_macro_level0(tmp_path, input_path):
+def test_macro_level0(tmp_path: Path, input_path: Path):
     """Test removal of preprocessor macros with arg=0."""
     input_path.write_text(
         """#ifndef FOO
@@ -491,7 +493,7 @@ def test_macro_level0(tmp_path, input_path):
     )
 
 
-def test_nested_macro_level0(tmp_path, input_path):
+def test_nested_macro_level0(tmp_path: Path, input_path: Path):
     """Test removal of preprocessor macros, placed inside a curly brace block, with arg=0."""
     input_path.write_text(
         """
@@ -509,7 +511,7 @@ def test_nested_macro_level0(tmp_path, input_path):
     assert len(all_transforms) == 1
 
 
-def test_nested_macro_level1(tmp_path, input_path):
+def test_nested_macro_level1(tmp_path: Path, input_path: Path):
     """Test removal of preprocessor macros, placed inside a curly brace block, with arg=1."""
     input_path.write_text(
         """
@@ -556,7 +558,7 @@ def test_nested_macro_level1(tmp_path, input_path):
     )
 
 
-def test_hash_character_not_macro_start(tmp_path, input_path):
+def test_hash_character_not_macro_start(tmp_path: Path, input_path: Path):
     """Test hash characters aren't mistakenly treated as macro/block start."""
     input_path.write_text(
         """
@@ -595,7 +597,7 @@ def test_hash_character_not_macro_start(tmp_path, input_path):
     )
 
 
-def test_transform_deletes_lines_range(tmp_path, input_path):
+def test_transform_deletes_lines_range(tmp_path: Path, input_path: Path):
     """Test various combinations of line deletion are attempted.
 
     This verifies the code performs the binary search or some similar strategy."""
@@ -680,7 +682,7 @@ def test_transform_deletes_lines_range(tmp_path, input_path):
     )
 
 
-def test_advance_on_success(tmp_path, input_path):
+def test_advance_on_success(tmp_path: Path, input_path: Path):
     """Test the scenario where successful advancements are interleaved with unsuccessful transforms."""
     input_path.write_text(
         """
@@ -707,7 +709,7 @@ def test_advance_on_success(tmp_path, input_path):
     )
 
 
-def test_arg_none(tmp_path, input_path):
+def test_arg_none(tmp_path: Path, input_path: Path):
     """Test that arg=None deletes individual lines as-is."""
     input_path.write_text(
         """
@@ -755,7 +757,7 @@ def test_arg_none(tmp_path, input_path):
 
 
 @pytest.mark.parametrize('pass_arg', [0, 'None'])
-def test_non_ascii(tmp_path, input_path, pass_arg):
+def test_non_ascii(tmp_path: Path, input_path: Path, pass_arg):
     input_path.write_bytes(
         b"""
         char *s = "Streichholzsch\xc3\xa4chtelchen";

--- a/cvise/tests/test_peep.py
+++ b/cvise/tests/test_peep.py
@@ -8,154 +8,112 @@ from cvise.tests.testabstract import iterate_pass
 
 class PeepATestCase(unittest.TestCase):
     def setUp(self):
+        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = PeepPass('a')
 
     def test_a_1(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write("<That's a small test> whether the transformation works!\n")
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text("<That's a small test> whether the transformation works!\n")
 
-        iterate_pass(self.pass_, tmp_path)
+        iterate_pass(self.pass_, self.input_path)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, ' whether the transformation works\n')
 
     def test_a_2(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write("{That's a small test} whether the transformation works!\n")
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text("{That's a small test} whether the transformation works!\n")
 
-        iterate_pass(self.pass_, tmp_path)
+        iterate_pass(self.pass_, self.input_path)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, ' whether the transformation works\n')
 
     def test_a_3(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('namespace cvise {Some more content} which is not interesting!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('namespace cvise {Some more content} which is not interesting!\n')
 
-        iterate_pass(self.pass_, tmp_path)
+        iterate_pass(self.pass_, self.input_path)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, ' which is not interesting\n')
 
     def test_a_4(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('namespace {Some more content} which is not interesting!\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('namespace {Some more content} which is not interesting!\n')
 
-        iterate_pass(self.pass_, tmp_path)
+        iterate_pass(self.pass_, self.input_path)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, ' which is not interesting\n')
 
     def test_a_5(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('struct test_t {} test;\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('struct test_t {} test;\n')
 
-        iterate_pass(self.pass_, tmp_path)
+        iterate_pass(self.pass_, self.input_path)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, ' test\n')
 
     def test_success_a(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('struct test_t {int a;} foo = {1};\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('struct test_t {int a;} foo = {1};\n')
 
-        state = self.pass_.new(tmp_path)
-        (_result, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path)
+        (_result, state) = self.pass_.transform(self.input_path, state, None)
 
-        iterate_pass(self.pass_, tmp_path)
+        iterate_pass(self.pass_, self.input_path)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, ' foo \n')
 
 
 class PeepBTestCase(unittest.TestCase):
     def setUp(self):
+        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = PeepPass('b')
 
     def test_b_1(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('struct test_t {} test;\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('struct test_t {} test;\n')
 
-        iterate_pass(self.pass_, tmp_path)
+        iterate_pass(self.pass_, self.input_path)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'struct  {} ;\n')
 
     def test_success_b(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('struct test_t {int a;} foo = {1};\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('struct test_t {int a;} foo = {1};\n')
 
-        state = self.pass_.new(tmp_path)
-        (_result, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path)
+        (_result, state) = self.pass_.transform(self.input_path, state, None)
 
-        iterate_pass(self.pass_, tmp_path)
+        iterate_pass(self.pass_, self.input_path)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'struct  { ;}  = {};\n')
 
     def test_infinite_loop(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write(',0,')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text(',0,')
 
-        state = self.pass_.new(tmp_path)
-        (_result, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path)
+        (_result, state) = self.pass_.transform(self.input_path, state, None)
 
-        iterate_pass(self.pass_, tmp_path)
+        iterate_pass(self.pass_, self.input_path)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, ',,')
 
 
 class PeepCTestCase(unittest.TestCase):
     def setUp(self):
+        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = PeepPass('c')
 
     def test_c_1(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('while   (a == b)\n{\n    int a = 4;\n    short b = 5;\n    break;\n}\n\nulong c = 18;\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text(
+            'while   (a == b)\n{\n    int a = 4;\n    short b = 5;\n    break;\n}\n\nulong c = 18;\n'
+        )
 
-        state = self.pass_.new(tmp_path)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, '{\n    int a = 4;\n    short b = 5;\n    \n}\n\nulong c = 18;\n')

--- a/cvise/tests/test_peep.py
+++ b/cvise/tests/test_peep.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import tempfile
 import unittest
 
@@ -13,81 +13,81 @@ class PeepATestCase(unittest.TestCase):
     def test_a_1(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write("<That's a small test> whether the transformation works!\n")
+            tmp_path = Path(tmp_file.name)
 
-        iterate_pass(self.pass_, tmp_file.name)
+        iterate_pass(self.pass_, tmp_path)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, ' whether the transformation works\n')
 
     def test_a_2(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write("{That's a small test} whether the transformation works!\n")
+            tmp_path = Path(tmp_file.name)
 
-        iterate_pass(self.pass_, tmp_file.name)
+        iterate_pass(self.pass_, tmp_path)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, ' whether the transformation works\n')
 
     def test_a_3(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('namespace cvise {Some more content} which is not interesting!\n')
+            tmp_path = Path(tmp_file.name)
 
-        iterate_pass(self.pass_, tmp_file.name)
+        iterate_pass(self.pass_, tmp_path)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, ' which is not interesting\n')
 
     def test_a_4(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('namespace {Some more content} which is not interesting!\n')
+            tmp_path = Path(tmp_file.name)
 
-        iterate_pass(self.pass_, tmp_file.name)
+        iterate_pass(self.pass_, tmp_path)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, ' which is not interesting\n')
 
     def test_a_5(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('struct test_t {} test;\n')
+            tmp_path = Path(tmp_file.name)
 
-        iterate_pass(self.pass_, tmp_file.name)
+        iterate_pass(self.pass_, tmp_path)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, ' test\n')
 
     def test_success_a(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('struct test_t {int a;} foo = {1};\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name)
-        (_result, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path)
+        (_result, state) = self.pass_.transform(tmp_path, state, None)
 
-        iterate_pass(self.pass_, tmp_file.name)
+        iterate_pass(self.pass_, tmp_path)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, ' foo \n')
 
@@ -99,45 +99,45 @@ class PeepBTestCase(unittest.TestCase):
     def test_b_1(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('struct test_t {} test;\n')
+            tmp_path = Path(tmp_file.name)
 
-        iterate_pass(self.pass_, tmp_file.name)
+        iterate_pass(self.pass_, tmp_path)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'struct  {} ;\n')
 
     def test_success_b(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('struct test_t {int a;} foo = {1};\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name)
-        (_result, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path)
+        (_result, state) = self.pass_.transform(tmp_path, state, None)
 
-        iterate_pass(self.pass_, tmp_file.name)
+        iterate_pass(self.pass_, tmp_path)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'struct  { ;}  = {};\n')
 
     def test_infinite_loop(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write(',0,')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name)
-        (_result, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path)
+        (_result, state) = self.pass_.transform(tmp_path, state, None)
 
-        iterate_pass(self.pass_, tmp_file.name)
+        iterate_pass(self.pass_, tmp_path)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, ',,')
 
@@ -149,13 +149,13 @@ class PeepCTestCase(unittest.TestCase):
     def test_c_1(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write('while   (a == b)\n{\n    int a = 4;\n    short b = 5;\n    break;\n}\n\nulong c = 18;\n')
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, '{\n    int a = 4;\n    short b = 5;\n    \n}\n\nulong c = 18;\n')

--- a/cvise/tests/test_special.py
+++ b/cvise/tests/test_special.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import tempfile
 import unittest
 
@@ -15,13 +15,13 @@ class SpecialATestCase(unittest.TestCase):
             tmp_file.write(
                 "// Useless comment\ntransparent_crc(g_376.f0, 'g_376.f0', print_hash_value);\ntransparent_crc(g_1194[i].f0, 'g_1194[i].f0', print_hash_value);\nint a = 9;"
             )
+            tmp_path = Path(tmp_file.name)
 
-        iterate_pass(self.pass_, tmp_file.name)
+        iterate_pass(self.pass_, tmp_path)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(
             variant,
@@ -33,16 +33,16 @@ class SpecialATestCase(unittest.TestCase):
             tmp_file.write(
                 "// Useless comment\ntransparent_crc(g_376.f0, 'g_376.f0', print_hash_value);\ntransparent_crc(g_1194[i].f0, 'g_1194[i].f0', print_hash_value);\nint a = 9;"
             )
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name)
-        (_result, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path)
+        (_result, state) = self.pass_.transform(tmp_path, state, None)
 
-        iterate_pass(self.pass_, tmp_file.name)
+        iterate_pass(self.pass_, tmp_path)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(
             variant,
@@ -57,14 +57,14 @@ class SpecialBTestCase(unittest.TestCase):
     def test_b(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write("void foo(){} extern 'C' {int a;}; a = 9;\n")
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'void foo(){}  {int a;}; a = 9;\n')
 
@@ -76,13 +76,13 @@ class SpecialCTestCase(unittest.TestCase):
     def test_c(self):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
             tmp_file.write("void foo(){} extern 'C++' {int a;}; a = 9;\n")
+            tmp_path = Path(tmp_file.name)
 
-        state = self.pass_.new(tmp_file.name)
-        (_, state) = self.pass_.transform(tmp_file.name, state, None)
+        state = self.pass_.new(tmp_path)
+        (_, state) = self.pass_.transform(tmp_path, state, None)
 
-        with open(tmp_file.name) as variant_file:
-            variant = variant_file.read()
+        variant = tmp_path.read_text()
 
-        os.unlink(tmp_file.name)
+        tmp_path.unlink()
 
         self.assertEqual(variant, 'void foo(){}  {int a;}; a = 9;\n')

--- a/cvise/tests/test_special.py
+++ b/cvise/tests/test_special.py
@@ -8,42 +8,34 @@ from cvise.tests.testabstract import iterate_pass
 
 class SpecialATestCase(unittest.TestCase):
     def setUp(self):
+        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = SpecialPass('a')
 
     def test_a(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write(
-                "// Useless comment\ntransparent_crc(g_376.f0, 'g_376.f0', print_hash_value);\ntransparent_crc(g_1194[i].f0, 'g_1194[i].f0', print_hash_value);\nint a = 9;"
-            )
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text(
+            "// Useless comment\ntransparent_crc(g_376.f0, 'g_376.f0', print_hash_value);\ntransparent_crc(g_1194[i].f0, 'g_1194[i].f0', print_hash_value);\nint a = 9;"
+        )
 
-        iterate_pass(self.pass_, tmp_path)
+        iterate_pass(self.pass_, self.input_path)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(
             variant,
             "// Useless comment\nprintf('%d\\n', (int)g_376.f0);\nprintf('%d\\n', (int)g_1194[i].f0);\nint a = 9;",
         )
 
     def test_success_a(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write(
-                "// Useless comment\ntransparent_crc(g_376.f0, 'g_376.f0', print_hash_value);\ntransparent_crc(g_1194[i].f0, 'g_1194[i].f0', print_hash_value);\nint a = 9;"
-            )
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text(
+            "// Useless comment\ntransparent_crc(g_376.f0, 'g_376.f0', print_hash_value);\ntransparent_crc(g_1194[i].f0, 'g_1194[i].f0', print_hash_value);\nint a = 9;"
+        )
 
-        state = self.pass_.new(tmp_path)
-        (_result, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path)
+        (_result, state) = self.pass_.transform(self.input_path, state, None)
 
-        iterate_pass(self.pass_, tmp_path)
+        iterate_pass(self.pass_, self.input_path)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(
             variant,
             "// Useless comment\nprintf('%d\\n', (int)g_376.f0);\nprintf('%d\\n', (int)g_1194[i].f0);\nint a = 9;",
@@ -52,37 +44,31 @@ class SpecialATestCase(unittest.TestCase):
 
 class SpecialBTestCase(unittest.TestCase):
     def setUp(self):
+        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = SpecialPass('b')
 
     def test_b(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write("void foo(){} extern 'C' {int a;}; a = 9;\n")
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text("void foo(){} extern 'C' {int a;}; a = 9;\n")
 
-        state = self.pass_.new(tmp_path)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'void foo(){}  {int a;}; a = 9;\n')
 
 
 class SpecialCTestCase(unittest.TestCase):
     def setUp(self):
+        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = SpecialPass('c')
 
     def test_c(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write("void foo(){} extern 'C++' {int a;}; a = 9;\n")
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text("void foo(){} extern 'C++' {int a;}; a = 9;\n")
 
-        state = self.pass_.new(tmp_path)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'void foo(){}  {int a;}; a = 9;\n')

--- a/cvise/tests/test_ternary.py
+++ b/cvise/tests/test_ternary.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 import tempfile
 import unittest

--- a/cvise/tests/test_ternary.py
+++ b/cvise/tests/test_ternary.py
@@ -8,112 +8,86 @@ from cvise.passes.ternary import TernaryPass
 
 class TernaryBTestCase(unittest.TestCase):
     def setUp(self):
+        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = TernaryPass('b')
 
     def test_b(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('int res = a ? b : c;\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('int res = a ? b : c;\n')
 
-        state = self.pass_.new(tmp_path)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'int res = b;\n')
 
     def test_parens(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('int res = (a != 0) ? (b + 5) : c;\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('int res = (a != 0) ? (b + 5) : c;\n')
 
-        state = self.pass_.new(tmp_path)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'int res = (b + 5);\n')
 
     def test_all_b(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('// no ? match :\nint res = a ? (ba ? bb : bc) : c\nint sec = t ? u : v\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('// no ? match :\nint res = a ? (ba ? bb : bc) : c\nint sec = t ? u : v\n')
 
-        state = self.pass_.new(tmp_path)
-        (result, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path)
+        (result, state) = self.pass_.transform(self.input_path, state, None)
 
         while result == PassResult.OK:
-            state = self.pass_.advance_on_success(tmp_path, state)
-            (result, state) = self.pass_.transform(tmp_path, state, None)
+            state = self.pass_.advance_on_success(self.input_path, state)
+            (result, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, '// match res = (bb)\nint sec = u\n')
 
     def test_all_b_2(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('// no ? match :!\nint res = a ? (ba ? bb : bc) : c\nint sec = t ? u : v\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('// no ? match :!\nint res = a ? (ba ? bb : bc) : c\nint sec = t ? u : v\n')
 
-        state = self.pass_.new(tmp_path)
-        (result, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path)
+        (result, state) = self.pass_.transform(self.input_path, state, None)
 
         iteration = 0
 
         while result == PassResult.OK and iteration < 5:
-            state = self.pass_.advance_on_success(tmp_path, state)
-            (result, state) = self.pass_.transform(tmp_path, state, None)
+            state = self.pass_.advance_on_success(self.input_path, state)
+            (result, state) = self.pass_.transform(self.input_path, state, None)
             iteration += 1
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(iteration, 3)
         self.assertEqual(variant, '// no ? match :!\nint res = (bb)\nint sec = u\n')
 
     def test_no_success(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('// no ? match :\nint res = a ? (ba ? bb : bc) : c\nint sec = t ? u : v\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('// no ? match :\nint res = a ? (ba ? bb : bc) : c\nint sec = t ? u : v\n')
 
-        state = self.pass_.new(tmp_path)
-        (result, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path)
+        (result, state) = self.pass_.transform(self.input_path, state, None)
 
         iteration = 0
 
         while result == PassResult.OK and iteration < 6:
-            tmp_path.write_text('// no ? match :\nint res = a ? (ba ? bb : bc) : c\nint sec = t ? u : v\n')
+            self.input_path.write_text('// no ? match :\nint res = a ? (ba ? bb : bc) : c\nint sec = t ? u : v\n')
 
-            state = self.pass_.advance(tmp_path, state)
-            (result, state) = self.pass_.transform(tmp_path, state, None)
+            state = self.pass_.advance(self.input_path, state)
+            (result, state) = self.pass_.transform(self.input_path, state, None)
             iteration += 1
-
-        tmp_path.unlink()
-
         self.assertEqual(iteration, 4)
 
 
 class TernaryCTestCase(unittest.TestCase):
     def setUp(self):
+        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = TernaryPass('c')
 
     def test_c(self):
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
-            tmp_file.write('int res = a ? b : c;\n')
-            tmp_path = Path(tmp_file.name)
+        self.input_path.write_text('int res = a ? b : c;\n')
 
-        state = self.pass_.new(tmp_path)
-        (_, state) = self.pass_.transform(tmp_path, state, None)
+        state = self.pass_.new(self.input_path)
+        (_, state) = self.pass_.transform(self.input_path, state, None)
 
-        variant = tmp_path.read_text()
-
-        tmp_path.unlink()
-
+        variant = self.input_path.read_text()
         self.assertEqual(variant, 'int res = c;\n')

--- a/cvise/tests/test_test_manager.py
+++ b/cvise/tests/test_test_manager.py
@@ -119,7 +119,7 @@ class LetterRemovingPass(StubPass):
             if c in self.letters_to_remove:
                 if instances == state:
                     # Found a matching letter with the expected index; remove it.
-                    Path(test_case).write_text(text[:i] + text[i + 1 :])
+                    test_case.write_text(text[:i] + text[i + 1 :])
                     return (PassResult.OK, state)
                 instances += 1
         return (PassResult.STOP, state)

--- a/cvise/tests/test_treesitter.py
+++ b/cvise/tests/test_treesitter.py
@@ -1,4 +1,6 @@
+from pathlib import Path
 import pytest
+from typing import Any, Tuple
 
 from cvise.passes.treesitter import TreeSitterPass
 from cvise.tests.testabstract import collect_all_transforms, validate_stored_hints
@@ -11,18 +13,18 @@ REMOVE_FUNCTION = 'remove-function'
 
 
 @pytest.fixture
-def input_path(tmp_path):
+def input_path(tmp_path: Path) -> Path:
     return tmp_path / 'input.cc'
 
 
-def init_pass(arg, tmp_dir, input_path):
+def init_pass(arg, tmp_dir: Path, input_path: Path) -> Tuple[TreeSitterPass, Any]:
     pass_ = TreeSitterPass(arg, find_external_programs())
     state = pass_.new(input_path, tmp_dir=tmp_dir)
     validate_stored_hints(state)
     return pass_, state
 
 
-def test_func_def_simple(tmp_path, input_path):
+def test_func_def_simple(tmp_path: Path, input_path: Path):
     """Test basic cases for the removal of function bodies."""
     input_path.write_text(
         """
@@ -73,7 +75,7 @@ def test_func_def_simple(tmp_path, input_path):
     assert len(all_transforms) == 3
 
 
-def test_func_def_class_method(tmp_path, input_path):
+def test_func_def_class_method(tmp_path: Path, input_path: Path):
     """Test removal of class methods or their bodies."""
     input_path.write_text(
         """
@@ -116,7 +118,7 @@ def test_func_def_class_method(tmp_path, input_path):
     )
 
 
-def test_func_def_class_constructor(tmp_path, input_path):
+def test_func_def_class_constructor(tmp_path: Path, input_path: Path):
     """Test removal of constructors or their bodies."""
     input_path.write_text(
         """
@@ -173,7 +175,7 @@ def test_func_def_class_constructor(tmp_path, input_path):
     )
 
 
-def test_func_def_class_destructor(tmp_path, input_path):
+def test_func_def_class_destructor(tmp_path: Path, input_path: Path):
     """Test removal of destructors or their bodies."""
     input_path.write_text(
         """
@@ -215,7 +217,7 @@ def test_func_def_class_destructor(tmp_path, input_path):
     )
 
 
-def test_func_def_regular_and_template_mix(tmp_path, input_path):
+def test_func_def_regular_and_template_mix(tmp_path: Path, input_path: Path):
     """Test removals of template functions are tackled separately from other functions."""
     input_path.write_text(
         """
@@ -265,7 +267,7 @@ def test_func_def_regular_and_template_mix(tmp_path, input_path):
     )
 
 
-def test_func_def_template(tmp_path, input_path):
+def test_func_def_template(tmp_path: Path, input_path: Path):
     """Test removal of template functions or their bodies."""
     input_path.write_text(
         """
@@ -327,7 +329,7 @@ def test_func_def_template(tmp_path, input_path):
     )
 
 
-def test_func_def_constexpr(tmp_path, input_path):
+def test_func_def_constexpr(tmp_path: Path, input_path: Path):
     """Test no removal happens for constexpr function bodies."""
     input_path.write_text(
         """
@@ -345,7 +347,7 @@ def test_func_def_constexpr(tmp_path, input_path):
     assert all_transforms == set()
 
 
-def test_func_erase_namespace(tmp_path, input_path):
+def test_func_erase_namespace(tmp_path: Path, input_path: Path):
     """Test the basic case for the removal of namespace contents."""
     input_path.write_text(
         """
@@ -383,7 +385,7 @@ def test_func_erase_namespace(tmp_path, input_path):
     )
 
 
-def test_func_erase_namespace_nested(tmp_path, input_path):
+def test_func_erase_namespace_nested(tmp_path: Path, input_path: Path):
     """Test the removal of contents of nested namespaces."""
     input_path.write_text(
         """
@@ -436,7 +438,7 @@ def test_func_erase_namespace_nested(tmp_path, input_path):
     )
 
 
-def test_remove_func(tmp_path, input_path):
+def test_remove_func(tmp_path: Path, input_path: Path):
     input_path.write_text(
         """
         int f() {
@@ -470,7 +472,7 @@ def test_remove_func(tmp_path, input_path):
     )
 
 
-def test_remove_func_template(tmp_path, input_path):
+def test_remove_func_template(tmp_path: Path, input_path: Path):
     input_path.write_text(
         """
         template <typename T>
@@ -501,7 +503,7 @@ def test_remove_func_template(tmp_path, input_path):
     )
 
 
-def test_remove_func_special(tmp_path, input_path):
+def test_remove_func_special(tmp_path: Path, input_path: Path):
     input_path.write_text(
         """
         class A {
@@ -531,7 +533,7 @@ def test_remove_func_special(tmp_path, input_path):
     )
 
 
-def test_remove_func_outofline(tmp_path, input_path):
+def test_remove_func_outofline(tmp_path: Path, input_path: Path):
     input_path.write_text(
         """
         class A {
@@ -571,7 +573,7 @@ def test_remove_func_outofline(tmp_path, input_path):
     )
 
 
-def test_remove_func_grouping_related(tmp_path, input_path):
+def test_remove_func_grouping_related(tmp_path: Path, input_path: Path):
     """Test that function removal attempts removing all instances of a function with a given name."""
     input_path.write_text(
         """

--- a/cvise/tests/testabstract.py
+++ b/cvise/tests/testabstract.py
@@ -7,7 +7,7 @@ from cvise.passes.hint_based import HintState
 from cvise.utils.hint import HINT_SCHEMA_STRICT, HintBundle, load_hints
 
 
-def iterate_pass(current_pass, path, **kwargs):
+def iterate_pass(current_pass, path: Path, **kwargs) -> None:
     state = current_pass.new(path, **kwargs)
     while state is not None:
         (result, state) = current_pass.transform(path, state, ProcessEventNotifier(None))

--- a/cvise/utils/error.py
+++ b/cvise/utils/error.py
@@ -1,4 +1,6 @@
 import os
+from pathlib import Path
+from typing import Set
 
 
 class CViseError(Exception):
@@ -23,7 +25,7 @@ class UnknownArgumentError(CViseError):
 
 
 class InvalidFileError(CViseError):
-    def __init__(self, path, error):
+    def __init__(self, path: Path, error):
         self.path = path
         self.error = error
 
@@ -47,7 +49,7 @@ class InvalidTestCaseError(InvalidFileError):
 
 
 class AbsolutePathTestCaseError(CViseError):
-    def __init__(self, path):
+    def __init__(self, path: Path):
         self.path = path
 
     def __str__(self):
@@ -55,7 +57,7 @@ class AbsolutePathTestCaseError(CViseError):
 
 
 class InvalidInterestingnessTestError(InvalidFileError):
-    def __init__(self, path):
+    def __init__(self, path: Path):
         super().__init__(path, None)
 
     def __str__(self):
@@ -63,7 +65,7 @@ class InvalidInterestingnessTestError(InvalidFileError):
 
 
 class ZeroSizeError(CViseError):
-    def __init__(self, test_cases):
+    def __init__(self, test_cases: Set[Path]):
         super().__init__()
         self.test_cases = test_cases
 
@@ -103,7 +105,7 @@ and creating an issue at https://github.com/marxin/cvise/issues and we will try 
 ***************************************************
 """
 
-    def __init__(self, current_pass, problem, state, crash_dir):
+    def __init__(self, current_pass, problem, state, crash_dir: Path):
         super().__init__()
         self.current_pass = current_pass
         self.state = state
@@ -115,7 +117,7 @@ and creating an issue at https://github.com/marxin/cvise/issues and we will try 
 
 
 class InsaneTestCaseError(CViseError):
-    def __init__(self, test_cases, test):
+    def __init__(self, test_cases: Set[Path], test: Path):
         super().__init__()
         self.test_cases = test_cases
         self.test = test

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -122,8 +122,7 @@ def apply_hints(bundles: List[HintBundle], file: Path) -> Tuple[bytes, HintAppli
                 patches.append(p)
     merged_patches = merge_overlapping_patches(patches)
 
-    with open(file, 'rb') as f:
-        orig_data = f.read()
+    orig_data = file.read_bytes()
 
     new_data = b''
     stats = HintApplicationStats(size_delta_per_pass={})

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -148,9 +148,7 @@ class TestEnvironment:
     def run(self):
         try:
             # transform by state
-            (result, self.state) = self.transform(
-                self.test_case_path, self.state, ProcessEventNotifier(self.pid_queue)
-            )
+            (result, self.state) = self.transform(self.test_case_path, self.state, ProcessEventNotifier(self.pid_queue))
             self.result = result
             if self.result != PassResult.OK:
                 return self

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -318,7 +318,7 @@ class TestManager:
         test_script,
         timeout,
         save_temps,
-        test_cases: List[str],
+        test_cases: List[Path],
         parallel_tests,
         no_cache,
         skip_key_off,

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -102,14 +102,14 @@ class TestEnvironment:
         state,
         order,
         test_script,
-        folder,
-        test_case,
-        all_test_cases,
+        folder: Path,
+        test_case: Path,
+        all_test_cases: Set[Path],
         transform,
         pid_queue=None,
     ):
         self.state = state
-        self.folder = folder
+        self.folder: Path = folder
         self.base_size = None
         self.test_script = test_script
         self.exitcode = None
@@ -118,9 +118,10 @@ class TestEnvironment:
         self.transform = transform
         self.pid_queue = pid_queue
         self.pwd = os.getcwd()
-        self.test_case = test_case
+        self.test_case: Path = test_case
+        self.original_test_case: Path = test_case.resolve()
         self.base_size = test_case.stat().st_size
-        self.all_test_cases = all_test_cases
+        self.all_test_cases: Set[Path] = all_test_cases
 
         # Copy files to the created folder
         for test_case in all_test_cases:
@@ -132,7 +133,7 @@ class TestEnvironment:
         return self.base_size - self.test_case_path.stat().st_size
 
     @property
-    def test_case_path(self):
+    def test_case_path(self) -> Path:
         return self.folder / self.test_case
 
     @property


### PR DESCRIPTION
Pathlib.Path is a more convenient and reliable way to work with file paths. Change the C-Vise code base to use it consistently, as opposed to using Str in half of places.

This is a pure refactoring change, but it'll be handy for the follow-up changes that bring multi-file (directory) reduction.