### PR TITLE
Optimize input copying: offload to workers; skip for some passes

### DIFF
--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -28,6 +28,7 @@ from cvise.utils.error import CViseError  # noqa: E402
 from cvise.utils.error import MissingPassGroupsError  # noqa: E402
 from cvise.utils.externalprograms import find_external_programs  # noqa: E402
 from cvise.utils.hint import apply_hints, load_hints  # noqa: E402
+from cvise.utils.misc import CloseableTemporaryFile  # noqa: E402
 import psutil  # noqa: E402
 
 
@@ -536,8 +537,11 @@ def do_apply_hints(args):
     if len(args.test_cases) > 1:
         sys.exit('exactly one TEST_CASE must be supplied')
     bundle = load_hints(Path(args.hints_file), args.hint_begin_index, args.hint_end_index)
-    new_data, stats = apply_hints([bundle], Path(args.test_cases[0]))
-    sys.stdout.buffer.write(new_data)
+    with CloseableTemporaryFile('wb') as tmp_file:
+        tmp_path = Path(tmp_file.name)
+        tmp_file.close()
+        apply_hints([bundle], source_file=Path(args.test_cases[0]), destination_file=tmp_path)
+        sys.stdout.buffer.write(tmp_path.read_bytes())
 
 
 if __name__ == '__main__':

--- a/cvise/passes/abstract.py
+++ b/cvise/passes/abstract.py
@@ -181,7 +181,7 @@ class AbstractPass:
     def advance_on_success(self, test_case: Path, state, succeeded_state, job_timeout, **kwargs):
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'advance_on_success'!")
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, process_event_notifier, original_test_case: Path, **kwargs):
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'transform'!")
 
 

--- a/cvise/passes/clang.py
+++ b/cvise/passes/clang.py
@@ -22,7 +22,7 @@ class ClangPass(AbstractPass):
     def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return state
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, process_event_notifier, *args, **kwargs):
         args = [
             self.external_programs['clang_delta'],
             f'--transformation={self.arg}',

--- a/cvise/passes/clangbinarysearch.py
+++ b/cvise/passes/clangbinarysearch.py
@@ -93,7 +93,7 @@ class ClangBinarySearchPass(AbstractPass):
                 # TODO: report?
                 pass
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, process_event_notifier, *args, **kwargs):
         logging.debug(f'TRANSFORM: {state}')
 
         args = [

--- a/cvise/passes/clex.py
+++ b/cvise/passes/clex.py
@@ -16,7 +16,7 @@ class ClexPass(AbstractPass):
     def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return state
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, process_event_notifier, *args, **kwargs):
         cmd = [self.external_programs['clex'], str(self.arg), str(state), str(test_case)]
         stdout, _stderr, returncode = process_event_notifier.run_process(cmd)
         if returncode == 51:

--- a/cvise/passes/gcdabinary.py
+++ b/cvise/passes/gcdabinary.py
@@ -43,7 +43,7 @@ class GCDABinaryPass(AbstractPass):
     def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return self.__create_state(test_case)
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, *args, **kwargs):
         data = test_case.read_bytes()
         old_len = len(data)
         newdata = data[0 : state.functions[state.index]]

--- a/cvise/passes/ifs.py
+++ b/cvise/passes/ifs.py
@@ -51,7 +51,7 @@ class IfPass(AbstractPass):
     def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return state.advance_on_success(self.__count_instances(test_case))
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, process_event_notifier, *args, **kwargs):
         with tempfile.NamedTemporaryFile(mode='w+', delete=False, dir=test_case.parent) as tmp_file:
             with open(test_case) as in_file:
                 i = 0

--- a/cvise/passes/includeincludes.py
+++ b/cvise/passes/includeincludes.py
@@ -20,7 +20,7 @@ class IncludeIncludesPass(AbstractPass):
     def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return state
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, *args, **kwargs):
         with open(test_case) as in_file:
             with tempfile.NamedTemporaryFile(mode='w+', delete=False, dir=test_case.parent) as tmp_file:
                 includes = 0

--- a/cvise/passes/includes.py
+++ b/cvise/passes/includes.py
@@ -20,7 +20,7 @@ class IncludesPass(AbstractPass):
     def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return state
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, *args, **kwargs):
         with tempfile.NamedTemporaryFile(mode='w+', delete=False, dir=test_case.parent) as tmp_file:
             with open(test_case) as in_file:
                 includes = 0

--- a/cvise/passes/indent.py
+++ b/cvise/passes/indent.py
@@ -17,7 +17,7 @@ class IndentPass(AbstractPass):
     def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return state + 1
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, process_event_notifier, *args, **kwargs):
         if state != 0:
             return (PassResult.STOP, state)
 

--- a/cvise/passes/ints.py
+++ b/cvise/passes/ints.py
@@ -90,7 +90,7 @@ class IntsPass(AbstractPass):
     def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return self.new(test_case)
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, *args, **kwargs):
         data = test_case.read_text()
         index = state['index']
         ((start, end), replacement) = state['modifications'][index]

--- a/cvise/passes/peep.py
+++ b/cvise/passes/peep.py
@@ -205,7 +205,7 @@ class PeepPass(AbstractPass):
     def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return state
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, *args, **kwargs):
         prog = test_case.read_text()
         prog2 = prog
 

--- a/cvise/passes/special.py
+++ b/cvise/passes/special.py
@@ -63,7 +63,7 @@ class SpecialPass(AbstractPass):
     def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return self.new(test_case)
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, *args, **kwargs):
         data = test_case.read_text()
         index = state['index']
         ((start, end), replacement) = state['modifications'][index]

--- a/cvise/passes/ternary.py
+++ b/cvise/passes/ternary.py
@@ -41,7 +41,7 @@ class TernaryPass(AbstractPass):
     def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return self.__get_next_match(test_case, pos=state['all'][0])
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, *args, **kwargs):
         prog = test_case.read_text()
         prog2 = prog
 

--- a/cvise/passes/unifdef.py
+++ b/cvise/passes/unifdef.py
@@ -20,7 +20,7 @@ class UnIfDefPass(AbstractPass):
     def advance_on_success(self, test_case: Path, state, *args, **kwargs):
         return state
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, process_event_notifier, *args, **kwargs):
         try:
             cmd = [self.external_programs['unifdef'], '-s', str(test_case)]
             proc = subprocess.run(cmd, text=True, capture_output=True)

--- a/cvise/tests/test_balanced.py
+++ b/cvise/tests/test_balanced.py
@@ -23,7 +23,9 @@ class BalancedParensTestCase(unittest.TestCase):
         self.input_path.write_text('This is a (simple) test!\n')
 
         state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
-        (_, state) = self.pass_.transform(self.input_path, state, None)
+        (_, state) = self.pass_.transform(
+            self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+        )
 
         variant = self.input_path.read_text()
         self.assertEqual(variant, 'This is a  test!\n')
@@ -32,7 +34,9 @@ class BalancedParensTestCase(unittest.TestCase):
         self.input_path.write_text('This (is a (simple) test)!\n')
 
         state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
-        (_, state) = self.pass_.transform(self.input_path, state, None)
+        (_, state) = self.pass_.transform(
+            self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+        )
 
         variant = self.input_path.read_text()
         self.assertEqual(variant, 'This !\n')
@@ -43,7 +47,9 @@ class BalancedParensTestCase(unittest.TestCase):
         state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         # Transform failed
         state = self.pass_.advance(self.input_path, state)
-        (_, state) = self.pass_.transform(self.input_path, state, None)
+        (_, state) = self.pass_.transform(
+            self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+        )
 
         variant = self.input_path.read_text()
         self.assertEqual(variant, 'This (is a  test)!\n')
@@ -65,7 +71,9 @@ class BalancedParensOnlyTestCase(unittest.TestCase):
         self.input_path.write_text('This is a (simple) test!\n')
 
         state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
-        (_, state) = self.pass_.transform(self.input_path, state, None)
+        (_, state) = self.pass_.transform(
+            self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+        )
 
         variant = self.input_path.read_text()
         self.assertEqual(variant, 'This is a simple test!\n')
@@ -86,7 +94,9 @@ class BalancedParensOnlyTestCase(unittest.TestCase):
         state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         # Transform failed
         state = self.pass_.advance(self.input_path, state)
-        (_, state) = self.pass_.transform(self.input_path, state, None)
+        (_, state) = self.pass_.transform(
+            self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+        )
 
         variant = self.input_path.read_text()
         self.assertEqual(variant, 'This (is a simple test)!\n')
@@ -105,7 +115,9 @@ class BalancedParensOnlyTestCase(unittest.TestCase):
         self.input_path.write_text('(This) (is a (((more)) complex) test)!\n')
 
         state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
-        (result, state) = self.pass_.transform(self.input_path, state, None)
+        (result, state) = self.pass_.transform(
+            self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+        )
 
         iteration = 0
 
@@ -113,7 +125,9 @@ class BalancedParensOnlyTestCase(unittest.TestCase):
             state = self.pass_.advance_on_success(self.input_path, state)
             if state is None:
                 break
-            (result, state) = self.pass_.transform(self.input_path, state, None)
+            (result, state) = self.pass_.transform(
+                self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+            )
             iteration += 1
 
         variant = self.input_path.read_text()
@@ -148,7 +162,9 @@ class BalancedParensInsideTestCase(unittest.TestCase):
         self.input_path.write_text('This is a (simple) test!\n')
 
         state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
-        (_, state) = self.pass_.transform(self.input_path, state, None)
+        (_, state) = self.pass_.transform(
+            self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+        )
 
         variant = self.input_path.read_text()
         self.assertEqual(variant, 'This is a () test!\n')
@@ -157,7 +173,9 @@ class BalancedParensInsideTestCase(unittest.TestCase):
         self.input_path.write_text('This (is a (simple) test)!\n')
 
         state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
-        (_, state) = self.pass_.transform(self.input_path, state, None)
+        (_, state) = self.pass_.transform(
+            self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+        )
 
         variant = self.input_path.read_text()
         self.assertEqual(variant, 'This ()!\n')
@@ -168,7 +186,9 @@ class BalancedParensInsideTestCase(unittest.TestCase):
         state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         # Transform failed
         state = self.pass_.advance(self.input_path, state)
-        (_, state) = self.pass_.transform(self.input_path, state, None)
+        (_, state) = self.pass_.transform(
+            self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+        )
 
         variant = self.input_path.read_text()
         self.assertEqual(variant, 'This (is a () test)!\n')
@@ -225,7 +245,9 @@ class BalancedParensToZeroTestCase(unittest.TestCase):
         self.input_path.write_text('int x = (10 + y) / 2;\n')
 
         state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
-        (_, state) = self.pass_.transform(self.input_path, state, None)
+        (_, state) = self.pass_.transform(
+            self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+        )
 
         variant = self.input_path.read_text()
         self.assertEqual(variant, 'int x = 0 / 2;\n')
@@ -247,7 +269,9 @@ class BalancedCurly3TestCase(unittest.TestCase):
         self.input_path.write_text('A a = { x, y };\n')
 
         state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
-        (_, state) = self.pass_.transform(self.input_path, state, None)
+        (_, state) = self.pass_.transform(
+            self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+        )
 
         variant = self.input_path.read_text()
         self.assertEqual(variant, 'A a ;\n')

--- a/cvise/tests/test_comments.py
+++ b/cvise/tests/test_comments.py
@@ -18,7 +18,9 @@ class CommentsTestCase(unittest.TestCase):
 
         state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         validate_stored_hints(state)
-        (_, state) = self.pass_.transform(self.input_path, state, None)
+        (_, state) = self.pass_.transform(
+            self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+        )
 
         variant = self.input_path.read_text()
         self.assertEqual(variant, 'This  !\n')
@@ -28,7 +30,9 @@ class CommentsTestCase(unittest.TestCase):
 
         state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         validate_stored_hints(state)
-        (_, state) = self.pass_.transform(self.input_path, state, None)
+        (_, state) = self.pass_.transform(
+            self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+        )
 
         variant = self.input_path.read_text()
         self.assertEqual(variant, 'This \n \n!\n')
@@ -38,13 +42,17 @@ class CommentsTestCase(unittest.TestCase):
 
         state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         validate_stored_hints(state)
-        (result, state) = self.pass_.transform(self.input_path, state, None)
+        (result, state) = self.pass_.transform(
+            self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+        )
 
         while result == PassResult.OK and state is not None:
             state = self.pass_.advance_on_success(self.input_path, state)
             if state is None:
                 break
-            (result, state) = self.pass_.transform(self.input_path, state, None)
+            (result, state) = self.pass_.transform(
+                self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+            )
 
         variant = self.input_path.read_text()
         self.assertEqual(variant, ' \n \n!\n')
@@ -54,7 +62,9 @@ class CommentsTestCase(unittest.TestCase):
 
         state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         validate_stored_hints(state)
-        (result, state) = self.pass_.transform(self.input_path, state, None)
+        (result, state) = self.pass_.transform(
+            self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+        )
 
         while result == PassResult.OK and state is not None:
             self.input_path.write_text('/*This*/ ///contains //two\n //comments\n!\n')
@@ -62,14 +72,18 @@ class CommentsTestCase(unittest.TestCase):
             state = self.pass_.advance(self.input_path, state)
             if state is None:
                 break
-            (result, state) = self.pass_.transform(self.input_path, state, None)
+            (result, state) = self.pass_.transform(
+                self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+            )
 
     def test_non_ascii(self):
         self.input_path.write_bytes(b'int x;\n// Streichholzsch\xc3\xa4chtelchen\nchar t[] = "nonutf\xff";\n// \xff\n')
 
         state = self.pass_.new(self.input_path, tmp_dir=self.tmp_dir)
         validate_stored_hints(state)
-        (_, state) = self.pass_.transform(self.input_path, state, None)
+        (_, state) = self.pass_.transform(
+            self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
+        )
 
         variant = self.input_path.read_bytes()
         self.assertEqual(variant, b'int x;\n\nchar t[] = "nonutf\xff";\n\n')

--- a/cvise/tests/test_hint.py
+++ b/cvise/tests/test_hint.py
@@ -7,8 +7,13 @@ from cvise.utils.hint import apply_hints, HintBundle, load_hints, store_hints, H
 
 
 @pytest.fixture
-def tmp_file(tmp_path: Path) -> Path:
+def tmp_test_case(tmp_path: Path) -> Path:
     return tmp_path / 'file.txt'
+
+
+@pytest.fixture
+def tmp_transformed_file(tmp_path: Path) -> Path:
+    return tmp_path / 'transformed.txt'
 
 
 @pytest.fixture
@@ -16,41 +21,41 @@ def tmp_hints_file(tmp_path: Path) -> Path:
     return tmp_path / 'hints.zst'
 
 
-def test_apply_hints_delete_prefix(tmp_file: Path):
-    tmp_file.write_text('Foo bar')
+def test_apply_hints_delete_prefix(tmp_test_case: Path, tmp_transformed_file: Path):
+    tmp_test_case.write_text('Foo bar')
     hint = {'p': [{'l': 0, 'r': 4}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
     bundle = HintBundle(hints=[hint])
 
-    new_data, stats = apply_hints([bundle], tmp_file)
+    apply_hints([bundle], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b'bar'
+    assert tmp_transformed_file.read_text() == 'bar'
 
 
-def test_apply_hints_delete_suffix(tmp_file: Path):
-    tmp_file.write_text('Foo bar')
+def test_apply_hints_delete_suffix(tmp_test_case: Path, tmp_transformed_file: Path):
+    tmp_test_case.write_text('Foo bar')
     hint = {'p': [{'l': 3, 'r': 7}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
     bundle = HintBundle(hints=[hint])
 
-    new_data, stats = apply_hints([bundle], tmp_file)
+    apply_hints([bundle], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b'Foo'
+    assert tmp_transformed_file.read_text() == 'Foo'
 
 
-def test_apply_hints_delete_middle(tmp_file: Path):
-    tmp_file.write_text('Foo bar baz')
+def test_apply_hints_delete_middle(tmp_test_case: Path, tmp_transformed_file: Path):
+    tmp_test_case.write_text('Foo bar baz')
     hint = {'p': [{'l': 3, 'r': 7}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
     bundle = HintBundle(hints=[hint])
 
-    new_data, stats = apply_hints([bundle], tmp_file)
+    apply_hints([bundle], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b'Foo baz'
+    assert tmp_transformed_file.read_text() == 'Foo baz'
 
 
-def test_apply_hints_delete_middle_multiple(tmp_file: Path):
-    tmp_file.write_text('Foo bar baz')
+def test_apply_hints_delete_middle_multiple(tmp_test_case: Path, tmp_transformed_file: Path):
+    tmp_test_case.write_text('Foo bar baz')
     hint1 = {'p': [{'l': 3, 'r': 4}]}
     hint2 = {'p': [{'l': 7, 'r': 8}]}
     hints = [hint1, hint2]
@@ -58,24 +63,24 @@ def test_apply_hints_delete_middle_multiple(tmp_file: Path):
         jsonschema.validate(h, schema=HINT_SCHEMA)
     bundle = HintBundle(hints=hints)
 
-    new_data, stats = apply_hints([bundle], tmp_file)
+    apply_hints([bundle], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b'Foobarbaz'
+    assert tmp_transformed_file.read_text() == 'Foobarbaz'
 
 
-def test_apply_hints_delete_all(tmp_file: Path):
-    tmp_file.write_text('Foo bar')
+def test_apply_hints_delete_all(tmp_test_case: Path, tmp_transformed_file: Path):
+    tmp_test_case.write_text('Foo bar')
     hint = {'p': [{'l': 0, 'r': 7}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
     bundle = HintBundle(hints=[hint])
 
-    new_data, stats = apply_hints([bundle], tmp_file)
+    apply_hints([bundle], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b''
+    assert tmp_transformed_file.read_text() == ''
 
 
-def test_apply_hints_delete_touching(tmp_file: Path):
-    tmp_file.write_text('Foo bar baz')
+def test_apply_hints_delete_touching(tmp_test_case: Path, tmp_transformed_file: Path):
+    tmp_test_case.write_text('Foo bar baz')
     # It's essentially the deletion of [3..7).
     hint1 = {'p': [{'l': 3, 'r': 4}]}
     hint2 = {'p': [{'l': 6, 'r': 7}]}
@@ -85,13 +90,13 @@ def test_apply_hints_delete_touching(tmp_file: Path):
         jsonschema.validate(h, schema=HINT_SCHEMA)
     bundle = HintBundle(hints=hints)
 
-    new_data, stats = apply_hints([bundle], tmp_file)
+    apply_hints([bundle], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b'Foo baz'
+    assert tmp_transformed_file.read_text() == 'Foo baz'
 
 
-def test_apply_hints_delete_overlapping(tmp_file: Path):
-    tmp_file.write_text('Foo bar baz')
+def test_apply_hints_delete_overlapping(tmp_test_case: Path, tmp_transformed_file: Path):
+    tmp_test_case.write_text('Foo bar baz')
     # It's essentially the deletion of [3..7).
     hint1 = {'p': [{'l': 3, 'r': 6}]}
     hint2 = {'p': [{'l': 4, 'r': 7}]}
@@ -100,13 +105,13 @@ def test_apply_hints_delete_overlapping(tmp_file: Path):
         jsonschema.validate(h, schema=HINT_SCHEMA)
     bundle = HintBundle(hints=hints)
 
-    new_data, stats = apply_hints([bundle], tmp_file)
+    apply_hints([bundle], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b'Foo baz'
+    assert tmp_transformed_file.read_text() == 'Foo baz'
 
 
-def test_apply_hints_delete_nested(tmp_file: Path):
-    tmp_file.write_text('Foo bar baz')
+def test_apply_hints_delete_nested(tmp_test_case: Path, tmp_transformed_file: Path):
+    tmp_test_case.write_text('Foo bar baz')
     hint1 = {'p': [{'l': 4, 'r': 6}]}
     hint2 = {'p': [{'l': 3, 'r': 7}]}
     hints = [hint1, hint2]
@@ -114,40 +119,40 @@ def test_apply_hints_delete_nested(tmp_file: Path):
         jsonschema.validate(h, schema=HINT_SCHEMA)
     bundle = HintBundle(hints=hints)
 
-    new_data, stats = apply_hints([bundle], tmp_file)
+    apply_hints([bundle], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b'Foo baz'
+    assert tmp_transformed_file.read_text() == 'Foo baz'
 
 
-def test_apply_hints_replace_with_shorter(tmp_file: Path):
+def test_apply_hints_replace_with_shorter(tmp_test_case: Path, tmp_transformed_file: Path):
     """Test a hint replacing a fragment with a shorter value."""
-    tmp_file.write_text('Foo foobarbaz baz')
+    tmp_test_case.write_text('Foo foobarbaz baz')
     vocab = ['xyz']
     hint = {'p': [{'l': 4, 'r': 13, 'v': 0}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
     bundle = HintBundle(vocabulary=vocab, hints=[hint])
 
-    new_data, stats = apply_hints([bundle], tmp_file)
+    apply_hints([bundle], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b'Foo xyz baz'
+    assert tmp_transformed_file.read_text() == 'Foo xyz baz'
 
 
-def test_apply_hints_replace_with_longer(tmp_file: Path):
+def test_apply_hints_replace_with_longer(tmp_test_case: Path, tmp_transformed_file: Path):
     """Test a hint replacing a fragment with a longer value."""
-    tmp_file.write_text('Foo x baz')
+    tmp_test_case.write_text('Foo x baz')
     vocab = ['z', 'abacaba']
     hint = {'p': [{'l': 4, 'r': 5, 'v': 1}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
     bundle = HintBundle(vocabulary=vocab, hints=[hint])
 
-    new_data, stats = apply_hints([bundle], tmp_file)
+    apply_hints([bundle], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b'Foo abacaba baz'
+    assert tmp_transformed_file.read_text() == 'Foo abacaba baz'
 
 
-def test_apply_hints_replacement_inside_deletion(tmp_file: Path):
+def test_apply_hints_replacement_inside_deletion(tmp_test_case: Path, tmp_transformed_file: Path):
     """Test that a replacement is a no-op if happening inside a to-be-deleted fragment."""
-    tmp_file.write_text('Foo bar baz')
+    tmp_test_case.write_text('Foo bar baz')
     vocab = ['x']
     hint1 = {'p': [{'l': 5, 'r': 6, 'v': 0}]}  # replaces "a" with "x" in "bar"
     hint2 = {'p': [{'l': 4, 'r': 7}]}  # deletes "bar"
@@ -156,14 +161,14 @@ def test_apply_hints_replacement_inside_deletion(tmp_file: Path):
         jsonschema.validate(h, schema=HINT_SCHEMA)
     bundle = HintBundle(vocabulary=vocab, hints=hints)
 
-    new_data, stats = apply_hints([bundle], tmp_file)
+    apply_hints([bundle], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b'Foo  baz'
+    assert tmp_transformed_file.read_text() == 'Foo  baz'
 
 
-def test_apply_hints_deletion_inside_replacement(tmp_file: Path):
+def test_apply_hints_deletion_inside_replacement(tmp_test_case: Path, tmp_transformed_file: Path):
     """Test that a deletion is a no-op if happening inside a to-be-replaced fragment."""
-    tmp_file.write_text('Foo bar baz')
+    tmp_test_case.write_text('Foo bar baz')
     vocab = ['some']
     hint1 = {'p': [{'l': 5, 'r': 6}]}  # deletes "a" in "bar"
     hint2 = {'p': [{'l': 4, 'r': 7, 'v': 0}]}  # replaces "bar" with "some"
@@ -172,17 +177,17 @@ def test_apply_hints_deletion_inside_replacement(tmp_file: Path):
         jsonschema.validate(h, schema=HINT_SCHEMA)
     bundle = HintBundle(vocabulary=vocab, hints=hints)
 
-    new_data, stats = apply_hints([bundle], tmp_file)
+    apply_hints([bundle], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b'Foo some baz'
+    assert tmp_transformed_file.read_text() == 'Foo some baz'
 
 
-def test_apply_hints_replacement_of_deleted_prefix(tmp_file: Path):
+def test_apply_hints_replacement_of_deleted_prefix(tmp_test_case: Path, tmp_transformed_file: Path):
     """Test that a deletion takes precedence over a replacement of the same substring's prefix.
 
     This covers the specific implementation detail of conflict resolution, beyond the simple rule "the leftmost hint
     wins in a group of overlapping hints" that'd suffice for other tests."""
-    tmp_file.write_text('Foo bar baz')
+    tmp_test_case.write_text('Foo bar baz')
     vocab = ['x']
     hint1 = {'p': [{'l': 4, 'r': 5, 'v': 0}]}  # replaces "b" with "x" in "bar"
     hint2 = {'p': [{'l': 4, 'r': 7}]}  # deletes "bar"
@@ -191,14 +196,14 @@ def test_apply_hints_replacement_of_deleted_prefix(tmp_file: Path):
         jsonschema.validate(h, schema=HINT_SCHEMA)
     bundle = HintBundle(vocabulary=vocab, hints=hints)
 
-    new_data, stats = apply_hints([bundle], tmp_file)
+    apply_hints([bundle], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b'Foo  baz'
+    assert tmp_transformed_file.read_text() == 'Foo  baz'
 
 
-def test_apply_hints_replacement_and_deletion_touching(tmp_file: Path):
+def test_apply_hints_replacement_and_deletion_touching(tmp_test_case: Path, tmp_transformed_file: Path):
     """Test that deletions and replacements in touching, but not overlapping, fragments are applied independently."""
-    tmp_file.write_text('Foo bar baz')
+    tmp_test_case.write_text('Foo bar baz')
     vocab = ['some']
     hint1 = {'p': [{'l': 5, 'r': 7, 'v': 0}]}  # replaces "ar" with "some"
     hint2 = {'p': [{'l': 4, 'r': 5}]}  # deletes "b" in "bar"
@@ -208,17 +213,17 @@ def test_apply_hints_replacement_and_deletion_touching(tmp_file: Path):
         jsonschema.validate(h, schema=HINT_SCHEMA)
     bundle = HintBundle(vocabulary=vocab, hints=hints)
 
-    new_data, stats = apply_hints([bundle], tmp_file)
+    apply_hints([bundle], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b'Foo somebaz'
+    assert tmp_transformed_file.read_text() == 'Foo somebaz'
 
 
-def test_apply_hints_overlapping_replacements(tmp_file: Path):
+def test_apply_hints_overlapping_replacements(tmp_test_case: Path, tmp_transformed_file: Path):
     """Test overlapping replacements are handled gracefully.
 
     As there's no ideal solution for this kind of merge conflict, the main goal is to verify the implementation doesn't
     break. At the moment, the leftwise patch wins in this case, but this is subject to change in the future."""
-    tmp_file.write_text('abcd')
+    tmp_test_case.write_text('abcd')
     vocab = ['foo', 'x']
     hint1 = {'p': [{'l': 1, 'r': 3, 'v': 0}]}  # replaces "bc" with "foo"
     hint2 = {'p': [{'l': 2, 'r': 4, 'v': 1}]}  # replaces "cd" with "x"
@@ -227,13 +232,13 @@ def test_apply_hints_overlapping_replacements(tmp_file: Path):
         jsonschema.validate(h, schema=HINT_SCHEMA)
     bundle = HintBundle(vocabulary=vocab, hints=hints)
 
-    new_data, stats = apply_hints([bundle], tmp_file)
+    apply_hints([bundle], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b'afoo'
+    assert tmp_transformed_file.read_text() == 'afoo'
 
 
-def test_apply_hints_multiple_bundles(tmp_file: Path):
-    tmp_file.write_text('foobar')
+def test_apply_hints_multiple_bundles(tmp_test_case: Path, tmp_transformed_file: Path):
+    tmp_test_case.write_text('foobar')
     hint02 = {'p': [{'l': 0, 'r': 2}]}
     hint13 = {'p': [{'l': 1, 'r': 3}]}
     hint24 = {'p': [{'l': 2, 'r': 4}]}
@@ -243,13 +248,13 @@ def test_apply_hints_multiple_bundles(tmp_file: Path):
     bundle1 = HintBundle(hints=[hint13])
     bundle2 = HintBundle(hints=[hint02, hint24])
 
-    new_data, stats = apply_hints([bundle1, bundle2], tmp_file)
+    apply_hints([bundle1, bundle2], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b'ar'
+    assert tmp_transformed_file.read_text() == 'ar'
 
 
-def test_apply_hints_utf8(tmp_file: Path):
-    tmp_file.write_text('Brötchen 🍴')
+def test_apply_hints_utf8(tmp_test_case: Path, tmp_transformed_file: Path):
+    tmp_test_case.write_text('Brötchen 🍴')
     hint1 = {'p': [{'l': 0, 'r': 1}, {'l': 5, 'r': 7}]}
     hint2 = {'p': [{'l': 10, 'r': 14}]}
     hints = [hint1]
@@ -258,26 +263,25 @@ def test_apply_hints_utf8(tmp_file: Path):
     bundle1 = HintBundle(hints=[hint1])
     bundle2 = HintBundle(hints=[hint2])
 
-    result1, stats1 = apply_hints([bundle1], tmp_file)
-    result2, stats2 = apply_hints([bundle2], tmp_file)
+    apply_hints([bundle1], tmp_test_case, tmp_transformed_file)
+    assert tmp_transformed_file.read_text() == 'röten 🍴'
+    apply_hints([bundle2], tmp_test_case, tmp_transformed_file)
+    assert tmp_transformed_file.read_text() == 'Brötchen '
 
-    assert result1 == 'röten 🍴'.encode()
-    assert result2 == 'Brötchen '.encode()
 
-
-def test_apply_hints_non_unicode(tmp_file: Path):
-    tmp_file.write_bytes(b'\0F\xffoo')
+def test_apply_hints_non_unicode(tmp_test_case: Path, tmp_transformed_file: Path):
+    tmp_test_case.write_bytes(b'\0F\xffoo')
     hint = {'p': [{'l': 2, 'r': 3}]}
     jsonschema.validate(hint, schema=HINT_SCHEMA)
     bundle = HintBundle(hints=[hint])
 
-    new_data, stats = apply_hints([bundle], tmp_file)
+    apply_hints([bundle], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b'\0Foo'
+    assert tmp_transformed_file.read_bytes() == b'\0Foo'
 
 
-def test_apply_hints_statistics(tmp_file: Path):
-    tmp_file.write_text('Foo bar baz')
+def test_apply_hints_statistics(tmp_test_case: Path, tmp_transformed_file: Path):
+    tmp_test_case.write_text('Foo bar baz')
     hint03 = {'p': [{'l': 0, 'r': 3}]}
     hint07 = {'p': [{'l': 0, 'r': 7}]}
     hint89 = {'p': [{'l': 8, 'r': 9}]}
@@ -287,9 +291,9 @@ def test_apply_hints_statistics(tmp_file: Path):
     bundle1 = HintBundle(hints=[hint03, hint89], pass_name='pass1')
     bundle2 = HintBundle(hints=[hint07], pass_name='pass2')
 
-    new_data, stats = apply_hints([bundle1, bundle2], tmp_file)
+    stats = apply_hints([bundle1, bundle2], tmp_test_case, tmp_transformed_file)
 
-    assert new_data == b' az'
+    assert tmp_transformed_file.read_text() == ' az'
     assert stats.size_delta_per_pass == {'pass1': -1, 'pass2': -7}
     assert stats.get_passes_ordered_by_delta() == ['pass2', 'pass1']
 
@@ -306,14 +310,14 @@ def test_store_load_hints(tmp_hints_file):
     assert load_hints(tmp_hints_file, 1, 2) == HintBundle(vocabulary=vocab, hints=[hint2])
 
 
-def test_hints_storage_compression(tmp_file: Path):
+def test_hints_storage_compression(tmp_hints_file: Path):
     COUNT = 10000
     hints = [{'p': [{'l': i, 'r': i + 1}]} for i in range(COUNT)]
     bundle = HintBundle(hints=hints)
-    store_hints(bundle, tmp_file)
+    store_hints(bundle, tmp_hints_file)
 
     # Check that the file is significantly smaller than a regular JSON representation (without extra spaces around
     # separators).
     RATIO_AT_LEAST = 10
     hints_json_size = len(json.dumps(hints, separators=(',', ':')))
-    assert tmp_file.stat().st_size * RATIO_AT_LEAST < hints_json_size
+    assert tmp_hints_file.stat().st_size * RATIO_AT_LEAST < hints_json_size

--- a/cvise/tests/test_line_markers.py
+++ b/cvise/tests/test_line_markers.py
@@ -21,7 +21,7 @@ def test_all(tmp_path: Path, input_path: Path):
     input_path.write_text("# 1 'foo.h'\n# 2 'bar.h'\n#4   'x.h'")
     pass_, state = init_pass(tmp_path, input_path)
 
-    (_, state) = pass_.transform(input_path, state, None)
+    (_, state) = pass_.transform(input_path, state, process_event_notifier=None, original_test_case=input_path)
 
     assert input_path.read_text() == ''
 
@@ -30,7 +30,7 @@ def test_only_last(tmp_path: Path, input_path: Path):
     input_path.write_text("# 1 'foo.h'\n# 2 'bar.h'\n#4   'x.h\nint x = 2;")
     pass_, state = init_pass(tmp_path, input_path)
 
-    (_, state) = pass_.transform(input_path, state, None)
+    (_, state) = pass_.transform(input_path, state, process_event_notifier=None, original_test_case=input_path)
 
     assert input_path.read_text() == 'int x = 2;'
 
@@ -54,7 +54,7 @@ def test_non_ascii(tmp_path: Path, input_path: Path):
         """,
     )
     pass_, state = init_pass(tmp_path, input_path)
-    (_, state) = pass_.transform(input_path, state, None)
+    (_, state) = pass_.transform(input_path, state, process_event_notifier=None, original_test_case=input_path)
 
     assert (
         input_path.read_bytes()

--- a/cvise/tests/test_lines.py
+++ b/cvise/tests/test_lines.py
@@ -22,7 +22,7 @@ def init_pass(depth, tmp_dir: Path, input_path: Path) -> Tuple[LinesPass, Any]:
 def advance_until(pass_, state, input_path: Path, predicate):
     backup = input_path.read_bytes()
     while True:
-        pass_.transform(input_path, state, process_event_notifier=None)
+        pass_.transform(input_path, state, process_event_notifier=None, original_test_case=input_path)
         if predicate(input_path.read_bytes()):
             return state
         input_path.write_bytes(backup)

--- a/cvise/tests/test_test_manager.py
+++ b/cvise/tests/test_test_manager.py
@@ -34,7 +34,7 @@ class StubPass(AbstractPass):
 class NaiveLinePass(StubPass):
     """Simple real-world-like pass that removes a line at a time."""
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, *args, **kwargs):
         with open(test_case) as f:
             lines = f.readlines()
         if not lines:
@@ -51,14 +51,14 @@ class NaiveLinePass(StubPass):
 class AlwaysInvalidPass(StubPass):
     """Never succeeds."""
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, *args, **kwargs):
         return (PassResult.INVALID, state)
 
 
 class HungPass(StubPass):
     """A very slow pass, for testing timeouts."""
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, *args, **kwargs):
         INFINITY = 1000
         time.sleep(INFINITY)
         return (PassResult.INVALID, state)
@@ -71,10 +71,10 @@ class NInvalidThenLinesPass(NaiveLinePass):
         super().__init__()
         self.invalid_n = invalid_n
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, *args, **kwargs):
         if state < self.invalid_n:
             return (PassResult.INVALID, state)
-        return super().transform(test_case, state, process_event_notifier)
+        return super().transform(test_case, state, *args, **kwargs)
 
 
 class OneOffLinesPass(NaiveLinePass):
@@ -87,7 +87,7 @@ class OneOffLinesPass(NaiveLinePass):
 class AlwaysUnalteredPass(StubPass):
     """Simulates the "buggy OKs infinite number of times" scenario."""
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, *args, **kwargs):
         return (PassResult.OK, state)
 
 
@@ -96,7 +96,7 @@ class SlowUnalteredThenStoppingPass(StubPass):
 
     DELAY_SECS = 1  # the larger the number, the higher the chance of catching bugs
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, *args, **kwargs):
         if state == 0:
             time.sleep(self.DELAY_SECS)
             return (PassResult.OK, state)
@@ -112,7 +112,7 @@ class LetterRemovingPass(StubPass):
         super().__init__()
         self.letters_to_remove = letters_to_remove
 
-    def transform(self, test_case: Path, state, process_event_notifier):
+    def transform(self, test_case: Path, state, *args, **kwargs):
         text = test_case.read_text()
         instances = 0
         for i, c in enumerate(text):

--- a/cvise/utils/folding.py
+++ b/cvise/utils/folding.py
@@ -105,9 +105,9 @@ class FoldingManager:
 
     @staticmethod
     def transform(
-        test_case: Path, state: FoldingStateIn, *args, **kwargs
+        test_case: Path, state: FoldingStateIn, process_event_notifier, original_test_case: Path, *args, **kwargs
     ) -> Tuple[PassResult, Union[FoldingStateOut, None]]:
-        statistics = HintBasedPass.load_and_apply_hints(test_case, state.sub_states)
+        statistics = HintBasedPass.load_and_apply_hints(original_test_case, test_case, state.sub_states)
         return PassResult.OK, FoldingStateOut(
             sub_states=state.sub_states,
             statistics=statistics,


### PR DESCRIPTION
Before this commit, before any reduction attempt is made (Pass.transform()), the input test was copied, and the main C-Vise process was responsible for this.

The commit optimizes this in two aspects:

1. Copying is moved to the worker process. This improves throughput, since copying is likely to be well parallelizable (at least for typical *nix tmpfs setups), and it makes the main process' scheduler loop more responsive.

2. Copying is skipped altogether for hint-based passes. In theory, we could do this for all passes - each pass anyway has to overwrite the test case when doing the transformation - but the implementation effort would be higher, and only hint-based passes are executed in the beginning, when the inputs are still huge.

This optimization seems to bring between 0 and 10% speedup to C-Vise, depending on the test case.