### PR TITLE
logging: Collect logs in main process, filter out canceled jobs

### DIFF
--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -23,7 +23,7 @@ if importlib.util.find_spec('cvise') is None:
 import chardet  # noqa: E402
 from cvise.cvise import CVise  # noqa: E402
 from cvise.passes.abstract import AbstractPass  # noqa: E402
-from cvise.utils import statistics, testing  # noqa: E402
+from cvise.utils import mplogging, statistics, testing  # noqa: E402
 from cvise.utils.error import CViseError  # noqa: E402
 from cvise.utils.error import MissingPassGroupsError  # noqa: E402
 from cvise.utils.externalprograms import find_external_programs  # noqa: E402
@@ -444,82 +444,84 @@ def do_reduce(args):
         args.interestingness_test = script.name
 
     try:
-        test_manager = testing.TestManager(
-            pass_statistic,
-            Path(args.interestingness_test),
-            args.timeout,
-            args.save_temps,
-            [Path(s) for s in args.test_cases],
-            args.n,
-            args.no_cache,
-            args.skip_key_off,
-            args.shaddap,
-            args.die_on_pass_bug,
-            args.print_diff,
-            args.max_improvement,
-            args.no_give_up,
-            args.also_interesting,
-            args.start_with_pass,
-            args.skip_after_n_transforms,
-            args.stopping_threshold,
-        )
+        with mplogging.MPLogger(args.n) as mplogger:
+            test_manager = testing.TestManager(
+                pass_statistic,
+                Path(args.interestingness_test),
+                args.timeout,
+                args.save_temps,
+                [Path(s) for s in args.test_cases],
+                args.n,
+                args.no_cache,
+                args.skip_key_off,
+                args.shaddap,
+                args.die_on_pass_bug,
+                args.print_diff,
+                args.max_improvement,
+                args.no_give_up,
+                args.also_interesting,
+                args.start_with_pass,
+                args.skip_after_n_transforms,
+                args.stopping_threshold,
+                mplogger,
+            )
 
-        reducer = CVise(test_manager, args.skip_interestingness_test_check)
+            reducer = CVise(test_manager, args.skip_interestingness_test_check)
 
-        reducer.tidy = args.tidy
+            reducer.tidy = args.tidy
 
-        # Track runtime
-        time_start = time.monotonic()
+            # Track runtime
+            time_start = time.monotonic()
 
-        try:
-            reducer.reduce(pass_group, skip_initial=args.skip_initial_passes)
-        except CViseError as err:
-            time_stop = time.monotonic()
-            print(err)
-        else:
-            time_stop = time.monotonic()
-            with open(args.log_file, 'ab') if args.log_file else nullcontext(sys.stderr.buffer) as fs:
-                fs.write(b'===< PASS statistics >===\n')
+            try:
+                reducer.reduce(pass_group, skip_initial=args.skip_initial_passes)
+            except CViseError as err:
+                print(err)
+                return
+
+        time_stop = time.monotonic()
+        with open(args.log_file, 'ab') if args.log_file else nullcontext(sys.stderr.buffer) as fs:
+            fs.write(b'===< PASS statistics >===\n')
+            fs.write(
+                (
+                    '  %-60s %14s %8s %8s %8s %8s %15s\n'
+                    % (
+                        'pass name',
+                        'bytes reduced',
+                        'time (s)',
+                        'time (%)',
+                        'worked',
+                        'failed',
+                        'total executed',
+                    )
+                ).encode()
+            )
+
+            for pass_name, pass_data in pass_statistic.sorted_results:
                 fs.write(
                     (
-                        '  %-60s %14s %8s %8s %8s %8s %15s\n'
+                        '  %-60s %14d %8.2f %8.2f %8d %8d %15d\n'
                         % (
-                            'pass name',
-                            'bytes reduced',
-                            'time (s)',
-                            'time (%)',
-                            'worked',
-                            'failed',
-                            'total executed',
+                            pass_name,
+                            -pass_data.total_size_delta,
+                            pass_data.total_seconds,
+                            100.0 * pass_data.total_seconds / (time_stop - time_start),
+                            pass_data.worked,
+                            pass_data.failed,
+                            pass_data.totally_executed,
                         )
                     ).encode()
                 )
+            fs.write(b'\n')
 
-                for pass_name, pass_data in pass_statistic.sorted_results:
-                    fs.write(
-                        (
-                            '  %-60s %14d %8.2f %8.2f %8d %8d %15d\n'
-                            % (
-                                pass_name,
-                                -pass_data.total_size_delta,
-                                pass_data.total_seconds,
-                                100.0 * pass_data.total_seconds / (time_stop - time_start),
-                                pass_data.worked,
-                                pass_data.failed,
-                                pass_data.totally_executed,
-                            )
-                        ).encode()
-                    )
+            if not args.no_timing:
+                fs.write(f'Runtime: {round(time_stop - time_start)} seconds\n'.encode())
+
+            fs.write(b'Reduced test-cases:\n\n')
+            for test_case in sorted(test_manager.test_cases):
+                fs.write(f'--- {test_case} ---\n'.encode())
+                fs.write(test_case.read_bytes())
                 fs.write(b'\n')
-
-                if not args.no_timing:
-                    fs.write(f'Runtime: {round(time_stop - time_start)} seconds\n'.encode())
-
-                fs.write(b'Reduced test-cases:\n\n')
-                for test_case in sorted(test_manager.test_cases):
-                    fs.write(f'--- {test_case} ---\n'.encode())
-                    fs.write(test_case.read_bytes())
-                    fs.write(b'\n')
     finally:
         if script:
             os.unlink(script.name)

--- a/cvise/CMakeLists.txt
+++ b/cvise/CMakeLists.txt
@@ -120,6 +120,7 @@ set(SOURCE_FILES
   "utils/hint.py"
   "utils/keyboard_interrupt_monitor.py"
   "utils/misc.py"
+  "utils/mplogging.py"
   "utils/nestedmatcher.py"
   "utils/readkey.py"
   "utils/statistics.py"

--- a/cvise/tests/test_test_manager.py
+++ b/cvise/tests/test_test_manager.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 from cvise.passes.abstract import AbstractPass, PassResult  # noqa: E402
 from cvise.passes.hint_based import HintBasedPass  # noqa: E402
-from cvise.utils import keyboard_interrupt_monitor, statistics, testing  # noqa: E402
+from cvise.utils import keyboard_interrupt_monitor, mplogging, statistics, testing  # noqa: E402
 from cvise.utils.hint import HintBundle
 
 
@@ -238,6 +238,7 @@ def manager(tmp_path: Path, input_file: Path, interestingness_script, job_timeou
         START_WITH_PASS,
         SKIP_AFTER_N_TRANSFORMS,
         STOPPING_THRESHOLD,
+        mplogging.MPLogger(PARALLEL_TESTS),
     )
 
 

--- a/cvise/utils/mplogging.py
+++ b/cvise/utils/mplogging.py
@@ -1,0 +1,105 @@
+"""Collects logs from multiprocessing workers and filters out canceled workers."""
+
+from collections import deque
+import logging
+import multiprocessing
+import threading
+from typing import Any, Callable
+
+
+class MPLogger:
+    """Collects and processes logs from multiprocessing workers in the main process.
+
+    Main features:
+    * Discards logs from canceled jobs (to hide spurious errors from the user).
+    * Supports logging to file (otherwise workers would try to write to the same file simultaneously).
+
+    Each worker should use worker_process_initializer() and worker_process_job_wrapper().
+    """
+
+    def __init__(self, worker_count: int):
+        self._lock = threading.Lock()
+        # Use SimpleQueue and not Queue, because Pebble can terminate workers at an arbitrary time point, and Queue may
+        # be corrupted if a process is killed while writing to it.
+        self._queue = multiprocessing.SimpleQueue()
+        self._thread = threading.Thread(target=self._main_process_thread_main, daemon=True)
+        # Don't use indefinitely much memory to remember all canceled job orders throughout the whole C-Vise execution;
+        # there's only worker_count workers at a time, but we store a few times more because logs are handled
+        # asynchronously, after possibly new jobs have been started and canceled.
+        self._job_orders_to_ignore = deque(maxlen=worker_count * 10)
+
+    def __enter__(self):
+        self._thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # Notify the shutdown by putting a sentinel value to the queue, and wait until the background thread processes
+        # all remaining items and quits.
+        self._queue.put(None)
+        self._thread.join(timeout=60)  # semi-arbitrary timeout to prevent even theoretical possibility of deadlocks
+        self._queue.close()
+
+    def ignore_logs_from_job(self, job_order: int):
+        with self._lock:
+            self._job_orders_to_ignore.append(job_order)
+
+    def worker_process_initializer(self):
+        level = logging.getLogger().getEffectiveLevel()
+        queue = self._queue
+        return lambda: _init_in_worker_process(level, queue)
+
+    @staticmethod
+    def worker_process_job_wrapper(job_order: int, func: Callable) -> Any:
+        root = logging.getLogger()
+        filter = _JobOrderAttachingFilter(job_order)
+        root.addFilter(filter)
+        try:
+            return func()
+        finally:
+            root.removeFilter(filter)
+
+    def _main_process_thread_main(self):
+        """Receives logs from worker processes and either discards or processes them."""
+        try:
+            while True:
+                record = self._queue.get()
+                if record is None:
+                    return
+                if hasattr(record, 'job_order'):
+                    with self._lock:
+                        if record.job_order in self._job_orders_to_ignore:
+                            continue
+                logger = logging.getLogger(record.name)
+                logger.handle(record)
+        except:
+            # On error, just drain the queue without any extra logic - an overflown queue would block a subprocess
+            # that's trying to put items to it.
+            while self._queue.get():
+                pass
+            raise
+
+
+class _QueueAppendingHandler(logging.Handler):
+    def __init__(self, queue: multiprocessing.SimpleQueue):
+        super().__init__()
+        self._queue = queue
+
+    def emit(self, record: logging.LogRecord):
+        self._queue.put(record)
+
+
+class _JobOrderAttachingFilter(logging.Filter):
+    def __init__(self, job_order: int):
+        super().__init__()
+        self._job_order = job_order
+
+    def filter(self, record: logging.LogRecord):
+        record.job_order = self._job_order
+        return True
+
+
+def _init_in_worker_process(level: int, queue: multiprocessing.SimpleQueue):
+    root = logging.getLogger()
+    root.setLevel(level)
+    root.handlers.clear()
+    root.addHandler(_QueueAppendingHandler(queue))

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -15,14 +15,13 @@ import subprocess
 import sys
 import tempfile
 import time
-import traceback
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Set, Tuple, Union
 import concurrent.futures
 
 from cvise.cvise import CVise
 from cvise.passes.abstract import AbstractPass, PassResult, ProcessEventNotifier, ProcessEventType
 from cvise.passes.hint_based import HintBasedPass
-from cvise.utils import keyboard_interrupt_monitor
+from cvise.utils import keyboard_interrupt_monitor, mplogging
 from cvise.utils.error import AbsolutePathTestCaseError
 from cvise.utils.error import InsaneTestCaseError
 from cvise.utils.error import InvalidInterestingnessTestError
@@ -173,12 +172,8 @@ class TestEnvironment:
             logging.debug('Skipping pass due to a unicode issue')
             self.result = PassResult.STOP
             return self
-        except OSError:
-            # this can happen when we clean up temporary files for cancelled processes
-            return self
         except Exception as e:
-            print('Unexpected TestEnvironment::run failure: ' + str(e))
-            traceback.print_exc()
+            logging.exception(f'Unexpected TestEnvironment::run failure')
             return self
 
     def run_test(self, verbose):
@@ -353,6 +348,7 @@ class TestManager:
         start_with_pass,
         skip_after_n_transforms,
         stopping_threshold,
+        mplogger: mplogging.MPLogger,
     ):
         self.test_script: Path = test_script.absolute()
         self.timeout = timeout
@@ -372,6 +368,7 @@ class TestManager:
         self.start_with_pass = start_with_pass
         self.skip_after_n_transforms = skip_after_n_transforms
         self.stopping_threshold = stopping_threshold
+        self.mplogger = mplogger
 
         for test_case in test_cases:
             test_case = Path(test_case)
@@ -732,14 +729,18 @@ class TestManager:
         new.take_file_ownership(env.test_case_path)
         self.success_candidate = new
 
-    @classmethod
-    def terminate_all(cls, pool):
+    def terminate_all(self, pool):
+        for job in self.jobs:
+            self.mplogger.ignore_logs_from_job(job.order)
         pool.stop()
         pool.join()
 
     def run_parallel_tests(self) -> None:
         assert not self.jobs
-        with pebble.ProcessPool(max_workers=self.parallel_tests) as pool:
+        with pebble.ProcessPool(
+            max_workers=self.parallel_tests,
+            initializer=self.mplogger.worker_process_initializer(),
+        ) as pool:
             try:
                 self.current_batch_start_order = self.order
                 self.next_pass_id = 0
@@ -1034,7 +1035,7 @@ class TestManager:
                 pass_succeeded_state=ctx.taken_succeeded_state,
                 job_timeout=self.timeout,
             )
-        future = pool.schedule(env.run)
+        future = pool.schedule(self.mplogger.worker_process_job_wrapper, args=[self.order, env.run])
         self.jobs.append(
             Job(
                 type=JobType.INIT,
@@ -1072,7 +1073,9 @@ class TestManager:
             ctx.pass_.transform,
             self.pid_queue,
         )
-        future = pool.schedule(env.run, timeout=self.timeout)
+        future = pool.schedule(
+            self.mplogger.worker_process_job_wrapper, args=[self.order, env.run], timeout=self.timeout
+        )
         self.jobs.append(
             Job(
                 type=JobType.TRANSFORM,
@@ -1107,7 +1110,9 @@ class TestManager:
             FoldingManager.transform,
             self.pid_queue,
         )
-        future = pool.schedule(env.run, timeout=self.timeout)
+        future = pool.schedule(
+            self.mplogger.worker_process_job_wrapper, args=[self.order, env.run], timeout=self.timeout
+        )
         self.jobs.append(
             Job(
                 type=JobType.TRANSFORM,


### PR DESCRIPTION
Send logs from worker processes over an IPC pipe instead of printing them directly to stderr. Discard logs coming from canceled jobs.

This is a more robust approach than the previous silent discarding of all OSError exceptions. Also it fixes the problem with --log-file due to workers unable to write to this file concurrently. Additionally, it allows us to implement more aggressive worker reuse and cancellation in follow-up PRs.