### PR TITLE
Fix flakiness in test_cvise.py - trailing line break

### DIFF
--- a/tests/test_cvise.py
+++ b/tests/test_cvise.py
@@ -52,7 +52,7 @@ def test_simple_reduction(tmp_path: Path):
     check_cvise(
         'blocksort-part.c',
         ['-c', r"gcc -c blocksort-part.c && grep '\<nextHi\>' blocksort-part.c"],
-        ['#define nextHi'],
+        ['#define nextHi', '#define nextHi\n'],
         tmp_path,
     )
 
@@ -61,7 +61,7 @@ def test_simple_reduction_no_interleaving_config(tmp_path: Path):
     check_cvise(
         'blocksort-part.c',
         ['-c', r"gcc -c blocksort-part.c && grep '\<nextHi\>' blocksort-part.c", '--pass-group', 'no-interleaving'],
-        ['#define nextHi'],
+        ['#define nextHi', '#define nextHi\n'],
         tmp_path,
     )
 
@@ -191,6 +191,6 @@ def test_non_ascii_interestingness_test(tmp_path: Path):
     check_cvise(
         'blocksort-part.c',
         ['-c', r"printf '\xc3\xa4\xff'; gcc -c blocksort-part.c && grep '\<nextHi\>' blocksort-part.c"],
-        ['#define nextHi'],
+        ['#define nextHi', '#define nextHi\n'],
         tmp_path,
     )


### PR DESCRIPTION
The tests were occasionally failing because the result may or may not terminate with a newline character.