### PR TITLE
multiprocessing: Don't create pool many times

### DIFF
--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -430,6 +430,8 @@ class TestManager:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.exit_stack.__exit__(exc_type, exc_val, exc_tb)
+        self.worker_pool.stop()
+        self.worker_pool = None
 
     def remove_roots(self):
         if self.save_temps:


### PR DESCRIPTION
Have a single process pool instead of recreating it every time pass(es)
are to be executed. We only need to make sure to cancel running jobs.

This brings a significant speedup especially for small cases or for late
stages of reductions in general, where it takes just a fraction of a
second to discover a reduction. Now we don't have to pay the price for
initializing the Pebble pool - hundreds of milliseconds - repeatedly.

While empirical measurements show 1.5x-2x speedup, unfortunately
most of it will be "eaten" by the switch to "forkserver" multiprocessing
mode - the latter seems unavoidable to fix occasional deadlocks.