### PR TITLE
test_manager: Quickly exit worker on signal outside jobs

### DIFF
--- a/cvise/cvise.py
+++ b/cvise/cvise.py
@@ -94,7 +94,7 @@ class CVise:
     }
 
     def __init__(self, test_manager, skip_interestingness_test_check):
-        sigmonitor.init()
+        sigmonitor.init(use_exceptions=True)
         self.test_manager = test_manager
         self.skip_interestingness_test_check = skip_interestingness_test_check
         self.tidy = False

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -768,7 +768,7 @@ class TestManager:
                         self.pass_reinit_queue.append(pass_id)
 
                 while self.jobs or any(c.can_start_job_now() for c in self.pass_contexts):
-                    sigmonitor.maybe_reraise()
+                    sigmonitor.maybe_retrigger_action()
 
                     # schedule new jobs, as long as there are free workers
                     while len(self.jobs) < self.parallel_tests and self.maybe_schedule_job(pool):
@@ -1135,13 +1135,13 @@ def override_tmpdir_env(old_env: Mapping[str, str], tmp_override: Path) -> Mappi
 
 
 def _init_worker_process(mplogger_initializer: Callable) -> None:
-    sigmonitor.init()
+    # By default (when not executing a job), terminate a worker immediately on relevant signals. Raising an exception at
+    # unexpected times, especially inside multiprocessing internals, can put the worker into a bad state.
+    sigmonitor.init(use_exceptions=False)
     mplogger_initializer()
 
 
 def _worker_process_job_wrapper(job_order: int, func: Callable) -> Any:
-    with mplogging.worker_process_job_wrapper(job_order):
-        sigmonitor.maybe_reraise()
-        result = func()
-        sigmonitor.maybe_reraise()
-    return result
+    with sigmonitor.scoped_use_exceptions():
+        with mplogging.worker_process_job_wrapper(job_order):
+            return func()


### PR DESCRIPTION
Stress-testing showed that raising KeyboardInterrupt/SystemExit exceptions at unpredictable time points, especially inside multiprocessing internals, can put the worker into a dysfunctional state, which may lead to deadlocks.

This commit employs a different strategy: exception-based signal propagation in worker processes is only used when executing a job; this lets the job gracefully release resources, like kill spawned subprocesses. Once the job completes or when a signal is received without any job, the process is terminated immediately.