### PR TITLE
tests: Run pytest tests in parallel

### DIFF
--- a/.github/workflows/build-llvm-nightly.yml
+++ b/.github/workflows/build-llvm-nightly.yml
@@ -39,5 +39,5 @@ jobs:
         working-directory: objdir
       - run: make -j`nproc` VERBOSE=1
         working-directory: objdir
-      - run: pytest -n $(nproc)
+      - run: pytest -n $(($(nproc) + 1))
         working-directory: objdir

--- a/.github/workflows/build-llvm-nightly.yml
+++ b/.github/workflows/build-llvm-nightly.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - run: apt-get update
-      - run: apt-get -qq install -y gcc g++ wget lsb-release wget software-properties-common gnupg git cmake flex python3-pebble python3-psutil python3-chardet python3-msgspec python3-pytest python3-pytest-mock python3-pytest-subprocess python3-jsonschema python3-zstandard vim unifdef sudo
+      - run: apt-get -qq install -y gcc g++ wget lsb-release wget software-properties-common gnupg git cmake flex python3-pebble python3-psutil python3-chardet python3-msgspec python3-pytest python3-pytest-mock python3-pytest-subprocess python3-pytest-xdist python3-jsonschema python3-zstandard vim unifdef sudo
       - uses: rui314/setup-mold@v1
       - run: ld --version
       - run: nproc
@@ -39,5 +39,5 @@ jobs:
         working-directory: objdir
       - run: make -j`nproc` VERBOSE=1
         working-directory: objdir
-      - run: pytest
+      - run: pytest -n auto
         working-directory: objdir

--- a/.github/workflows/build-llvm-nightly.yml
+++ b/.github/workflows/build-llvm-nightly.yml
@@ -39,5 +39,5 @@ jobs:
         working-directory: objdir
       - run: make -j`nproc` VERBOSE=1
         working-directory: objdir
-      - run: pytest -n $(($(nproc) + 1))
+      - run: pytest -n $(nproc)
         working-directory: objdir

--- a/.github/workflows/build-llvm-nightly.yml
+++ b/.github/workflows/build-llvm-nightly.yml
@@ -39,5 +39,5 @@ jobs:
         working-directory: objdir
       - run: make -j`nproc` VERBOSE=1
         working-directory: objdir
-      - run: pytest -n auto
+      - run: pytest -n $(($(nproc) + 1))
         working-directory: objdir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
             ${{ matrix.env }} cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_FLAGS=${{ matrix.extra-flags }}
             make -j`nproc` VERBOSE=1
     - name: test
-      run: pytest -n $(($(nproc) + 1))
+      run: pytest -n $(nproc)
       working-directory: objdir
 
   ruff:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
             ${{ matrix.env }} cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_FLAGS=${{ matrix.extra-flags }}
             make -j`nproc` VERBOSE=1
     - name: test
-      run: pytest -n auto
+      run: pytest -n $(($(nproc) + 1))
       working-directory: objdir
 
   ruff:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,9 +39,9 @@ jobs:
     steps:
     - run: zypper -n install
         binutils clang${{ matrix.llvm }}-devel cmake flex gcc-c++ llvm${{ matrix.llvm }}-devel
-        python3-Pebble python3-pytest python3-pytest-mock python3-pytest-subprocess unifdef python3-psutil
-        curl git python3-chardet findutils sudo wget python3-pip python3-jsonschema python3-msgspec
-        python3-zstandard
+        python3-Pebble python3-pytest python3-pytest-mock python3-pytest-subprocess python3-pytest-xdist
+        unifdef python3-psutil curl git python3-chardet findutils sudo wget python3-pip python3-jsonschema
+        python3-msgspec python3-zstandard
     - run: zypper -n install sqlite-devel python3
     - run: pip install --break-system-packages pytest-cov
     - uses: rui314/setup-mold@v1
@@ -55,7 +55,7 @@ jobs:
             ${{ matrix.env }} cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_FLAGS=${{ matrix.extra-flags }}
             make -j`nproc` VERBOSE=1
     - name: test
-      run: pytest
+      run: pytest -n auto
       working-directory: objdir
 
   ruff:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
             ${{ matrix.env }} cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_FLAGS=${{ matrix.extra-flags }}
             make -j`nproc` VERBOSE=1
     - name: test
-      run: pytest -n $(nproc)
+      run: pytest -n $(($(nproc) + 1))
       working-directory: objdir
 
   ruff:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -106,6 +106,8 @@ Optional packages:
 
 * [pytest-subprocess](https://pypi.org/project/pytest-subprocess/)
 
+* [pytest-xdist](https://pypi.org/project/pytest-xdist/)
+
 * [colordiff](https://www.colordiff.org/)
 
 * [jsonschema](https://pypi.org/project/jsonschema/)


### PR DESCRIPTION
Use the pytest-xdist plugin to run tests concurrently to each other,
to shorten the wait time.

We use the "number_of_processing_units + 1" formula, to improve
resource utilization when tests are bound by i/o or other waits.