### PR TITLE
Fix colordiff exception

### DIFF
--- a/.github/workflows/build-llvm-nightly.yml
+++ b/.github/workflows/build-llvm-nightly.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - run: apt-get update
-      - run: apt-get -qq install -y gcc g++ wget lsb-release wget software-properties-common gnupg git cmake flex python3-pebble python3-psutil python3-chardet python3-msgspec python3-pytest python3-jsonschema python3-zstandard vim unifdef sudo
+      - run: apt-get -qq install -y gcc g++ wget lsb-release wget software-properties-common gnupg git cmake flex python3-pebble python3-psutil python3-chardet python3-msgspec python3-pytest python3-pytest-mock python3-pytest-subprocess python3-jsonschema python3-zstandard vim unifdef sudo
       - uses: rui314/setup-mold@v1
       - run: ld --version
       - run: nproc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,9 @@ jobs:
     steps:
     - run: zypper -n install
         binutils clang${{ matrix.llvm }}-devel cmake flex gcc-c++ llvm${{ matrix.llvm }}-devel
-        python3-Pebble python3-pytest unifdef python3-psutil curl git python3-chardet findutils
-        sudo wget python3-pip python3-jsonschema python3-msgspec python3-zstandard
+        python3-Pebble python3-pytest python3-pytest-mock python3-pytest-subprocess unifdef python3-psutil
+        curl git python3-chardet findutils sudo wget python3-pip python3-jsonschema python3-msgspec
+        python3-zstandard
     - run: zypper -n install sqlite-devel python3
     - run: pip install --break-system-packages pytest-cov
     - uses: rui314/setup-mold@v1
@@ -82,7 +83,7 @@ jobs:
       run: |
             python3.12 -m venv ~/venv
             source ~/venv/bin/activate
-            pip install chardet jsonschema msgspec pebble psutil pytest pytype zstandard
+            pip install chardet jsonschema msgspec pebble psutil pytest pytest-mock pytest-subprocess pytype zstandard
     - name: build
       run: |
             source ~/venv/bin/activate

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -102,6 +102,10 @@ Optional packages:
 
 * [pytest](https://docs.pytest.org/en/latest/)
 
+* [pytest-mock](https://pypi.org/project/pytest-mock/)
+
+* [pytest-subprocess](https://pypi.org/project/pytest-subprocess/)
+
 * [colordiff](https://www.colordiff.org/)
 
 * [jsonschema](https://pypi.org/project/jsonschema/)


### PR DESCRIPTION
Fix a bug causing the following exception when --print-diff is used, colordiff is installed and the output is a terminal tty:

  TypeError: memoryview: a bytes-like object is required, not 'str'

Also make the code robust to colordiff failures.