### PR TITLE
multifile: Add support to Tree-sitter pass

### DIFF
--- a/cvise/passes/treesitter.py
+++ b/cvise/passes/treesitter.py
@@ -1,5 +1,6 @@
 import msgspec
 from pathlib import Path
+import subprocess
 
 from cvise.passes.hint_based import HintBasedPass
 from cvise.utils.hint import HintBundle
@@ -12,13 +13,25 @@ class TreeSitterPass(HintBasedPass):
     def check_prerequisites(self):
         return self.check_external_program('treesitter_delta')
 
+    def supports_dir_test_cases(self):
+        return True
+
     def generate_hints(self, test_case: Path, process_event_notifier: ProcessEventNotifier, *args, **kwargs):
-        cmd = [
-            self.external_programs['treesitter_delta'],
-            self.arg,
-            str(test_case),
-        ]
-        stdout = process_event_notifier.check_output(cmd)
+        # If the test case is a single file, simply specify its path via cmd line. If it's a directory, enumerate all
+        # files (we do it on the Python side for flexibility) and send the list via stdin (to not hit the cmd line size
+        # limit).
+        if test_case.is_dir():
+            work_dir = test_case
+            paths = [p.relative_to(test_case) for p in test_case.rglob('*') if not p.is_dir()]
+            stdin = b'\n'.join(bytes(p) for p in paths)
+            cmd_arg = '--'
+        else:
+            work_dir = '.'
+            stdin = b''
+            cmd_arg = str(test_case)
+
+        cmd = [self.external_programs['treesitter_delta'], self.arg, cmd_arg]
+        stdout = process_event_notifier.check_output(cmd, cwd=work_dir, stdin=subprocess.PIPE, input=stdin, stderr=None)
 
         # When reading, gracefully handle EOF because the tool might've failed with no output.
         stdout = iter(stdout.splitlines())

--- a/cvise/passes/treesitter.py
+++ b/cvise/passes/treesitter.py
@@ -31,7 +31,7 @@ class TreeSitterPass(HintBasedPass):
             cmd_arg = str(test_case)
 
         cmd = [self.external_programs['treesitter_delta'], self.arg, cmd_arg]
-        stdout = process_event_notifier.check_output(cmd, cwd=work_dir, stdin=subprocess.PIPE, input=stdin, stderr=None)
+        stdout = process_event_notifier.check_output(cmd, cwd=work_dir, stdin=subprocess.PIPE, input=stdin)
 
         # When reading, gracefully handle EOF because the tool might've failed with no output.
         stdout = iter(stdout.splitlines())

--- a/cvise/utils/process.py
+++ b/cvise/utils/process.py
@@ -33,6 +33,7 @@ class ProcessEventNotifier:
     def run_process(
         self,
         cmd: Union[List[str], str],
+        input: Union[bytes, None] = None,
         stdout: int = subprocess.PIPE,
         stderr: int = subprocess.PIPE,
         shell: bool = False,
@@ -57,12 +58,13 @@ class ProcessEventNotifier:
         with self._auto_notify_finish(proc):
             with _auto_kill(proc):
                 self._notify_start(proc)
-                stdout, stderr = proc.communicate(timeout=timeout)
+                stdout, stderr = proc.communicate(input=input, timeout=timeout)
                 return stdout, stderr, proc.returncode
 
     def check_output(
         self,
         cmd: Union[List[str], str],
+        input: Union[bytes, None] = None,
         stdout: int = subprocess.PIPE,
         stderr: int = subprocess.PIPE,
         shell: bool = False,
@@ -70,7 +72,7 @@ class ProcessEventNotifier:
         timeout: Union[int, None] = None,
         **kwargs,
     ) -> bytes:
-        stdout, stderr, returncode = self.run_process(cmd, stdout, stderr, shell, env, timeout, **kwargs)
+        stdout, stderr, returncode = self.run_process(cmd, input, stdout, stderr, shell, env, timeout, **kwargs)
         if returncode != 0:
             stderr = stderr.decode('utf-8', 'ignore').strip()
             delim = ': ' if stderr else ''

--- a/treesitter_delta/CMakeLists.txt
+++ b/treesitter_delta/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(treesitter_delta
     Main.cpp
     RemoveFunction.cpp
     ReplaceFunctionDefWithDecl.cpp
+    TransformationFactory.cpp
     TreeSitterUtils.cpp
 )
 target_link_libraries(treesitter_delta

--- a/treesitter_delta/EraseNamespace.h
+++ b/treesitter_delta/EraseNamespace.h
@@ -2,16 +2,21 @@
 #define ERASE_NAMESPACE_H
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include <tree_sitter/api.h>
 
+#include "Transformation.h"
+
 // Emits hints that delete contents inside C++ namespaces.
-class NamespaceEraser {
+class NamespaceEraser : public Transformation {
 public:
   NamespaceEraser();
-  ~NamespaceEraser();
-  void processFile(const std::string &FileContents, TSTree &Tree);
+  ~NamespaceEraser() override;
+  std::vector<std::string> getVocabulary() const override;
+  void processFile(const std::string &FileContents, TSTree &Tree,
+                   std::optional<int> FileId) override;
 
 private:
   std::unique_ptr<TSQuery, decltype(&ts_query_delete)> Query;

--- a/treesitter_delta/Main.cpp
+++ b/treesitter_delta/Main.cpp
@@ -1,18 +1,31 @@
-#include "EraseNamespace.h"
 #include "Parsers.h"
-#include "RemoveFunction.h"
-#include "ReplaceFunctionDefWithDecl.h"
+#include "Transformation.h"
+#include "TransformationFactory.h"
 
 #include <filesystem>
 #include <fstream>
 #include <ios>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <string>
 #include <system_error>
 #include <utility>
+#include <vector>
 
 #include <tree_sitter/api.h>
+
+static void printVocab(const std::vector<std::string> &Vocab) {
+  std::cout << '[';
+  for (size_t I = 0; I < Vocab.size(); ++I) {
+    if (I > 0)
+      std::cout << ',';
+    // For simplicity, we assume no character needs escaping for JSON (always
+    // true for replacement strings in treesitter_delta).
+    std::cout << '"' << Vocab[I] << '"';
+  }
+  std::cout << "]\n";
+}
 
 static bool readFile(const std::string &Path, std::string &Contents) {
   std::error_code Error;
@@ -34,47 +47,73 @@ static bool readFile(const std::string &Path, std::string &Contents) {
   return true;
 }
 
+std::unique_ptr<TSTree, decltype(&ts_tree_delete)>
+parseFile(const std::string &Contents, TSParser *Parser) {
+  return std::unique_ptr<TSTree, decltype(&ts_tree_delete)>(
+      ts_parser_parse_string(Parser, /*old_tree=*/nullptr, Contents.c_str(),
+                             Contents.length()),
+      ts_tree_delete);
+}
+
 int main(int argc, char *argv[]) {
   std::ios::sync_with_stdio(false); // speed up C++ I/O streams
 
   if (argc != 3) {
     std::cerr << "Usage: " << argv[0] << " transformation input/file/path\n"
-              << "  transformation: currently only "
-                 "\"replace-function-def-with-decl\"";
+              << "  or, for multi-file, send the paths as newline-separated "
+                 "list in stdin: "
+              << argv[0] << " transformation --\n"
+              << "transformation: one of \"replace-function-def-with-decl\", "
+                 "\"erase-namespace\", \"remove-function\".\n";
     return -1;
   }
-  const std::string Transformation = argv[1];
-  const std::string InputPath = argv[2];
+  const std::string TransformationName = argv[1];
+  const std::string InputPathArg = argv[2];
+
+  // Build the input file list.
+  bool MultiFile = InputPathArg == "--";
+  std::vector<std::filesystem::path> InputPaths;
+  if (MultiFile) {
+    std::string Line;
+    while (std::getline(std::cin, Line)) {
+      if (Line.empty())
+        continue;
+      InputPaths.push_back(std::move(Line));
+    }
+  } else {
+    InputPaths.push_back(InputPathArg);
+  }
+
+  auto Transform = createTransformation(TransformationName);
+  if (!Transform) {
+    std::cerr << "Unknown transformation: " << TransformationName << "\n";
+    return -1;
+  }
+  std::vector<std::string> Vocab = Transform->getVocabulary();
+  if (MultiFile)
+    Vocab.insert(Vocab.end(), InputPaths.begin(), InputPaths.end());
+  printVocab(Vocab);
 
   // Prepare the common parsing state.
   std::unique_ptr<TSParser, decltype(&ts_parser_delete)> Parser(
       ts_parser_new(), ts_parser_delete);
   ts_parser_set_language(Parser.get(), tree_sitter_cpp());
 
-  // Parse the input.
+  // Process each file and emit hints.
   std::string Contents;
-  if (!readFile(InputPath, Contents)) {
-    // The error details are logged by the function.
-    return 1;
+  for (size_t InputIndex = 0; InputIndex < InputPaths.size(); ++InputIndex) {
+    const auto &InputPath = InputPaths[InputIndex];
+    if (!readFile(InputPath, Contents))
+      continue; // The error details are logged by the function.
+    auto Tree = parseFile(Contents, Parser.get());
+    if (!Tree) {
+      std::cerr << "Failed to parse " << InputPath << "\n";
+      continue;
+    }
+    auto FileId = MultiFile ? std::make_optional<int>(
+                                  Vocab.size() - InputPaths.size() + InputIndex)
+                            : std::nullopt;
+    Transform->processFile(Contents, *Tree, FileId);
   }
-  std::unique_ptr<TSTree, decltype(&ts_tree_delete)> Tree(
-      ts_parser_parse_string(Parser.get(), /*old_tree=*/nullptr,
-                             Contents.c_str(), Contents.length()),
-      ts_tree_delete);
-  if (!Tree) {
-    std::cerr << "Failed to parse " << InputPath << "\n";
-    return 1;
-  }
-
-  // Run heuristics and emit hints.
-  if (Transformation == "replace-function-def-with-decl") {
-    FuncDefWithDeclReplacer().processFile(Contents, *Tree);
-  } else if (Transformation == "erase-namespace") {
-    NamespaceEraser().processFile(Contents, *Tree);
-  } else if (Transformation == "remove-function") {
-    FunctionRemover().processFile(Contents, *Tree);
-  } else {
-    std::cerr << "Unknown transformation: " << Transformation << "\n";
-    return 1;
-  }
+  Transform->finalize();
 }

--- a/treesitter_delta/RemoveFunction.h
+++ b/treesitter_delta/RemoveFunction.h
@@ -1,23 +1,42 @@
 #ifndef REMOVE_FUNCTION_H
 #define REMOVE_FUNCTION_H
 
+#include <cstdint>
+#include <map>
 #include <memory>
+#include <optional>
 #include <string>
+#include <vector>
 
 #include <tree_sitter/api.h>
+
+#include "Transformation.h"
 
 // Generates hints that remove C/C++ functions.
 //
 // A single attempt (hint) is made for all definitions/declarations that share
 // the same name; file/namespace/class scopes are ignored.
-class FunctionRemover {
+class FunctionRemover : public Transformation {
 public:
+  struct Instance {
+    std::optional<int> FileId;
+    uint32_t StartByte = 0;
+    uint32_t EndByte = 0;
+
+    bool operator<(const Instance &Other) const;
+  };
+
+  using NameToInstanceVec = std::map<std::string, std::vector<Instance>>;
+
   FunctionRemover();
-  ~FunctionRemover();
-  void processFile(const std::string &FileContents, TSTree &Tree);
+  ~FunctionRemover() override;
+  void processFile(const std::string &FileContents, TSTree &Tree,
+                   std::optional<int> FileId) override;
+  void finalize() override;
 
 private:
   std::unique_ptr<TSQuery, decltype(&ts_query_delete)> Query;
+  NameToInstanceVec InstancesByName;
 };
 
 #endif

--- a/treesitter_delta/ReplaceFunctionDefWithDecl.h
+++ b/treesitter_delta/ReplaceFunctionDefWithDecl.h
@@ -2,17 +2,22 @@
 #define REPLACE_FUNCTION_FUNC_DEF_WITH_DECL_H
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include <tree_sitter/api.h>
 
+#include "Transformation.h"
+
 // Emits hints that deletes function bodies (either replacing them with
 // semicolons or deleting the whole definition altogether).
-class FuncDefWithDeclReplacer {
+class FuncDefWithDeclReplacer : public Transformation {
 public:
   FuncDefWithDeclReplacer();
-  ~FuncDefWithDeclReplacer();
-  void processFile(const std::string &FileContents, TSTree &Tree);
+  ~FuncDefWithDeclReplacer() override;
+  std::vector<std::string> getVocabulary() const override;
+  void processFile(const std::string &FileContents, TSTree &Tree,
+                   std::optional<int> FileId) override;
 
 private:
   std::unique_ptr<TSQuery, decltype(&ts_query_delete)> Query;

--- a/treesitter_delta/Transformation.h
+++ b/treesitter_delta/Transformation.h
@@ -7,13 +7,18 @@
 
 #include <tree_sitter/api.h>
 
+// Base class for a heuristic transformation.
 class Transformation {
 public:
   virtual ~Transformation() = default;
 
+  // Should return the static list of strings needed by hints.
   virtual std::vector<std::string> getVocabulary() const { return {}; }
+  // Handle an input file and, when appropriate, emit hints.
   virtual void processFile(const std::string &FileContents, TSTree &Tree,
                            std::optional<int> FileId) = 0;
+  // Called after all processFile() invocations - can be used to emit additional
+  // hints.
   virtual void finalize() {}
 };
 

--- a/treesitter_delta/Transformation.h
+++ b/treesitter_delta/Transformation.h
@@ -1,0 +1,20 @@
+#ifndef TRANSFORMATION_H
+#define TRANSFORMATION_H
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <tree_sitter/api.h>
+
+class Transformation {
+public:
+  virtual ~Transformation() = default;
+
+  virtual std::vector<std::string> getVocabulary() const { return {}; }
+  virtual void processFile(const std::string &FileContents, TSTree &Tree,
+                           std::optional<int> FileId) = 0;
+  virtual void finalize() {}
+};
+
+#endif

--- a/treesitter_delta/TransformationFactory.cpp
+++ b/treesitter_delta/TransformationFactory.cpp
@@ -1,0 +1,19 @@
+#include "TransformationFactory.h"
+
+#include <memory>
+#include <string>
+
+#include "EraseNamespace.h"
+#include "RemoveFunction.h"
+#include "ReplaceFunctionDefWithDecl.h"
+#include "Transformation.h"
+
+std::unique_ptr<Transformation> createTransformation(const std::string &Name) {
+  if (Name == "replace-function-def-with-decl")
+    return std::make_unique<FuncDefWithDeclReplacer>();
+  if (Name == "erase-namespace")
+    return std::make_unique<NamespaceEraser>();
+  if (Name == "remove-function")
+    return std::make_unique<FunctionRemover>();
+  return nullptr;
+}

--- a/treesitter_delta/TransformationFactory.h
+++ b/treesitter_delta/TransformationFactory.h
@@ -1,0 +1,11 @@
+#ifndef TRANSFORMATION_FACTORY_H
+#define TRANSFORMATION_FACTORY_H
+
+#include <memory>
+#include <string>
+
+#include "Transformation.h"
+
+std::unique_ptr<Transformation> createTransformation(const std::string &Name);
+
+#endif


### PR DESCRIPTION
Migrate all Tree-sitter based heuristics (replace-function-def-with-decl, erase-namespace, remove-function) to support multi-file inputs, i.e. test cases that are directories.

Note: "remove-function" is the first truly cross-file heuristic, as it's attempting to remove all function defs/decls sharing the same name from all files.