### PR TITLE
multiprocessing: Use forkserver in all tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,12 @@ configure_file(
 )
 
 configure_file(
+  "${PROJECT_SOURCE_DIR}/conftest.py"
+  "${PROJECT_BINARY_DIR}/conftest.py"
+  COPYONLY
+)
+
+configure_file(
   "${PROJECT_SOURCE_DIR}/tests/test_cvise.py"
   "${PROJECT_BINARY_DIR}/tests/test_cvise.py"
   COPYONLY

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,13 @@
+"""Contains fixtures common across all Pytest tests, including the ones in subdirectories."""
+
+import multiprocessing
+import pytest
+
+
+@pytest.fixture(scope='session', autouse=True)
+def mp_start_method():
+    """Configures the default multiprocessing method for all tests.
+
+    The "forkserver" mode is the same as the one used by the C-Vise CLI.
+    """
+    multiprocessing.set_start_method('forkserver')


### PR DESCRIPTION
Some unit tests run child processes, and before this commit they used the default multiprocessing mode ("fork" on *nix currently).

Change all tests to use "forkserver", to be consistent with the mode actually used by the C-Vise when it's run via the CLI tool.