### PR TITLE
multiprocessing: Stop all jobs before doing pool.__exit__

### DIFF
--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -429,8 +429,8 @@ class TestManager:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.exit_stack.__exit__(exc_type, exc_val, exc_tb)
         self.worker_pool.stop()
+        self.exit_stack.__exit__(exc_type, exc_val, exc_tb)
         self.worker_pool = None
 
     def remove_roots(self):


### PR DESCRIPTION
In order to exit quickly on Ctrl-C or other signals, we should switch the Pebble process pool into the stopped mode, which cancels all jobs and starts shutting down all workers.