### PR TITLE
subprocesses: Make PID queue robuster to signals

### DIFF
--- a/cvise/cvise.py
+++ b/cvise/cvise.py
@@ -96,7 +96,7 @@ class CVise:
     }
 
     def __init__(self, test_manager, skip_interestingness_test_check):
-        sigmonitor.init(use_exceptions=True)
+        sigmonitor.init(sigmonitor.Mode.RAISE_EXCEPTION)
         self.test_manager = test_manager
         self.skip_interestingness_test_check = skip_interestingness_test_check
         self.tidy = False

--- a/cvise/tests/test_test_manager.py
+++ b/cvise/tests/test_test_manager.py
@@ -167,7 +167,7 @@ def extra_dir_count():
 
 @pytest.fixture(autouse=True)
 def signal_monitor():
-    sigmonitor.init(use_exceptions=True)
+    sigmonitor.init(sigmonitor.Mode.RAISE_EXCEPTION)
 
 
 # Run all tests in the temp dir, to prevent artifacts like the cvise_bug_* from appearing in the build directory.

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -1137,14 +1137,14 @@ def override_tmpdir_env(old_env: Mapping[str, str], tmp_override: Path) -> Mappi
 def _init_worker_process(mplogger_initializer: Callable) -> None:
     # By default (when not executing a job), terminate a worker immediately on relevant signals. Raising an exception at
     # unexpected times, especially inside multiprocessing internals, can put the worker into a bad state.
-    sigmonitor.init(use_exceptions=False)
+    sigmonitor.init(sigmonitor.Mode.QUICK_EXIT)
     mplogger_initializer()
 
 
 def _worker_process_job_wrapper(job_order: int, func: Callable) -> Any:
     # Handle signals as exceptions within the job, to let the code do proper resource deallocation (like terminating
     # subprocesses), but once the func returns after a signal was triggered, terminate the worker.
-    with sigmonitor.scoped_use_exceptions():
+    with sigmonitor.scoped_mode(sigmonitor.Mode.RAISE_EXCEPTION):
         # Annotate each log message with the job order, for the log recipient in the main process to discard logs coming
         # from canceled jobs.
         with mplogging.worker_process_job_wrapper(job_order):


### PR DESCRIPTION
Don't allow signals to interrupt run_process() in a way that neither FINISHED nor ORPHANED are returned.

Refactor the sigmonitor code so that various modes (os._exit, raise, remember-but-raise-on-demand-only) are easier to control and to reduce the runtime overhead if we add it into hotpaths.