### PR TITLE
hints: Passes declare output hint types

### DIFF
--- a/cvise/passes/blank.py
+++ b/cvise/passes/blank.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import re
+from typing import List
 
 from cvise.passes.hint_based import HintBasedPass
 from cvise.utils.hint import HintBundle
@@ -13,6 +14,9 @@ class BlankPass(HintBasedPass):
 
     def check_prerequisites(self):
         return True
+
+    def output_hint_types(self) -> List[str]:
+        return list(self.PATTERNS.keys())
 
     def generate_hints(self, test_case: Path, *args, **kwargs):
         hints = []

--- a/cvise/passes/clangmodulemap.py
+++ b/cvise/passes/clangmodulemap.py
@@ -36,6 +36,9 @@ class ClangModuleMapPass(HintBasedPass):
     def supports_dir_test_cases(self):
         return True
 
+    def output_hint_types(self) -> List[str]:
+        return [v.value[1] for v in _Vocab]
+
     def generate_hints(self, test_case: Path, *args, **kwargs):
         paths = list(test_case.rglob('*')) if test_case.is_dir() else [test_case]
         interesting_paths = [p for p in paths if _interesting_file(p)]

--- a/cvise/passes/comments.py
+++ b/cvise/passes/comments.py
@@ -19,6 +19,9 @@ class CommentsPass(HintBasedPass):
     def supports_dir_test_cases(self):
         return True
 
+    def output_hint_types(self) -> List[str]:
+        return list(self.INITIAL_VOCAB)
+
     def generate_hints(self, test_case: Path, *args, **kwargs):
         vocab = list(self.INITIAL_VOCAB)
         hints = []

--- a/cvise/passes/hint_based.py
+++ b/cvise/passes/hint_based.py
@@ -139,6 +139,13 @@ class HintBasedPass(AbstractPass):
     ) -> HintBundle:
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'generate_hints'!")
 
+    def output_hint_types(self) -> List[str]:
+        """Declares hint types that are produced by this pass.
+
+        A pass must override this method if it produces hints with a nonempty type (the "t" field).
+        """
+        return []
+
     def create_elementary_state(self, hint_count: int) -> Any:
         """Creates a single underlying state for enumerating hints of a particular type.
 

--- a/cvise/passes/treesitter.py
+++ b/cvise/passes/treesitter.py
@@ -1,6 +1,7 @@
 import msgspec
 from pathlib import Path
 import subprocess
+from typing import List
 
 from cvise.passes.hint_based import HintBasedPass
 from cvise.utils.hint import HintBundle
@@ -15,6 +16,13 @@ class TreeSitterPass(HintBasedPass):
 
     def supports_dir_test_cases(self):
         return True
+
+    def output_hint_types(self) -> List[str]:
+        # Must stay in sync with the heuristic implementations in //treesitter_delta/.
+        if self.arg == 'replace-function-def-with-decl':
+            return ['regular', 'template-function']
+        else:
+            return []
 
     def generate_hints(self, test_case: Path, process_event_notifier: ProcessEventNotifier, *args, **kwargs):
         # If the test case is a single file, simply specify its path via cmd line. If it's a directory, enumerate all

--- a/cvise/tests/test_blank.py
+++ b/cvise/tests/test_blank.py
@@ -16,7 +16,7 @@ def input_path(tmp_path: Path) -> Path:
 def init_pass(tmp_dir: Path, input_path: Path) -> Tuple[BlankPass, Union[HintState, None]]:
     pass_ = BlankPass()
     state = pass_.new(input_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None))
-    validate_stored_hints(state)
+    validate_stored_hints(state, pass_)
     return pass_, state
 
 

--- a/cvise/tests/test_clanghints.py
+++ b/cvise/tests/test_clanghints.py
@@ -21,7 +21,7 @@ def init_pass(transformation: str, tmp_dir: Path, input_path: Path) -> Tuple[Cla
     pass_ = ClangHintsPass(transformation, find_external_programs())
     pass_.user_clang_delta_std = None
     state = pass_.new(input_path, tmp_dir=tmp_dir, job_timeout=100, process_event_notifier=ProcessEventNotifier(None))
-    validate_stored_hints(state)
+    validate_stored_hints(state, pass_)
     return pass_, state
 
 

--- a/cvise/tests/test_clangmodulemap.py
+++ b/cvise/tests/test_clangmodulemap.py
@@ -17,7 +17,7 @@ def test_case_path(tmp_path: Path) -> Path:
 def init_pass(tmp_dir: Path, test_case_path: Path) -> Tuple[ClangModuleMapPass, Any]:
     pass_ = ClangModuleMapPass()
     state = pass_.new(test_case_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None))
-    validate_stored_hints(state)
+    validate_stored_hints(state, pass_)
     return pass_, state
 
 

--- a/cvise/tests/test_clexhints.py
+++ b/cvise/tests/test_clexhints.py
@@ -114,7 +114,7 @@ def input_path(tmp_path: Path) -> Path:
 def init_pass(arg, tmp_dir: Path, input_path: Path) -> Tuple[ClexHintsPass, Any]:
     pass_ = ClexHintsPass(arg, find_external_programs())
     state = pass_.new(input_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None))
-    validate_stored_hints(state)
+    validate_stored_hints(state, pass_)
     return pass_, state
 
 

--- a/cvise/tests/test_comments.py
+++ b/cvise/tests/test_comments.py
@@ -23,7 +23,7 @@ class CommentsTestCase(unittest.TestCase):
         self.input_path.write_text('This /* contains *** /* two */ /*comments*/!\n')
 
         state = self._pass_new()
-        validate_stored_hints(state)
+        validate_stored_hints(state, self.pass_)
         (_, state) = self.pass_.transform(
             self.input_path,
             state,
@@ -38,7 +38,7 @@ class CommentsTestCase(unittest.TestCase):
         self.input_path.write_text('This ///contains //two\n //comments\n!\n')
 
         state = self._pass_new()
-        validate_stored_hints(state)
+        validate_stored_hints(state, self.pass_)
         (_, state) = self.pass_.transform(
             self.input_path,
             state,
@@ -53,7 +53,7 @@ class CommentsTestCase(unittest.TestCase):
         self.input_path.write_text('/*This*/ ///contains //two\n //comments\n!\n')
 
         state = self._pass_new()
-        validate_stored_hints(state)
+        validate_stored_hints(state, self.pass_)
         (result, state) = self.pass_.transform(
             self.input_path,
             state,
@@ -81,7 +81,7 @@ class CommentsTestCase(unittest.TestCase):
         self.input_path.write_text('/*This*/ ///contains //two\n //comments\n!\n')
 
         state = self._pass_new()
-        validate_stored_hints(state)
+        validate_stored_hints(state, self.pass_)
         (result, state) = self.pass_.transform(
             self.input_path,
             state,
@@ -106,7 +106,7 @@ class CommentsTestCase(unittest.TestCase):
         self.input_path.write_bytes(b'int x;\n// Streichholzsch\xc3\xa4chtelchen\nchar t[] = "nonutf\xff";\n// \xff\n')
 
         state = self._pass_new()
-        validate_stored_hints(state)
+        validate_stored_hints(state, self.pass_)
         (_, state) = self.pass_.transform(
             self.input_path,
             state,
@@ -124,7 +124,7 @@ class CommentsTestCase(unittest.TestCase):
 
         state = self._pass_new()
         output_path = self.tmp_dir / 'transformed_test_case'
-        validate_stored_hints(state)
+        validate_stored_hints(state, self.pass_)
         (_, state) = self.pass_.transform(
             output_path, state, process_event_notifier=ProcessEventNotifier(None), original_test_case=self.input_path
         )

--- a/cvise/tests/test_hint.py
+++ b/cvise/tests/test_hint.py
@@ -292,7 +292,7 @@ def test_apply_hints_dir(tmp_path: Path):
     hint_un = {'p': [{'l': 0, 'r': 2, 'f': 0}]}
     hint_ar = {'p': [{'l': 6, 'r': 8, 'f': 1}]}
     bundle = HintBundle(hints=[hint_oo, hint_un, hint_ar], vocabulary=vocab)
-    validate_hint_bundle(bundle)
+    validate_hint_bundle(bundle, allowed_hint_types=set())
 
     output_dir = tmp_path / 'output'
     apply_hints([bundle], input_dir, output_dir)
@@ -312,7 +312,7 @@ def test_apply_hints_dir_nonexisting_parent(tmp_path: Path):
     (input_dir / 'foo.h').write_text('foo')
     (input_dir / 'bar.cc').write_text('void bar();')
     bundle = HintBundle(hints=[])
-    validate_hint_bundle(bundle)
+    validate_hint_bundle(bundle, allowed_hint_types=set())
 
     non_existing_dir = tmp_path / 'nonexisting'
     output_dir = non_existing_dir / 'output'

--- a/cvise/tests/test_hint_based.py
+++ b/cvise/tests/test_hint_based.py
@@ -13,11 +13,14 @@ class StubHintBasedPass(HintBasedPass):
         self.contents_to_hints = contents_to_hints
         self.vocabulary = vocabulary or []
 
+    def output_hint_types(self) -> List[str]:
+        return self.vocabulary
+
     def generate_hints(self, test_case: Path, *args, **kwargs) -> HintBundle:
         contents = test_case.read_bytes()
         hints = self.contents_to_hints.get(contents, [])
         bundle = HintBundle(vocabulary=self.vocabulary, hints=hints)
-        validate_hint_bundle(bundle)
+        validate_hint_bundle(bundle, allowed_hint_types=self.output_hint_types())
         return bundle
 
 

--- a/cvise/tests/test_hint_based.py
+++ b/cvise/tests/test_hint_based.py
@@ -20,7 +20,7 @@ class StubHintBasedPass(HintBasedPass):
         contents = test_case.read_bytes()
         hints = self.contents_to_hints.get(contents, [])
         bundle = HintBundle(vocabulary=self.vocabulary, hints=hints)
-        validate_hint_bundle(bundle, allowed_hint_types=self.output_hint_types())
+        validate_hint_bundle(bundle, allowed_hint_types=set(self.output_hint_types()))
         return bundle
 
 

--- a/cvise/tests/test_line_markers.py
+++ b/cvise/tests/test_line_markers.py
@@ -14,7 +14,7 @@ def input_path(tmp_path: Path):
 def init_pass(tmp_path: Path, input_path: Path):
     pass_ = LineMarkersPass()
     state = pass_.new(input_path, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None))
-    validate_stored_hints(state)
+    validate_stored_hints(state, pass_)
     return pass_, state
 
 

--- a/cvise/tests/test_lines.py
+++ b/cvise/tests/test_lines.py
@@ -16,7 +16,7 @@ def input_path(tmp_path: Path) -> Path:
 def init_pass(depth, tmp_dir: Path, input_path: Path) -> Tuple[LinesPass, Any]:
     pass_ = LinesPass(depth, find_external_programs())
     state = pass_.new(input_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None))
-    validate_stored_hints(state)
+    validate_stored_hints(state, pass_)
     return pass_, state
 
 

--- a/cvise/tests/test_treesitter.py
+++ b/cvise/tests/test_treesitter.py
@@ -21,7 +21,7 @@ def input_path(tmp_path: Path) -> Path:
 def init_pass(arg, tmp_dir: Path, input_path: Path) -> Tuple[TreeSitterPass, Any]:
     pass_ = TreeSitterPass(arg, find_external_programs())
     state = pass_.new(input_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None))
-    validate_stored_hints(state)
+    validate_stored_hints(state, pass_)
     return pass_, state
 
 


### PR DESCRIPTION
Each pass now explicitly declares types of the hints it produces.

This will be used to implement pass dependencies - some passes consuming the information produced by others.