### PR TITLE
hints: Allow a pass consuming hints from another pass

### DIFF
--- a/cvise/tests/test_balanced.py
+++ b/cvise/tests/test_balanced.py
@@ -17,7 +17,9 @@ class BalancedParensTestCase(unittest.TestCase):
         self.pass_ = BalancedPass('parens')
 
     def _pass_new(self) -> Union[HintState, None]:
-        return self.pass_.new(self.input_path, tmp_dir=self.tmp_dir, process_event_notifier=ProcessEventNotifier(None))
+        return self.pass_.new(
+            self.input_path, tmp_dir=self.tmp_dir, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+        )
 
     def test_parens_no_match(self):
         self.input_path.write_text('This is a simple test!\n')
@@ -68,7 +70,9 @@ class BalancedParensOnlyTestCase(unittest.TestCase):
         self.pass_ = BalancedPass('parens-only')
 
     def _pass_new(self) -> Union[HintState, None]:
-        return self.pass_.new(self.input_path, tmp_dir=self.tmp_dir, process_event_notifier=ProcessEventNotifier(None))
+        return self.pass_.new(
+            self.input_path, tmp_dir=self.tmp_dir, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+        )
 
     def test_parens_no_match(self):
         self.input_path.write_text('This is a simple test!\n')
@@ -135,7 +139,7 @@ class BalancedParensOnlyTestCase(unittest.TestCase):
 
         while result == PassResult.OK:
             state = self.pass_.advance_on_success(
-                self.input_path, state, process_event_notifier=ProcessEventNotifier(None)
+                self.input_path, state, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
             )
             if state is None:
                 break
@@ -170,7 +174,9 @@ class BalancedParensInsideTestCase(unittest.TestCase):
         self.pass_ = BalancedPass('parens-inside')
 
     def _pass_new(self) -> Union[HintState, None]:
-        return self.pass_.new(self.input_path, tmp_dir=self.tmp_dir, process_event_notifier=ProcessEventNotifier(None))
+        return self.pass_.new(
+            self.input_path, tmp_dir=self.tmp_dir, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+        )
 
     def test_parens_no_match(self):
         self.input_path.write_text('This is a simple test!\n')
@@ -256,7 +262,9 @@ class BalancedParensToZeroTestCase(unittest.TestCase):
         self.pass_ = BalancedPass('parens-to-zero')
 
     def _pass_new(self) -> Union[HintState, None]:
-        return self.pass_.new(self.input_path, tmp_dir=self.tmp_dir, process_event_notifier=ProcessEventNotifier(None))
+        return self.pass_.new(
+            self.input_path, tmp_dir=self.tmp_dir, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+        )
 
     def test_no_match(self):
         self.input_path.write_text('This is a simple test!\n')
@@ -283,7 +291,9 @@ class BalancedCurly3TestCase(unittest.TestCase):
         self.pass_ = BalancedPass('curly3')
 
     def _pass_new(self) -> Union[HintState, None]:
-        return self.pass_.new(self.input_path, tmp_dir=self.tmp_dir, process_event_notifier=ProcessEventNotifier(None))
+        return self.pass_.new(
+            self.input_path, tmp_dir=self.tmp_dir, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+        )
 
     def test_no_match(self):
         self.input_path.write_text('This is a simple test!\n')

--- a/cvise/tests/test_blank.py
+++ b/cvise/tests/test_blank.py
@@ -15,7 +15,7 @@ def input_path(tmp_path: Path) -> Path:
 
 def init_pass(tmp_dir: Path, input_path: Path) -> Tuple[BlankPass, Union[HintState, None]]:
     pass_ = BlankPass()
-    state = pass_.new(input_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None))
+    state = pass_.new(input_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[])
     validate_stored_hints(state, pass_)
     return pass_, state
 

--- a/cvise/tests/test_clanghints.py
+++ b/cvise/tests/test_clanghints.py
@@ -20,7 +20,13 @@ def get_data_path(testcase: str) -> Path:
 def init_pass(transformation: str, tmp_dir: Path, input_path: Path) -> Tuple[ClangHintsPass, Any]:
     pass_ = ClangHintsPass(transformation, find_external_programs())
     pass_.user_clang_delta_std = None
-    state = pass_.new(input_path, tmp_dir=tmp_dir, job_timeout=100, process_event_notifier=ProcessEventNotifier(None))
+    state = pass_.new(
+        input_path,
+        tmp_dir=tmp_dir,
+        job_timeout=100,
+        process_event_notifier=ProcessEventNotifier(None),
+        dependee_hints=[],
+    )
     validate_stored_hints(state, pass_)
     return pass_, state
 

--- a/cvise/tests/test_clangmodulemap.py
+++ b/cvise/tests/test_clangmodulemap.py
@@ -16,7 +16,9 @@ def test_case_path(tmp_path: Path) -> Path:
 
 def init_pass(tmp_dir: Path, test_case_path: Path) -> Tuple[ClangModuleMapPass, Any]:
     pass_ = ClangModuleMapPass()
-    state = pass_.new(test_case_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None))
+    state = pass_.new(
+        test_case_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+    )
     validate_stored_hints(state, pass_)
     return pass_, state
 

--- a/cvise/tests/test_clexhints.py
+++ b/cvise/tests/test_clexhints.py
@@ -113,7 +113,7 @@ def input_path(tmp_path: Path) -> Path:
 
 def init_pass(arg, tmp_dir: Path, input_path: Path) -> Tuple[ClexHintsPass, Any]:
     pass_ = ClexHintsPass(arg, find_external_programs())
-    state = pass_.new(input_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None))
+    state = pass_.new(input_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[])
     validate_stored_hints(state, pass_)
     return pass_, state
 

--- a/cvise/tests/test_comments.py
+++ b/cvise/tests/test_comments.py
@@ -17,7 +17,9 @@ class CommentsTestCase(unittest.TestCase):
         self.pass_ = CommentsPass()
 
     def _pass_new(self) -> Union[HintState, None]:
-        return self.pass_.new(self.input_path, tmp_dir=self.tmp_dir, process_event_notifier=ProcessEventNotifier(None))
+        return self.pass_.new(
+            self.input_path, tmp_dir=self.tmp_dir, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+        )
 
     def test_block(self):
         self.input_path.write_text('This /* contains *** /* two */ /*comments*/!\n')
@@ -63,7 +65,7 @@ class CommentsTestCase(unittest.TestCase):
 
         while result == PassResult.OK and state is not None:
             state = self.pass_.advance_on_success(
-                self.input_path, state, process_event_notifier=ProcessEventNotifier(None)
+                self.input_path, state, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
             )
             if state is None:
                 break

--- a/cvise/tests/test_hint_based.py
+++ b/cvise/tests/test_hint_based.py
@@ -35,7 +35,9 @@ def test_hint_based_first_char_once(tmp_path: Path):
     test_case = tmp_path / 'input.txt'
     test_case.write_text('foo')
 
-    iterate_pass(pass_, test_case, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None))
+    iterate_pass(
+        pass_, test_case, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+    )
 
     assert test_case.read_text() == 'oo'
 
@@ -55,7 +57,9 @@ def test_hint_based_last_char_repeatedly(tmp_path: Path):
     test_case = tmp_path / 'input.txt'
     test_case.write_text('foo')
 
-    iterate_pass(pass_, test_case, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None))
+    iterate_pass(
+        pass_, test_case, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+    )
 
     assert test_case.read_text() == ''
 
@@ -77,7 +81,9 @@ def test_hint_based_all_chars_grouped(tmp_path: Path):
     test_case = tmp_path / 'input.txt'
     test_case.write_text('foo')
 
-    iterate_pass(pass_, test_case, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None))
+    iterate_pass(
+        pass_, test_case, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+    )
 
     assert test_case.read_text() == ''
 
@@ -100,7 +106,7 @@ def test_hint_based_state_iteration(tmp_path: Path):
     test_case = tmp_path / 'input.txt'
     test_case.write_text('abc def')
 
-    state = pass_.new(test_case, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None))
+    state = pass_.new(test_case, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[])
     all_transforms = collect_all_transforms(pass_, state, test_case)
     assert b'c def' in all_transforms  # 01 applied
     assert b'a def' in all_transforms  # 12 applied
@@ -126,7 +132,7 @@ def test_hint_based_multiple_types(tmp_path: Path):
     test_case = tmp_path / 'input.txt'
     test_case.write_text('aba cab a')
 
-    state = pass_.new(test_case, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None))
+    state = pass_.new(test_case, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[])
     all_transforms = collect_all_transforms(pass_, state, test_case)
     assert b'abacab a' in all_transforms  # space1 applied
     assert b'aba caba' in all_transforms  # space2 applied
@@ -154,7 +160,7 @@ def test_hint_based_type1_fewer_than_type2(tmp_path: Path):
     test_case = tmp_path / 'input.txt'
     test_case.write_text('abc')
 
-    state = pass_.new(test_case, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None))
+    state = pass_.new(test_case, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[])
     all_transforms = collect_all_transforms(pass_, state, test_case)
     assert b'bc' in all_transforms  # hint1 applied
     assert b'a' in all_transforms  # hint2&3 applied
@@ -180,7 +186,7 @@ def test_hint_based_type2_fewer_than_type1(tmp_path: Path):
     test_case = tmp_path / 'input.txt'
     test_case.write_text('abc')
 
-    state = pass_.new(test_case, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None))
+    state = pass_.new(test_case, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[])
     all_transforms = collect_all_transforms(pass_, state, test_case)
     assert b'c' in all_transforms  # hint1&2 applied
     assert b'ab' in all_transforms  # hint3 applied
@@ -203,7 +209,7 @@ def test_hint_based_non_utf8(tmp_path: Path):
     test_case = tmp_path / 'input.txt'
     test_case.write_bytes(input)
 
-    state = pass_.new(test_case, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None))
+    state = pass_.new(test_case, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[])
     all_transforms = collect_all_transforms(pass_, state, test_case)
     assert b'fo\xffo\xc3\x84' in all_transforms  # hint12 applied
     assert b'f\0\xffo\xc3\x84' in all_transforms  # hint23 applied

--- a/cvise/tests/test_line_markers.py
+++ b/cvise/tests/test_line_markers.py
@@ -13,7 +13,9 @@ def input_path(tmp_path: Path):
 
 def init_pass(tmp_path: Path, input_path: Path):
     pass_ = LineMarkersPass()
-    state = pass_.new(input_path, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None))
+    state = pass_.new(
+        input_path, tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+    )
     validate_stored_hints(state, pass_)
     return pass_, state
 

--- a/cvise/tests/test_lines.py
+++ b/cvise/tests/test_lines.py
@@ -15,7 +15,7 @@ def input_path(tmp_path: Path) -> Path:
 
 def init_pass(depth, tmp_dir: Path, input_path: Path) -> Tuple[LinesPass, Any]:
     pass_ = LinesPass(depth, find_external_programs())
-    state = pass_.new(input_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None))
+    state = pass_.new(input_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[])
     validate_stored_hints(state, pass_)
     return pass_, state
 
@@ -698,11 +698,11 @@ def test_advance_on_success(tmp_path: Path, input_path: Path):
     # Cut 'foo' first, pretending that all previous transforms (e.g., deletion of the whole text) didn't pass the
     # interestingness test.
     state = advance_until(p, state, input_path, lambda s: b'bar' in s and b'baz' in s)
-    p.advance_on_success(input_path, state, process_event_notifier=ProcessEventNotifier(None))
+    p.advance_on_success(input_path, state, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[])
     # Cut 'baz' now, pretending that all transforms in between (e.g, deletion of "bar;") didn't pass the
     # interestingness test.
     state = advance_until(p, state, input_path, lambda s: b'bar' in s)
-    p.advance_on_success(input_path, state, process_event_notifier=ProcessEventNotifier(None))
+    p.advance_on_success(input_path, state, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[])
 
     assert (
         input_path.read_bytes()

--- a/cvise/tests/test_treesitter.py
+++ b/cvise/tests/test_treesitter.py
@@ -20,7 +20,7 @@ def input_path(tmp_path: Path) -> Path:
 
 def init_pass(arg, tmp_dir: Path, input_path: Path) -> Tuple[TreeSitterPass, Any]:
     pass_ = TreeSitterPass(arg, find_external_programs())
-    state = pass_.new(input_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None))
+    state = pass_.new(input_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[])
     validate_stored_hints(state, pass_)
     return pass_, state
 

--- a/cvise/tests/testabstract.py
+++ b/cvise/tests/testabstract.py
@@ -17,7 +17,9 @@ def iterate_pass(current_pass: AbstractPass, path: Path, **kwargs) -> None:
             path, state, process_event_notifier=ProcessEventNotifier(None), original_test_case=path
         )
         if result == PassResult.OK:
-            state = current_pass.advance_on_success(path, state, process_event_notifier=ProcessEventNotifier(None))
+            state = current_pass.advance_on_success(
+                path, state, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+            )
         else:
             state = current_pass.advance(path, state)
 


### PR DESCRIPTION
This introduces dependencies between passes - i.e., allowing one pass to use hints produced by other pass(es).

This will unblock the following use cases:

* Implementing a generic language-agnostic pass that consumes information from language-aware passes (e.g., unused file removal based on cppmaps, resolution of #include directives, etc.).

* Combining ideas from different heuristics without having to rerun their logic multiple times - e.g., combining Clang's dump-minimization-hints with topformflat.

* Saving resources by not having to repeat the same analysis multiple times.