### PR TITLE
multiprocessing: Only do Pebble workaround when needed

### DIFF
--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -830,10 +830,11 @@ class TestManager:
             if self.success_candidate and self.should_proceed_with_success_candidate():
                 break
 
-        for job in self.jobs:
-            self.cancel_job(job)
-        self.mp_task_loss_workaround.execute(self.worker_pool)
-        self.release_all_jobs()
+        if self.jobs:
+            for job in self.jobs:
+                self.cancel_job(job)
+            self.mp_task_loss_workaround.execute(self.worker_pool)  # only do it if at least one job canceled
+            self.release_all_jobs()
 
     def run_passes(self, passes: List[AbstractPass], interleaving: bool):
         assert len(passes) == 1 or interleaving


### PR DESCRIPTION
Don't spend time on the workaround against hung Pebble jobs if there are no jobs that were canceled.

This is a common case at later stages of reduction, since passes often init with returning no candidates at all, or only a few candidates that are all executed till completion. Hence this commit speeds up C-Vise performance by 5-10% on small/medium-size inputs.