### PR TITLE
cache: Store in tmpfs; use hashing; limit per LRU

### DIFF
--- a/cvise/CMakeLists.txt
+++ b/cvise/CMakeLists.txt
@@ -118,6 +118,7 @@ set(SOURCE_FILES
   "tests/test_test_manager.py"
   "tests/test_treesitter.py"
   "utils/__init__.py"
+  "utils/cache.py"
   "utils/error.py"
   "utils/externalprograms.py"
   "utils/fileutil.py"

--- a/cvise/utils/cache.py
+++ b/cvise/utils/cache.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+from pathlib import Path
+import tempfile
+from typing import Dict, Optional, Sequence
+
+from cvise.passes.abstract import AbstractPass
+from cvise.utils import fileutil
+
+
+@dataclass
+class _Item:
+    tmp_dir: Path
+    path: Path
+
+
+class Cache:
+    MAX_ITEMS_PER_PASS_GROUP = 3
+
+    def __init__(self, tmp_prefix: str):
+        self._tmp_prefix: str = tmp_prefix
+        self._items: Dict[str, Dict[bytes, _Item]] = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for mapping in self._items.values():
+            for item in mapping.values():
+                fileutil.rmfolder(item.tmp_dir)
+        self._items = {}
+
+    def lookup(self, passes: Sequence[AbstractPass], hash_before: bytes) -> Optional[Path]:
+        key = self._key(passes)
+        item = self._items.get(key, {}).get(hash_before)
+        return item.path if item else None
+
+    def add(self, passes: Sequence[AbstractPass], hash_before: bytes, path_after: Path) -> None:
+        key = self._key(passes)
+        mapping = self._items.setdefault(key, {})
+        if len(mapping) >= self.MAX_ITEMS_PER_PASS_GROUP:
+            evict_hash, evict_item = next(iter(mapping.items()))
+            fileutil.rmfolder(evict_item.tmp_dir)
+            del mapping[evict_hash]
+
+        tmp_dir = Path(tempfile.mkdtemp(prefix=self._tmp_prefix))
+        mapping[hash_before] = _Item(tmp_dir, tmp_dir / path_after)
+        fileutil.copy_test_case(path_after, tmp_dir)
+
+    def _key(self, passes: Sequence[AbstractPass]) -> str:
+        return repr([passes])

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -23,7 +23,7 @@ import concurrent.futures
 from cvise.cvise import CVise
 from cvise.passes.abstract import AbstractPass, PassResult
 from cvise.passes.hint_based import HintBasedPass
-from cvise.utils import fileutil, mplogging, sigmonitor
+from cvise.utils import cache, fileutil, mplogging, sigmonitor
 from cvise.utils.error import AbsolutePathTestCaseError
 from cvise.utils.error import InsaneTestCaseError
 from cvise.utils.error import InvalidInterestingnessTestError
@@ -404,7 +404,7 @@ class TestManager:
             self.test_cases.add(test_case)
 
         self.orig_total_file_size = self.total_file_size
-        self.cache = {}
+        self.cache = None if self.no_cache else cache.Cache(f'{self.TEMP_PREFIX}cache-')
         self.pass_contexts: List[PassContext] = []
         self.interleaving: bool = False
         if not self.is_valid_test(self.test_script):
@@ -440,6 +440,8 @@ class TestManager:
         self.mp_task_loss_workaround = MPTaskLossWorkaround(self.parallel_tests)
 
     def __enter__(self):
+        self.exit_stack.enter_context(self.cache)
+
         if self.key_logger:
             self.exit_stack.enter_context(self.key_logger)
         self.exit_stack.enter_context(self.process_monitor)
@@ -853,7 +855,6 @@ class TestManager:
             self.pass_contexts.append(PassContext.create(pass_))
         self.interleaving = interleaving
         self.jobs = []
-        cache_key = repr([c.pass_ for c in self.pass_contexts])
 
         pass_titles = ', '.join(repr(c.pass_) for c in self.pass_contexts)
         logging.info(f'===< {pass_titles} >===')
@@ -871,9 +872,9 @@ class TestManager:
                     continue
 
                 if not self.no_cache:
-                    test_case_before_pass = test_case.read_bytes()
-                    if cache_key in self.cache and test_case_before_pass in self.cache[cache_key]:
-                        test_case.write_bytes(self.cache[cache_key][test_case_before_pass])
+                    hash_before_pass = fileutil.hash_test_case(test_case)
+                    if cached_path := self.cache.lookup(passes, hash_before_pass):
+                        fileutil.replace_test_case_atomically(cached_path, test_case, move=False)
                         logging.info(f'cache hit for {test_case}')
                         continue
 
@@ -926,11 +927,8 @@ class TestManager:
                         logging.info(f'skipping after {success_count} successful transformations')
                         break
 
-                # Cache result of this pass
                 if not self.no_cache:
-                    if cache_key not in self.cache:
-                        self.cache[cache_key] = {}
-                    self.cache[cache_key][test_case_before_pass] = test_case.read_bytes()
+                    self.cache.add(passes, hash_before_pass, test_case)
 
             self.restore_mode()
             self.remove_roots()


### PR DESCRIPTION
Change the cache implementation to store contents as files (in temp dirs) as opposed to keeping them all in memory of C-Vise process. Only keep a few last items instead of caching forever. Use hashing via SHA-256 to perform cache lookups.

This significantly reduces the memory usage by C-Vise main process and makes the cache operations faster. Additionally, this paves the way for supporting multi-file (directory) input caching.