### PR TITLE
Observe signals in event loop via futures instead of timeouts

### DIFF
--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -348,7 +348,6 @@ class TestManager:
     TEMP_PREFIX = 'cvise-'
     BUG_DIR_PREFIX = 'cvise_bug_'
     EXTRA_DIR_PREFIX = 'cvise_extra_'
-    EVENT_LOOP_TIMEOUT = 1  # seconds
     # How often passes should be reinitialized (see maybe_schedule_job()). Chosen at 1% to not slow down the overall
     # reduction in case reinits don't lead to new discoveries.
     REINIT_JOB_INTERVAL = 100
@@ -822,7 +821,9 @@ class TestManager:
                 pass
 
             # no more jobs could be scheduled at the moment - wait for some results
-            wait([j.future for j in self.jobs], return_when=FIRST_COMPLETED, timeout=self.EVENT_LOOP_TIMEOUT)
+            wait([j.future for j in self.jobs] + [sigmonitor.get_future()], return_when=FIRST_COMPLETED)
+            sigmonitor.maybe_retrigger_action()
+
             self.workaround_missing_timeouts()
             self.process_done_futures()
 


### PR DESCRIPTION
Get rid of unnecessary iterations and timeouts in the C-Vise main process event loop, and use futures to immediately exit the loop when a signal is observed.

This removes some unnecessary work from the otherwise busy main loop, and makes the process more responsive even signals occur at unexpected times. As a bonus, we get rid of one magic constant in the code.