### PR TITLE
multifile: Fix rm-tok trying to del spaces across files

### DIFF
--- a/clex/driver.c
+++ b/clex/driver.c
@@ -317,10 +317,12 @@ static void hints_toks(void) {
     if (tok_list[i].kind == TOK_WS || tok_list[i].kind == TOK_NEWLINE)
       continue;
     int cut_start = tok_list[i].start_pos;
-    // Also eat subsequent spaces, so that two consecutive hints remove both
-    // tokens with all spaces between them.
-    while (i + 1 < toks && (tok_list[i + 1].kind == TOK_WS ||
-                            tok_list[i + 1].kind == TOK_NEWLINE)) {
+    // Also eat subsequent spaces within the same file, so that two consecutive
+    // hints remove both tokens with all spaces between them.
+    while (i + 1 < toks &&
+           (tok_list[i + 1].kind == TOK_WS ||
+            tok_list[i + 1].kind == TOK_NEWLINE) &&
+           tok_list[i + 1].file_id == tok_list[i].file_id) {
       ++i;
     }
     int cut_end = tok_list[i].start_pos + tok_list[i].len;

--- a/cvise/tests/test_clexhints.py
+++ b/cvise/tests/test_clexhints.py
@@ -233,3 +233,15 @@ def test_directory_input(tmp_path: Path):
     assert (('a.c', b'int x;'), ('b.c', b'y;')) in all_transforms
     assert (('a.c', b'int x;'), ('b.c', b'char ;')) in all_transforms
     assert (('a.c', b'int x;'), ('b.c', b'char y')) in all_transforms
+
+
+def test_directory_input_space_across_file(tmp_path: Path):
+    test_case = tmp_path / 'test_case'
+    test_case.mkdir()
+    (test_case / 'a.txt').write_text('\nint\n')
+    (test_case / 'b.txt').write_text('\nint\n')
+    p, state = init_pass('rm-toks-1-to-1', tmp_path, test_case)
+    all_transforms = collect_all_transforms_dir(p, state, test_case)
+
+    assert (('a.txt', b'\n'), ('b.txt', b'\nint\n')) in all_transforms
+    assert (('a.txt', b'\nint\n'), ('b.txt', b'\n')) in all_transforms


### PR DESCRIPTION
Fix the clexhints rm-toks pass producing invalid hints, in case any file except the first one starts from a whitespace. We should only eat spaces after a token only within the same file.