### PR TITLE
multifile: Create @fileref in ClangModuleMap

### DIFF
--- a/cvise/tests/testabstract.py
+++ b/cvise/tests/testabstract.py
@@ -69,6 +69,10 @@ def validate_stored_hints(state: Union[HintState, None], pass_: HintBasedPass) -
         path = state.tmp_dir / substate.hints_file_name
         bundle = load_hints(path, 0, substate.underlying_state.instances)
         validate_hint_bundle(bundle, output_types)
+    for substate in state.special_hints:
+        path = state.tmp_dir / substate.hints_file_name
+        bundle = load_hints(path, 0, substate.hint_count)
+        validate_hint_bundle(bundle, output_types)
 
 
 def validate_hint_bundle(bundle: HintBundle, allowed_hint_types: Optional[Set[bytes]] = None) -> None:
@@ -83,6 +87,9 @@ def validate_hint_bundle(bundle: HintBundle, allowed_hint_types: Optional[Set[by
             hint_type = bundle.vocabulary[hint.type]
             if allowed_hint_types is not None:
                 assert hint_type in allowed_hint_types
+        if hint.extra is not None:
+            assert hint.extra < len(bundle.vocabulary)
+            assert not Path(bundle.vocabulary[hint.extra].decode()).is_absolute()
         for patch in hint.patches:
             assert patch.left < patch.right
             if patch.value is not None:

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -44,6 +44,7 @@ class Hint(msgspec.Struct, omit_defaults=True, gc=False):
 
     patches: List[Patch] = msgspec.field(name='p')
     type: Optional[int] = msgspec.field(default=None, name='t')
+    extra: Optional[int] = msgspec.field(default=None, name='e')
 
 
 @dataclasses.dataclass
@@ -116,6 +117,14 @@ HINT_SCHEMA = {
                 'intended to be consumed by other passes as input data. Types not starting from "@" are just used as a '
                 'way to split hints from a particular pass into distinct groups, to guide the generic logic that '
                 'attempts taking consecutive ranges of same-typed hints.'
+            ),
+            'type': 'integer',
+            'minimum': 0,
+        },
+        'e': {
+            'description': (
+                'Extra value associated with the hint, as an index in the vocabulary. For example, for "@fileref" '
+                'hints this contains the path of the mentioned file.'
             ),
             'type': 'integer',
             'minimum': 0,


### PR DESCRIPTION
Extend the ClangModuleMap pass to additionally report "@fileref" hints for each mentioned header file. To store the references, extend the hint data schema to have a new field "extra".

This commit by itself doesn't affect the reduction process, however it's preparation for the introduction of the unused file removal pass.