### PR TITLE
multifile: Forbid interestingness script inside test case

### DIFF
--- a/cvise/utils/error.py
+++ b/cvise/utils/error.py
@@ -64,6 +64,15 @@ class InvalidInterestingnessTestError(InvalidFileError):
         return f"The specified interestingness test '{self.path}' cannot be executed!"
 
 
+class ScriptInsideTestCaseError(CViseError):
+    def __init__(self, test_case_path: Path, script_path: Path):
+        self.test_case_path = test_case_path
+        self.script_path = script_path
+
+    def __str__(self):
+        return f"Interestingness test '{self.script_path}' is inside test case directory '{self.test_case_path}'!"
+
+
 class ZeroSizeError(CViseError):
     def __init__(self, test_cases: Set[Path]):
         super().__init__()

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -24,12 +24,15 @@ from cvise.cvise import CVise
 from cvise.passes.abstract import AbstractPass, PassResult
 from cvise.passes.hint_based import HintBasedPass
 from cvise.utils import cache, fileutil, mplogging, sigmonitor
-from cvise.utils.error import AbsolutePathTestCaseError
-from cvise.utils.error import InsaneTestCaseError
-from cvise.utils.error import InvalidInterestingnessTestError
-from cvise.utils.error import InvalidTestCaseError
-from cvise.utils.error import PassBugError
-from cvise.utils.error import ZeroSizeError
+from cvise.utils.error import (
+    AbsolutePathTestCaseError,
+    InsaneTestCaseError,
+    InvalidInterestingnessTestError,
+    InvalidTestCaseError,
+    PassBugError,
+    ScriptInsideTestCaseError,
+    ZeroSizeError,
+)
 from cvise.utils.folding import FoldingManager, FoldingStateIn, FoldingStateOut
 from cvise.utils.hint import load_hints
 from cvise.utils.process import MPContextHook, MPTaskLossWorkaround, ProcessEventNotifier, ProcessMonitor
@@ -403,6 +406,8 @@ class TestManager:
             self.check_file_permissions(test_case, [os.F_OK, os.R_OK, os.W_OK], InvalidTestCaseError)
             if test_case.parent.is_absolute():
                 raise AbsolutePathTestCaseError(test_case)
+            if test_case.resolve() in self.test_script.resolve().parents:
+                raise ScriptInsideTestCaseError(test_case, self.test_script)
             self.test_cases.add(test_case)
 
         self.orig_total_file_size = self.total_file_size

--- a/tests/test_cvise.py
+++ b/tests/test_cvise.py
@@ -257,7 +257,7 @@ def test_script_inside_test_case_error(tmp_path: Path, overridden_subprocess_tmp
     test_case.mkdir()
     (test_case / 'foo.txt').touch()
     interestingness_test = test_case / 'check.sh'
-    interestingness_test.write_text(f'#!/bin/sh\ntrue\n')
+    interestingness_test.write_text('#!/bin/sh\ntrue\n')
     interestingness_test.chmod(interestingness_test.stat().st_mode | stat.S_IEXEC)
 
     proc = start_cvise(
@@ -272,5 +272,5 @@ def test_script_inside_test_case_error(tmp_path: Path, overridden_subprocess_tmp
     )
     _stdout, stderr = proc.communicate()
 
-    assert proc.returncode != 0, f'Process succeeded unexpectedly; stderr:\n' + stderr
+    assert proc.returncode != 0, 'Process succeeded unexpectedly; stderr:\n' + stderr
     assert 'is inside test case directory' in stderr


### PR DESCRIPTION
Check at the very start whether the user-specified interestingness script lies inside any of the test cases - this is unsupported and likely to bring troubles (as a randomly-modified shell script won't perform any useful check, and may even be dangerous to run).