### PR TITLE
multifile: Support caching

### DIFF
--- a/cvise/tests/test_fileutil.py
+++ b/cvise/tests/test_fileutil.py
@@ -304,7 +304,7 @@ def _stress_test_atomicity(path_to_check: Path, init_callback: Callable, test_co
             assert result_callback(run_subprocess(critical_time - step * j)) != _AtomicityResult.CONTENTS_UNEXPECTED
 
 
-def test_hash_equality(tmp_path: Path):
+def test_hash_equality_file(tmp_path: Path):
     path_a = tmp_path / 'a.txt'
     path_a.write_text('foo')
     path_b = tmp_path / 'b.txt'
@@ -323,3 +323,58 @@ def test_hash_empty_file(tmp_path: Path):
     path_b.touch()
 
     assert hash_test_case(path_a) == hash_test_case(path_b)
+
+
+def test_hash_dir_same_files(tmp_path: Path):
+    dir_a = tmp_path / 'a'
+    dir_a.mkdir()
+    (dir_a / 'foo.txt').write_text('foo')
+    dir_b = tmp_path / 'b'
+    dir_b.mkdir()
+    (dir_b / 'foo.txt').write_text('foo')
+
+    assert hash_test_case(dir_a) == hash_test_case(dir_b)
+
+
+def test_hash_dir_different_file_paths(tmp_path: Path):
+    dir_a = tmp_path / 'a'
+    dir_a.mkdir()
+    (dir_a / 'foo.txt').write_text('foo')
+    dir_b = tmp_path / 'b'
+    dir_b.mkdir()
+    (dir_b / 'bar.txt').write_text('foo')
+
+    assert hash_test_case(dir_a) != hash_test_case(dir_b)
+
+
+def test_hash_dir_different_file_contents(tmp_path: Path):
+    dir_a = tmp_path / 'a'
+    dir_a.mkdir()
+    (dir_a / 'foo.txt').write_text('foo')
+    dir_b = tmp_path / 'b'
+    dir_b.mkdir()
+    (dir_b / 'foo.txt').write_text('bar')
+
+    assert hash_test_case(dir_a) != hash_test_case(dir_b)
+
+
+def test_hash_dir_same_subdirs(tmp_path: Path):
+    dir_a = tmp_path / 'a'
+    dir_a.mkdir()
+    (dir_a / 'foo').mkdir()
+    dir_b = tmp_path / 'b'
+    dir_b.mkdir()
+    (dir_b / 'foo').mkdir()
+
+    assert hash_test_case(dir_a) == hash_test_case(dir_b)
+
+
+def test_hash_dir_different_subdirs(tmp_path: Path):
+    dir_a = tmp_path / 'a'
+    dir_a.mkdir()
+    (dir_a / 'foo').mkdir()
+    dir_b = tmp_path / 'b'
+    dir_b.mkdir()
+    (dir_b / 'bar').mkdir()
+
+    assert hash_test_case(dir_a) != hash_test_case(dir_b)

--- a/cvise/tests/test_fileutil.py
+++ b/cvise/tests/test_fileutil.py
@@ -378,3 +378,25 @@ def test_hash_dir_different_subdirs(tmp_path: Path):
     (dir_b / 'bar').mkdir()
 
     assert hash_test_case(dir_a) != hash_test_case(dir_b)
+
+
+def test_hash_dir_same_symlinks(tmp_path: Path):
+    dir_a = tmp_path / 'a'
+    dir_a.mkdir()
+    (dir_a / 'foo').symlink_to('bar')
+    dir_b = tmp_path / 'b'
+    dir_b.mkdir()
+    (dir_b / 'foo').symlink_to('bar')
+
+    assert hash_test_case(dir_a) == hash_test_case(dir_b)
+
+
+def test_hash_dir_different_symlinks(tmp_path: Path):
+    dir_a = tmp_path / 'a'
+    dir_a.mkdir()
+    (dir_a / 'foo').symlink_to('bar')
+    dir_b = tmp_path / 'b'
+    dir_b.mkdir()
+    (dir_b / 'foo').symlink_to('barbaz')
+
+    assert hash_test_case(dir_a) != hash_test_case(dir_b)

--- a/cvise/utils/fileutil.py
+++ b/cvise/utils/fileutil.py
@@ -124,11 +124,37 @@ def hash_test_case(test_case: Path) -> bytes:
     buf = _hash_buf  # cache in local variables, which are presumably faster
 
     buf_view = memoryview(buf)
+    if test_case.is_dir():
+        return _hash_dir_tree(test_case, buf_view)
+    else:
+        return _hash_file(test_case, buf_view)
+
+
+def _hash_file(path: Path, buf: memoryview) -> bytes:
     hash = hashlib.sha256()
-    with io.FileIO(test_case, 'r') as f:  # use FileIO instead of open() as otherwise linters don't allow readinto()
-        while read_size := f.readinto(buf_view):
-            hash.update(buf_view[:read_size])
+    with io.FileIO(path, 'r') as f:  # use FileIO instead of open() as otherwise linters don't allow readinto()
+        while read_size := f.readinto(buf):
+            hash.update(buf[:read_size])
     return hash.digest()
+
+
+def _hash_dir_tree(dir: Path, buf: memoryview) -> bytes:
+    dir_hash = hashlib.sha256()
+    descendants = sorted(dir.rglob('*'))
+    for path in descendants:
+        rel_path = str(path.relative_to(dir)).encode()
+        dir_hash.update(str(len(rel_path)).encode())
+        dir_hash.update(rel_path)
+
+        dir_hash.update(bytes([path.is_dir(), path.is_file(), path.is_symlink()]))
+
+        if path.is_symlink():
+            dest = str(Path(os.readlink(path))).encode()
+            dir_hash.update(str(len(dest)))
+            dir_hash.update(dest)
+        elif path.is_file():
+            dir_hash.update(_hash_file(path, buf))
+    return dir_hash.digest()
 
 
 def _get_test_case_files(test_case: Path) -> Iterable[Path]:

--- a/cvise/utils/fileutil.py
+++ b/cvise/utils/fileutil.py
@@ -143,15 +143,15 @@ def _hash_dir_tree(dir: Path, buf: memoryview) -> bytes:
     descendants = sorted(dir.rglob('*'))
     for path in descendants:
         rel_path = str(path.relative_to(dir)).encode()
-        dir_hash.update(f'{len(rel_path)}#'.encode())
-        dir_hash.update(rel_path)
+        path_hash = hashlib.sha256(rel_path).digest()
+        dir_hash.update(path_hash)
 
         dir_hash.update(bytes([path.is_dir(), path.is_file(), path.is_symlink()]))
 
         if path.is_symlink():
-            dest = str(Path(os.readlink(path))).encode()
-            dir_hash.update(f'{len(dest)}#'.encode())
-            dir_hash.update(dest)
+            dest_path = str(Path(os.readlink(path))).encode()
+            dest_path_hash = hashlib.sha256(dest_path).digest()
+            dir_hash.update(dest_path_hash)
         elif path.is_file():
             dir_hash.update(_hash_file(path, buf))
     return dir_hash.digest()

--- a/cvise/utils/fileutil.py
+++ b/cvise/utils/fileutil.py
@@ -143,14 +143,14 @@ def _hash_dir_tree(dir: Path, buf: memoryview) -> bytes:
     descendants = sorted(dir.rglob('*'))
     for path in descendants:
         rel_path = str(path.relative_to(dir)).encode()
-        dir_hash.update(str(len(rel_path)).encode())
+        dir_hash.update(f'{len(rel_path)}#'.encode())
         dir_hash.update(rel_path)
 
         dir_hash.update(bytes([path.is_dir(), path.is_file(), path.is_symlink()]))
 
         if path.is_symlink():
             dest = str(Path(os.readlink(path))).encode()
-            dir_hash.update(str(len(dest)))
+            dir_hash.update(f'{len(dest)}#'.encode())
             dir_hash.update(dest)
         elif path.is_file():
             dir_hash.update(_hash_file(path, buf))

--- a/tests/test_cvise.py
+++ b/tests/test_cvise.py
@@ -237,7 +237,6 @@ def test_dir_test_case(tmp_path: Path, overridden_subprocess_tmpdir: Path):
             'gcc -c repro/a.cc && grep "nextHi = x" repro/a.cc',
             'repro',
             '--tidy',
-            '--no-cache',
         ],
         tmp_path,
         overridden_subprocess_tmpdir,


### PR DESCRIPTION
This removes the need in specifying "--no-cache" when reducing directory (multi-file) test cases.

Implementation-wise, the only missing piece was computing a hash of a directory - all other primitives used by the cache already support dirs.