### PR TITLE
test_manager: Giveup is per pass, not for whole category

### DIFF
--- a/cvise/tests/test_test_manager.py
+++ b/cvise/tests/test_test_manager.py
@@ -70,17 +70,17 @@ class HungPass(StubPass):
         return (PassResult.INVALID, state)
 
 
-class NInvalidThenLinesPass(NaiveLinePass):
-    """Starts removing lines after the first N invalid results."""
+class InvalidAndEveryNLinesPass(NaiveLinePass):
+    """Removes a line every N job; others exit with INVALID."""
 
     def __init__(self, invalid_n):
         super().__init__()
         self.invalid_n = invalid_n
 
     def transform(self, test_case: Path, state, *args, **kwargs):
-        if state < self.invalid_n:
+        if (state + 1) % self.invalid_n != 0:
             return (PassResult.INVALID, state)
-        return super().transform(test_case, state, *args, **kwargs)
+        return super().transform(test_case, state // self.invalid_n, *args, **kwargs)
 
 
 class OneOffLinesPass(NaiveLinePass):
@@ -334,7 +334,7 @@ def test_succeed_via_n_one_off_passes(input_file: Path, manager):
 def test_succeed_after_n_invalid_results(input_file: Path, manager):
     """Check that we still succeed even if the first few invocations were unsuccessful."""
     INVALID_N = 15
-    p = NInvalidThenLinesPass(INVALID_N)
+    p = InvalidAndEveryNLinesPass(INVALID_N)
     manager.run_passes([p], interleaving=False)
     assert input_file.read_text() == ''
     assert bug_dir_count() == 0
@@ -347,6 +347,17 @@ def test_give_up_on_stuck_pass(input_file: Path, manager):
     manager.run_passes([p], interleaving=False)
     assert input_file.read_text() == INPUT_DATA
     # The "pass got stuck" report.
+    assert bug_dir_count() == 1
+
+
+@patch('cvise.utils.testing.TestManager.GIVEUP_CONSTANT', 100)
+def test_interleaving_gives_up_only_stuck_passes(input_file: Path, manager):
+    """Check that when some passes get stuck in interleaving mode, they're stopped meanwhile others continue."""
+    stuck_pass = AlwaysInvalidPass()
+    occasionally_working_pass = InvalidAndEveryNLinesPass(testing.TestManager.GIVEUP_CONSTANT // 3)
+    manager.run_passes([stuck_pass, occasionally_working_pass], interleaving=True)
+    assert input_file.read_text() == ''
+    # The "pass got stuck" report (for the stuck pass).
     assert bug_dir_count() == 1
 
 

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from typing import Any, Callable, Dict, List, Mapping, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Union
 import concurrent.futures
 
 from cvise.cvise import CVise
@@ -233,11 +233,15 @@ class PassContext:
     state: Any
     # The state that succeeded in the previous batch of jobs - to be passed as succeeded_state to advance_on_success().
     taken_succeeded_state: Any
+    # The overall number of jobs that have been started for the pass, throughout the whole run_passes() invocation.
+    pass_job_counter: int
+    # The value of pass_job_counter used for scheduling the most recent successful job.
+    last_success_pass_job_counter: int
     # The number of jobs started within the current batch (run_parallel_tests()).
-    current_batch_jobs: int
+    current_batch_pass_job_counter: int
     # Currently running transform jobs, as the (order, state) mapping.
     running_transform_order_to_state: Dict[int, Any]
-    # When True, the pass is considered dysfunctional and shouldn't be used anymore.
+    # When True, the pass is considered dysfunctional (due to an issue) and shouldn't be used anymore.
     defunct: bool
     # How many times a job for this pass timed out.
     timeout_count: int
@@ -256,7 +260,9 @@ class PassContext:
             temporary_root=Path(root),
             state=None,
             taken_succeeded_state=None,
-            current_batch_jobs=0,
+            pass_job_counter=0,
+            last_success_pass_job_counter=0,
+            current_batch_pass_job_counter=0,
             running_transform_order_to_state={},
             defunct=False,
             timeout_count=0,
@@ -294,9 +300,10 @@ class Job:
     order: int
 
     # If this job executes a method of a pass, these store pointers to it; None otherwise.
-    pass_: Union[AbstractPass, None]
-    pass_id: Union[int, None]
+    pass_: Optional[AbstractPass]
+    pass_id: Optional[int]
     pass_name: str
+    pass_job_counter: Optional[int]
 
     start_time: float
     timeout: float
@@ -719,12 +726,15 @@ class TestManager:
     def handle_finished_transform_job(self, job: Job) -> None:
         env: TestEnvironment = job.future.result()
         self.pass_statistic.add_executed(job.pass_, job.start_time, self.parallel_tests)
-        if job.pass_id is not None:
-            self.pass_contexts[job.pass_id].running_transform_order_to_state.pop(job.order)
+
+        ctx = self.pass_contexts[job.pass_id] if job.pass_id is not None else None
+        if ctx:
+            ctx.running_transform_order_to_state.pop(job.order)
 
         outcome = self.check_pass_result(job)
         if outcome == PassCheckingOutcome.STOP:
-            self.pass_contexts[job.pass_id].state = None
+            assert ctx is not None
+            ctx.state = None
             return
         if outcome == PassCheckingOutcome.IGNORE:
             self.pass_statistic.add_failure(job.pass_)
@@ -736,6 +746,8 @@ class TestManager:
         self.maybe_update_success_candidate(job.order, job.pass_, job.pass_id, env)
         if self.interleaving:
             self.folding_manager.on_transform_job_success(env.state)
+        if ctx:
+            ctx.last_success_pass_job_counter = max(ctx.last_success_pass_job_counter, job.pass_job_counter)
 
     def check_pass_result(self, job: Job):
         test_env: TestEnvironment = job.future.result()
@@ -762,11 +774,12 @@ class TestManager:
                 self.report_pass_bug(job, 'pass error')
                 return PassCheckingOutcome.STOP
 
-        if not self.no_give_up and test_env.order - self.current_batch_start_order > self.GIVEUP_CONSTANT:
-            if not self.giveup_reported:
+        if not self.no_give_up and job.pass_id is not None:
+            ctx = self.pass_contexts[job.pass_id]
+            if not ctx.defunct and ctx.pass_job_counter - ctx.last_success_pass_job_counter > self.GIVEUP_CONSTANT:
                 self.report_pass_bug(job, 'pass got stuck')
-                self.giveup_reported = True
-            return PassCheckingOutcome.STOP
+                ctx.defunct = True
+                return PassCheckingOutcome.STOP
         return PassCheckingOutcome.IGNORE
 
     def maybe_update_success_candidate(
@@ -801,7 +814,6 @@ class TestManager:
     def run_parallel_tests(self) -> None:
         assert not self.jobs
         self.current_batch_start_order = self.order
-        self.giveup_reported = False
         assert self.success_candidate is None
         if self.interleaving:
             self.folding_manager = FoldingManager()
@@ -809,7 +821,7 @@ class TestManager:
         for pass_id, ctx in enumerate(self.pass_contexts):
             # Clean up the information about previously running jobs.
             ctx.running_transform_order_to_state = {}
-            ctx.current_batch_jobs = 0
+            ctx.current_batch_pass_job_counter = 0
             # Unfinished initializations from the last run will need to be restarted.
             if ctx.stage == PassStage.IN_INIT:
                 ctx.stage = PassStage.BEFORE_INIT
@@ -1031,7 +1043,7 @@ class TestManager:
         ready_hint_types = self.get_fully_initialized_hint_types()
         for pass_id, ctx in enumerate(self.pass_contexts):
             if ctx.can_init_now(ready_hint_types):
-                self.schedule_init(pass_id)
+                self.schedule_init(pass_id, ready_hint_types)
                 return True
         # 2. Reinitializing a previously finished pass.
         # We throttle reinits (only once out of REINIT_JOB_INTERVAL jobs) because they're only occasionally useful: for
@@ -1046,10 +1058,11 @@ class TestManager:
             ctx = self.pass_contexts[pass_id]
             assert ctx.stage == PassStage.ENUMERATING
             assert ctx.state is None
-            ctx.stage = PassStage.BEFORE_INIT
-            self.last_reinit_job_order = self.order
-            self.schedule_init(pass_id)
-            return True
+            if ctx.can_init_now(ready_hint_types):
+                ctx.stage = PassStage.BEFORE_INIT
+                self.last_reinit_job_order = self.order
+                self.schedule_init(pass_id, ready_hint_types)
+                return True
         # 3. Attempting a fold (simultaneous application) of previously discovered successful transformations; only
         # supported in the "interleaving" pass execution mode.
         if self.interleaving:
@@ -1065,7 +1078,7 @@ class TestManager:
         for cand_id, ctx in enumerate(self.pass_contexts):
             if not ctx.can_transform_now():
                 continue
-            if pass_id is not None and self.pass_contexts[pass_id].current_batch_jobs <= ctx.current_batch_jobs:
+            if pass_id is not None and self.pass_contexts[pass_id].current_batch_pass_job_counter <= ctx.current_batch_pass_job_counter:
                 continue
             pass_id = cand_id
         if pass_id is not None:
@@ -1073,9 +1086,9 @@ class TestManager:
             return True
         return False
 
-    def schedule_init(self, pass_id: int) -> None:
+    def schedule_init(self, pass_id: int, ready_hint_types: Set[bytes]) -> None:
         ctx = self.pass_contexts[pass_id]
-        assert ctx.can_init_now(self.get_fully_initialized_hint_types())
+        assert ctx.can_init_now(ready_hint_types)
 
         dependee_types = ctx.pass_.input_hint_types() if isinstance(ctx.pass_, HintBasedPass) else set()
         dependee_bundle_paths = []
@@ -1117,13 +1130,15 @@ class TestManager:
                 pass_=ctx.pass_,
                 pass_id=pass_id,
                 pass_name=repr(ctx.pass_),
+                pass_job_counter=ctx.pass_job_counter,
                 start_time=time.monotonic(),
                 timeout=init_timeout,
                 temporary_folder=None,
             )
         )
 
-        ctx.current_batch_jobs += 1
+        ctx.pass_job_counter += 1
+        ctx.current_batch_pass_job_counter += 1
         ctx.stage = PassStage.IN_INIT
         self.order += 1
 
@@ -1159,6 +1174,7 @@ class TestManager:
                 pass_=ctx.pass_,
                 pass_id=pass_id,
                 pass_name=repr(ctx.pass_),
+                pass_job_counter=ctx.pass_job_counter,
                 start_time=time.monotonic(),
                 timeout=self.timeout,
                 temporary_folder=folder,
@@ -1167,7 +1183,8 @@ class TestManager:
         assert self.order not in ctx.running_transform_order_to_state
         ctx.running_transform_order_to_state[self.order] = ctx.state
 
-        ctx.current_batch_jobs += 1
+        ctx.pass_job_counter += 1
+        ctx.current_batch_pass_job_counter += 1
         self.order += 1
         ctx.state = ctx.pass_.advance(self.current_test_case, ctx.state)
 
@@ -1198,6 +1215,7 @@ class TestManager:
                 pass_=None,
                 pass_id=None,
                 pass_name='Folding',
+                pass_job_counter=None,
                 start_time=time.monotonic(),
                 timeout=self.timeout,
                 temporary_folder=folder,


### PR DESCRIPTION
Apply the "giveup" limit - assume "pass got stuck" after 50000 unsuccessful jobs in a row - to an individual pass rather than to the whole pass group.

This allows the "interleaving" mode to continue making progress using some passes even if others got stuck and shouldn't be used anymore.