### PR TITLE
hints: Fix error in advance() when there're only special hints

### DIFF
--- a/cvise/passes/hint_based.py
+++ b/cvise/passes/hint_based.py
@@ -107,6 +107,10 @@ class HintState:
         return self.per_type_states[self.ptr].underlying_state.real_chunk()
 
     def advance(self) -> Union[HintState, None]:
+        if not self.per_type_states:
+            # This is reachable if only special hint types are present.
+            return None
+
         # First, prepare the current type's sub-state to point to the next enumeration step.
         new_substate = self.per_type_states[self.ptr].advance()
         if new_substate is None and len(self.per_type_states) == 1:

--- a/cvise/tests/test_hint_based.py
+++ b/cvise/tests/test_hint_based.py
@@ -263,3 +263,4 @@ def test_hint_based_special_hints_stored(tmp_path: Path):
 
     all_transforms = collect_all_transforms(pass_, state, test_case)
     assert all_transforms == set()
+    assert pass_.advance(test_case, state) is None


### PR DESCRIPTION
Fix an exception happening when all hints produced by a pass have the "special" type.

For example, this was possible to trigger when an empty makefile is passed - the MakefilePass would only emit the "@fileref" hint in that case.