### PR TITLE
multifile: Fix wrong paths in Lines; more robust path handling

### DIFF
--- a/clex/clex.l
+++ b/clex/clex.l
@@ -165,6 +165,7 @@ int count = 0;
 // index of byte where the current yytext ends in the input.
 int tok_end_pos = 0;
 
-void reset_to_initial_state(void) {
+void restart_with_new_file(void) {
     BEGIN(INITIAL);
+    YY_NEW_FILE;
 }

--- a/clex/defs.h
+++ b/clex/defs.h
@@ -26,7 +26,7 @@ extern int yyleng;
  */
 extern int count;
 extern int tok_end_pos;
-void reset_to_initial_state(void);
+void restart_with_new_file(void);
 
 enum tok_kind {
   TOK_KEYWORD = 999,

--- a/clex/driver.c
+++ b/clex/driver.c
@@ -482,22 +482,21 @@ int yywrap(void) {
   }
   char *line = NULL;
   size_t size = 0;
-  ssize_t nread = getline(&line, &size, stdin);
-  if (nread == -1) {
-    free(line);
-    return 1;
-  }
-  if (nread > 0 && line[nread - 1] == '\n')
-    line[nread - 1] = 0;
-  if (!strlen(line)) {
+  ssize_t nread = getdelim(&line, &size, 0, stdin);
+  if (nread == -1 || !strlen(line)) {
     free(line);
     return 1;
   }
   yyin = fopen(line, "r");
-  free(line);
-  reset_to_initial_state();
+  if (!yyin) {
+    fprintf(stderr, "Cannot open file: %s\n", line);
+    free(line);
+    return 1;
+  }
   tok_end_pos = 0;
-  return !yyin;
+  restart_with_new_file();
+  free(line);
+  return 0;
 }
 
 int main(int argc, char *argv[]) {
@@ -545,7 +544,8 @@ int main(int argc, char *argv[]) {
   if (strcmp(argv[3], "--") == 0) {
     file_id = 0;
     yyin = NULL;
-    yywrap();
+    if (yywrap())
+      exit(STOP);
   } else {
     file_id = -1;
     yyin = fopen(argv[3], "r");

--- a/clex/driver.c
+++ b/clex/driver.c
@@ -502,6 +502,9 @@ int yywrap(void) {
 int main(int argc, char *argv[]) {
   if (argc != 4) {
     printf("USAGE: %s command index file\n", argv[0]);
+    printf("  \"--\" can be specified instead of file, in which case input\n"
+           "  file paths should be sent as null-character-separated list into\n"
+           "  stdin.\n");
     exit(STOP);
   }
 

--- a/clex/strlex.l
+++ b/clex/strlex.l
@@ -162,6 +162,7 @@ int count = 0;
 // index of byte where the current yytext ends in the input.
 int tok_end_pos = 0;
 
-void reset_to_initial_state(void) {
+void restart_with_new_file(void) {
     BEGIN(INITIAL);
+    YY_NEW_FILE;
 }

--- a/cvise/passes/clexhints.py
+++ b/cvise/passes/clexhints.py
@@ -34,11 +34,11 @@ class ClexHintsPass(HintBasedPass):
         if test_case.is_dir():
             work_dir = test_case
             paths = [p.relative_to(test_case) for p in test_case.rglob('*') if not p.is_dir()]
-            stdin = b'\n'.join(bytes(p) for p in paths)
+            stdin = b'\0'.join(bytes(p) for p in paths)
             files_vocab = [str(p).encode() for p in paths]
             cmd_arg = '--'
         else:
-            work_dir = '.'
+            work_dir = None
             stdin = b''
             files_vocab = []
             cmd_arg = str(test_case)

--- a/cvise/passes/lines.py
+++ b/cvise/passes/lines.py
@@ -57,10 +57,10 @@ class LinesPass(HintBasedPass):
         # limit).
         if is_dir:
             work_dir = test_case
-            stdin = b'\n'.join(bytes(p) for p in paths)
+            stdin = b'\0'.join(bytes(p.relative_to(test_case)) for p in paths)
             cmd_file_arg = '--'
         else:
-            work_dir = '.'
+            work_dir = None
             stdin = b''
             cmd_file_arg = str(test_case)
 

--- a/cvise/passes/treesitter.py
+++ b/cvise/passes/treesitter.py
@@ -31,10 +31,10 @@ class TreeSitterPass(HintBasedPass):
         if test_case.is_dir():
             work_dir = test_case
             paths = [p.relative_to(test_case) for p in test_case.rglob('*') if not p.is_dir()]
-            stdin = b'\n'.join(bytes(p) for p in paths)
+            stdin = b'\0'.join(bytes(p) for p in paths)
             cmd_arg = '--'
         else:
-            work_dir = '.'
+            work_dir = None
             stdin = b''
             cmd_arg = str(test_case)
 

--- a/cvise/tests/testabstract.py
+++ b/cvise/tests/testabstract.py
@@ -100,6 +100,7 @@ def validate_hint_bundle(bundle: HintBundle, test_case: Path, allowed_hint_types
                 path = Path(bundle.vocabulary[hint.extra].decode())
                 assert not path.is_absolute()
                 assert (test_case / path).exists()
+                assert (test_case / path).is_relative_to(test_case)
         for patch in hint.patches:
             assert patch.left <= patch.right
             assert (patch.file is not None) == test_case.is_dir()
@@ -108,6 +109,8 @@ def validate_hint_bundle(bundle: HintBundle, test_case: Path, allowed_hint_types
                 path = Path(bundle.vocabulary[patch.file].decode())
                 assert not path.is_absolute()
                 assert (test_case / path).exists()
+                assert (test_case / path).is_relative_to(test_case)
+                assert patch.right <= (test_case / path).stat().st_size
             if patch.operation is not None:
                 assert patch.operation < len(bundle.vocabulary)
                 assert bundle.vocabulary[patch.operation] in _KNOWN_OPERATIONS

--- a/delta/topformflat.l
+++ b/delta/topformflat.l
@@ -183,6 +183,9 @@ int main(int argc, char *argv[])
   if (argc != 3) {
     printf("topformflat_hints version %s\n", version);
     printf("USAGE: %s threshold file >hints.jsonl\n", argv[0]);
+    printf("  \"--\" can be specified instead of file, in which case input\n"
+           "  file paths should be sent as null-character-separated list into\n"
+           "  stdin.\n");
     printf("  The threshold (default: 0) specifies at what nesting level\n"
            "  of braces will line breaks be allowed (or inserted).  By\n"
            "  starting with 0, you get all top-level forms, one per line\n"

--- a/delta/topformflat.l
+++ b/delta/topformflat.l
@@ -160,21 +160,21 @@ int yywrap(void) {
   }
   char *line = NULL;
   size_t size = 0;
-  ssize_t nread = getline(&line, &size, stdin);
-  if (nread == -1) {
-    free(line);
-    return 1;
-  }
-  if (nread > 0 && line[nread - 1] == '\n')
-    line[nread - 1] = 0;
-  if (!strlen(line)) {
+  ssize_t nread = getdelim(&line, &size, 0, stdin);
+  if (nread == -1 || !strlen(line)) {
     free(line);
     return 1;
   }
   yyin = fopen(line, "r");
-  free(line);
+  if (!yyin) {
+    fprintf(stderr, "Cannot open file: %s\n", line);
+    free(line);
+    return 1;
+  }
   reset_to_initial_state();
-  return !yyin;
+  yyrestart(yyin);
+  free(line);
+  return 0;
 }
 
 char *version = "2025.6.25";
@@ -197,7 +197,8 @@ int main(int argc, char *argv[])
   if (strcmp(argv[2], "--") == 0) {
     file_id = 0;
     yyin = NULL;
-    yywrap();
+    if (yywrap())
+      return 2;
   } else {
     file_id = -1;
     yyin = fopen(argv[2], "r");

--- a/treesitter_delta/Main.cpp
+++ b/treesitter_delta/Main.cpp
@@ -60,8 +60,8 @@ int main(int argc, char *argv[]) {
 
   if (argc != 3) {
     std::cerr << "Usage: " << argv[0] << " transformation input/file/path\n"
-              << "  or, for multi-file, send the paths as newline-separated "
-                 "list in stdin: "
+              << "  or, for multi-file, send the paths as "
+                 "null-character-separated list in stdin: "
               << argv[0] << " transformation --\n"
               << "transformation: one of \"replace-function-def-with-decl\", "
                  "\"erase-namespace\", \"remove-function\".\n";

--- a/treesitter_delta/Main.cpp
+++ b/treesitter_delta/Main.cpp
@@ -75,7 +75,7 @@ int main(int argc, char *argv[]) {
   std::vector<std::filesystem::path> InputPaths;
   if (MultiFile) {
     std::string Line;
-    while (std::getline(std::cin, Line)) {
+    while (std::getline(std::cin, Line, '\0')) {
       if (Line.empty())
         continue;
       InputPaths.push_back(std::move(Line));


### PR DESCRIPTION
Fix the LinesPass producing malformed hints for directory (multi-file) test cases, because the Python side didn't pass relative paths.

Fix file opening error handling in LinesPass and ClexHintsPass to not accidentally fall back to reading stdin (previously we left yyin as NULL and proceeded to running Flex, which then by default fell back to reading from stdin).

Make LinesPass, ClexHintsPass and TreesitterPass robust to file names with newlines by using null characters to delimit file names (this approach was already used for ClangIncludeGraphPass).

In tests, assert additionally that each hint patch doesn't exceed file boundaries.