### PR TITLE
multifile: Fix Clex rm-toks crash on unended comments

### DIFF
--- a/clex/clex.l
+++ b/clex/clex.l
@@ -22,6 +22,7 @@ IS			(u|U|l|L)*
 #endif
 
 #include <defs.h>
+#include <limits.h>
 
 // update the position whenever a token is about to be processed
 // (this macro is triggered by Flex prior to executing the matched rule’s action).
@@ -132,7 +133,7 @@ L?\"(\\.|[^\\"])*\"	{ process_token(TOK_STRING); }
                 int prev = 0;
                 for (;;)  {
                     int c = input();
-                    if (c == EOF)
+                    if (c == EOF || file_id == INT_MAX)
                         break;
                     if (file_id != start_file_id) {
                         /* don't cross file boundaries */

--- a/clex/clex.l
+++ b/clex/clex.l
@@ -128,30 +128,23 @@ L?\"(\\.|[^\\"])*\"	{ process_token(TOK_STRING); }
 "\\"                    { process_token(TOK_OTHER); }
 
 "/*"        {
-                     for ( ; ; )  {
-                         int c;
-                         /* eat up text of comment */
-                         do {
-                            c = input();
-                            ++tok_end_pos;
-                         } while (c != '*' && c != EOF);
-
-                         if ( c == '*' )
-                             {
-                             do {
-                                c = input();
-                                ++tok_end_pos;
-                             } while (c == '*');
-                             if ( c == '/' )
-                                 break;    /* found the end */
-                             }
-
-                         if ( c == EOF )
-                             {
-                                 exit(STOP);
-                             }
+                int start_file_id = file_id;
+                int prev = 0;
+                for (;;)  {
+                    int c = input();
+                    if (c == EOF)
+                        break;
+                    if (file_id != start_file_id) {
+                        /* don't cross file boundaries */
+                        unput(c);
+                        break;
                     }
-           }
+                    ++tok_end_pos;
+                    if (c == '/' && prev == '*')
+                        break;  /* found the end */
+                    prev = c;
+                }
+            }
 
 [ \t\v\f]		{ process_token(TOK_WS); }
 

--- a/clex/defs.h
+++ b/clex/defs.h
@@ -26,6 +26,7 @@ extern int yyleng;
  */
 extern int count;
 extern int tok_end_pos;
+extern int file_id;
 void restart_with_new_file(void);
 
 enum tok_kind {

--- a/clex/driver.c
+++ b/clex/driver.c
@@ -37,13 +37,14 @@ struct tok_t {
   int start_pos;
 };
 
-static int file_id;
+int file_id;
 static struct tok_t *tok_list;
 static int toks;
 static int max_toks;
 static const int initial_length = 1;
 
 static int add_tok(char *str, enum tok_kind kind) {
+  // fprintf(stderr, "add_tok\n");
   assert(str);
   if (toks >= max_toks) {
     max_toks *= 2;

--- a/clex/strlex.l
+++ b/clex/strlex.l
@@ -24,6 +24,7 @@ IS			(u|U|l|L)*
 #endif
 
 #include <defs.h>
+#include <limits.h>
 
 // update the position whenever a token is about to be processed
 // (this macro is triggered by Flex prior to executing the matched rule’s action).

--- a/clex/strlex.l
+++ b/clex/strlex.l
@@ -129,27 +129,23 @@ L?\"(\\.|[^\\"])*\"	{ process_token(TOK_STRING); }
 "\\"                    { process_token(TOK_OTHER); }
 
 "/*"        {
-                     for ( ; ; )  {
-                         int c;
-                         while ( (c = input()) != '*' &&
-                                  c != EOF )
-                             ;    /* eat up text of comment */
-
-                         if ( c == '*' )
-                             {
-                             while ( (c = input()) == '*' )
-                                 ;
-                             if ( c == '/' )
-                                 break;    /* found the end */
-                             }
-
-                         if ( c == EOF )
-                             {
-                             fprintf(stderr, "EOF in comment" );
-			     assert (0);
-                             }
+                int start_file_id = file_id;
+                int prev = 0;
+                for (;;)  {
+                    int c = input();
+                    if (c == EOF)
+                        break;
+                    if (file_id != start_file_id) {
+                        /* don't cross file boundaries */
+                        unput(c);
+                        break;
                     }
-           }
+                    ++tok_end_pos;
+                    if (c == '/' && prev == '*')
+                        break;  /* found the end */
+                    prev = c;
+                }
+            }
 
 [ \t\v\n\f]		{ process_token(TOK_WS); }
 

--- a/clex/strlex.l
+++ b/clex/strlex.l
@@ -133,7 +133,7 @@ L?\"(\\.|[^\\"])*\"	{ process_token(TOK_STRING); }
                 int prev = 0;
                 for (;;)  {
                     int c = input();
-                    if (c == EOF)
+                    if (c == EOF || file_id == INT_MAX)
                         break;
                     if (file_id != start_file_id) {
                         /* don't cross file boundaries */

--- a/cvise/tests/test_clexhints.py
+++ b/cvise/tests/test_clexhints.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import pytest
+import stat
 from typing import Any, List, Tuple
 
 from cvise.passes.abstract import SubsegmentState
@@ -258,3 +259,15 @@ def test_directory_unclosed_c_comment(tmp_path: Path):
 
     assert (('a.c', b'/*\n'), ('b.c', b'char /*\n')) in all_transforms
     assert (('a.c', b'int /*\n'), ('b.c', b'/*\n')) in all_transforms
+
+
+def test_directory_file_reading_failure(tmp_path: Path):
+    test_case = tmp_path / 'test_case'
+    test_case.mkdir()
+    file = test_case / 'foo.c'
+    file.touch()
+    file.chmod(file.stat().st_mode & ~stat.S_IRUSR)
+    p, state = init_pass('rm-toks-1-to-1', tmp_path, test_case)
+    all_transforms = collect_all_transforms_dir(p, state, test_case)
+
+    assert all_transforms == set()

--- a/cvise/tests/test_clexhints.py
+++ b/cvise/tests/test_clexhints.py
@@ -245,3 +245,16 @@ def test_directory_input_leading_trailing_spaces(tmp_path: Path):
 
     assert (('a.txt', b'\n'), ('b.txt', b'\nchar\n')) in all_transforms
     assert (('a.txt', b'\nint\n'), ('b.txt', b'\n')) in all_transforms
+
+
+def test_directory_unclosed_c_comment(tmp_path: Path):
+    """Test that we don't let C comments across file boundaries"""
+    test_case = tmp_path / 'test_case'
+    test_case.mkdir()
+    (test_case / 'a.c').write_text('int /*\n')
+    (test_case / 'b.c').write_text('char /*\n')
+    p, state = init_pass('rm-toks-1-to-1', tmp_path, test_case)
+    all_transforms = collect_all_transforms_dir(p, state, test_case)
+
+    assert (('a.c', b'/*\n'), ('b.c', b'char /*\n')) in all_transforms
+    assert (('a.c', b'int /*\n'), ('b.c', b'/*\n')) in all_transforms

--- a/cvise/tests/test_clexhints.py
+++ b/cvise/tests/test_clexhints.py
@@ -262,6 +262,7 @@ def test_directory_unclosed_c_comment(tmp_path: Path):
 
 
 def test_directory_file_reading_failure(tmp_path: Path):
+    """Test that the pass doesn't raise exceptions or hang when some file is unreadable."""
     test_case = tmp_path / 'test_case'
     test_case.mkdir()
     file = test_case / 'foo.c'


### PR DESCRIPTION
Fix the ClexHintsPass returning no hints when a directory (multi-file) test case has files with unfinished C-style comments.

Implementation-wise, there were two issues: first, Flex doesn't report EOF from input() when it was the last file and yywrap() куегктув тщтяукщ; repeatedly calling input() was causing a segfault. Second, we should stop the loop that "eats" comments when we cross input file boundary.