### PR TITLE
Fix Lines to delete last unfinished block in a file

### DIFF
--- a/cvise/tests/test_lines.py
+++ b/cvise/tests/test_lines.py
@@ -815,3 +815,15 @@ def test_multi_file_arg_0(tmp_path: Path):
     ) in all_transforms
     assert (('bar.cc', b'void f() {\n}\nvoid g() {\n}\n'), ('foo.cc', b'int x;\n')) in all_transforms
     assert (('bar.cc', b'\n'), ('foo.cc', b'\n')) in all_transforms
+
+
+def test_multi_file_arg_0_unclosed_block(tmp_path: Path):
+    input_dir = tmp_path / 'test_case'
+    input_dir.mkdir()
+    (input_dir / 'bar.h').write_text('namespace {\n')
+    (input_dir / 'foo.h').write_text('class A {\n')
+    p, state = init_pass('0', tmp_path, input_dir)
+    all_transforms = collect_all_transforms_dir(p, state, input_dir)
+
+    assert (('bar.h', b''), ('foo.h', b'class A {\n')) in all_transforms
+    assert (('bar.h', b'namespace {\n'), ('foo.h', b'')) in all_transforms

--- a/delta/topformflat.l
+++ b/delta/topformflat.l
@@ -6,6 +6,8 @@
  * very heuristic... */
 
 %{
+#include <assert.h>
+#include <limits.h>
 #include <stdlib.h>     // atoi
 
 // debugging diagnostic, emitted when enabled
@@ -122,18 +124,24 @@ void possibleChunkBegin(int pos)
   }
 }
 
+void chunkEnd(int pos)
+{
+  if (chunk_start_pos >= pos)
+    return;  // Empty chunk.
+  if (whitespace_start_pos <= chunk_start_pos && pos <= whitespace_end_pos)
+    return;  // Skip deleting chunks consisting of whitespaces only.
+  printf("{\"p\":[{\"l\":%d,\"r\":%d", chunk_start_pos, pos);
+  if (file_id != -1)
+    printf(",\"f\":%d", file_id);
+  printf("}]}\n");
+}
+
 void possibleChunkEnd(int pos)
 {
+  assert(file_id != INT_MAX);
   // Only attempt deleting chunks exactly at the specified nesting.
-  if (nesting == threshold && chunk_start_pos < pos) {
-    // Skip deleting chunks consisting of whitespaces only.
-    if (chunk_start_pos < whitespace_start_pos || pos > whitespace_end_pos) {
-      printf("{\"p\":[{\"l\":%d,\"r\":%d", chunk_start_pos, pos);
-      if (file_id != -1)
-        printf(",\"f\":%d", file_id);
-      printf("}]}\n");
-    }
-  }
+  if (nesting == threshold)
+    chunkEnd(pos);
   possibleChunkBegin(pos);
 }
 
@@ -149,31 +157,36 @@ void reset_to_initial_state(void) {
 int yywrap(void) {
   // In case there's some chunk of text remaining - e.g., if the file is not
   // EOL-terminated and the last line was a preprocessor directive.
-  possibleChunkEnd(token_end_pos);
+  if (nesting >= threshold)
+    chunkEnd(token_end_pos);
 
-  if (file_id == -1)
+  if (file_id == -1) {
+    file_id = INT_MAX;
     return 1;
+  }
+  char *path = NULL;
+  size_t size = 0;
+  ssize_t nread = getdelim(&path, &size, 0, stdin);
+  if (nread == -1 || !strlen(path)) {
+    free(path);
+    file_id = INT_MAX;
+    return 1;
+  }
+  FILE* f = fopen(path, "r");
+  if (!f) {
+    fprintf(stderr, "Cannot open file: %s\n", path);
+    free(path);
+    file_id = INT_MAX;
+    return 1;
+  }
+  free(path);
   if (yyin) {
     fclose(yyin);
-    yyin = NULL;
     ++file_id;
   }
-  char *line = NULL;
-  size_t size = 0;
-  ssize_t nread = getdelim(&line, &size, 0, stdin);
-  if (nread == -1 || !strlen(line)) {
-    free(line);
-    return 1;
-  }
-  yyin = fopen(line, "r");
-  if (!yyin) {
-    fprintf(stderr, "Cannot open file: %s\n", line);
-    free(line);
-    return 1;
-  }
+  yyin = f;
   reset_to_initial_state();
   yyrestart(yyin);
-  free(line);
   return 0;
 }
 


### PR DESCRIPTION
Improve the LinesPass to also emit a hint for the last chunk in the file when it's unfinished. For example, for a file ending with "namespace {" we'll now attempt deleting this ending for arg="0". Such examples occur often in the middle of reduction, or when macros with curly brackets confuse the nesting calculation.

Also make topformflat robust to file opening failures, similarly to what was done to Clex rm-toks in #365.