### PR TITLE
ClangIncludeGraph: Support Clang Header Modules

### DIFF
--- a/cvise/passes/clangincludegraph.py
+++ b/cvise/passes/clangincludegraph.py
@@ -12,7 +12,7 @@ from cvise.utils.process import ProcessEventNotifier
 # TODO: Make these parameters configurable.
 # Only execute clang_include_graph for the makefile recipe commands that start from the following programs. The goal is
 # to skip running the tool for non-compiler commands, like "mkdir".
-_RECOGNIZED_PROGRAMS = re.compile(r'\bCC\b|clang|CLANG|\bCXX\b|g++|G++|gcc|GCC')
+_RECOGNIZED_PROGRAMS = re.compile(r'\bCC\b|clang|CLANG|\bCXX\b|g\+\+|G\+\+|gcc|GCC')
 # Remove Clang C/C++ header module references, since built module PCMs aren't available without compiling the whole test
 # case. Remove "$(EXTRA_CFLAGS)" since the makefile substitution isn't used here and it'd look like a name of an input
 # file.


### PR DESCRIPTION
Support Clang C/C++ header modules when extracting the include graph in ClangIncludeGraphPass.

Implementation-wise, we have to manipulate the command line because "-fmodule-file=..." arguments would refer to non-existing PCM files, so these and "-fmodule-map-file=..." arguments that depend on them have to be deleted.

On the other hand, "-fmodules" has to be kept, otherwise we won't be able to easily run Clang's preprocessor on a modulemap file. Also "-fmodule-map-file-home-is-cwd", if present, has to be kept - otherwise Clang won't find the headers mentioned in the modulemap.