### PR TITLE
hints: Use tuples, make frozen and comparable

### DIFF
--- a/cvise/passes/abstract.py
+++ b/cvise/passes/abstract.py
@@ -5,7 +5,7 @@ import logging
 from pathlib import Path
 import random
 import shutil
-from typing import Self, Union
+from typing import List, Self, Union
 
 from cvise.utils.process import ProcessEventNotifier
 
@@ -176,12 +176,18 @@ class AbstractPass:
     def check_prerequisites(self):
         raise NotImplementedError(f"Class {type(self).__name__} has not implemented 'check_prerequisites'!")
 
+    def user_visible(self) -> bool:
+        return True
+
     def supports_dir_test_cases(self):
         """Whether the pass supports input test cases that are directories (as opposed to single files).
 
         By default false; intended to be overridden by subclasses which do implement directory support.
         """
         return False
+
+    def create_subordinate_passes(self) -> List[Self]:
+        return []
 
     def new(
         self, test_case: Path, tmp_dir: Path, job_timeout: int, process_event_notifier: ProcessEventNotifier, **kwargs

--- a/cvise/passes/balanced.py
+++ b/cvise/passes/balanced.py
@@ -73,21 +73,22 @@ class BalancedPass(HintBasedPass):
             if start_pos is None:
                 return None
             if config.to_delete == Deletion.ALL:
-                p = Patch(left=start_pos, right=file_pos + 1, file=file_id)
+                val = None
                 if config.replacement:
-                    p.value = 0  # when config.replacement is used, the first string in the vocabulary points to it
-                return Hint(patches=[p])
+                    val = 0  # when config.replacement is used, the first string in the vocabulary points to it
+                p = Patch(left=start_pos, right=file_pos + 1, file=file_id, value=val)
+                return Hint(patches=(p,))
             if config.to_delete == Deletion.ONLY:
                 return Hint(
-                    patches=[
+                    patches=(
                         Patch(left=start_pos, right=start_pos + 1, file=file_id),
                         Patch(left=file_pos, right=file_pos + 1, file=file_id),
-                    ]
+                    )
                 )
             if config.to_delete == Deletion.INSIDE:
                 if file_pos - start_pos <= 1:
                     return None  # don't create an empty hint
-                return Hint(patches=[Patch(left=start_pos + 1, right=file_pos, file=file_id)])
+                return Hint(patches=(Patch(left=start_pos + 1, right=file_pos, file=file_id),))
             raise ValueError(f'Unexpected config {config}')
 
         # Scan the text left-to-right and maintain active (not yet matched) open brackets in a stack; None denotes a

--- a/cvise/passes/blank.py
+++ b/cvise/passes/blank.py
@@ -45,5 +45,5 @@ class BlankPass(HintBasedPass):
                 end_pos = file_pos + len(line)
                 for idx, pattern in enumerate(self.PATTERNS.values()):
                     if re.match(pattern, line) is not None:
-                        hints.append(Hint(type=idx, patches=[Patch(left=file_pos, right=end_pos, file=file_id)]))
+                        hints.append(Hint(type=idx, patches=(Patch(left=file_pos, right=end_pos, file=file_id),)))
                 file_pos = end_pos

--- a/cvise/passes/clangincludegraph.py
+++ b/cvise/passes/clangincludegraph.py
@@ -103,7 +103,7 @@ class ClangIncludeGraphPass(HintBasedPass):
                 # If a file was included from a file inside test case, create a patch pointing to the include directive;
                 # otherwise leave the hint patchless (e.g., a system/resource dir header including a standard library
                 # header that's included into the test case).
-                patches = [] if e.from_node is None else [Patch(left=e.loc_begin, right=e.loc_end, file=e.from_node)]
+                patches = () if e.from_node is None else (Patch(left=e.loc_begin, right=e.loc_end, file=e.from_node),)
                 hints.append(Hint(type=0, patches=patches, extra=e.to_node))
         return HintBundle(hints=hints, vocabulary=vocab)
 

--- a/cvise/passes/clangmodulemap.py
+++ b/cvise/passes/clangmodulemap.py
@@ -126,13 +126,13 @@ def _create_hints_for_module(
         hints.append(
             Hint(
                 type=_Vocab.DELETE_EMPTY_SUBMODULE.value[0],
-                patches=[
+                patches=(
                     Patch(
                         file=file_id,
                         left=mod.loc.begin,
                         right=mod.loc.end,
-                    )
-                ],
+                    ),
+                ),
             )
         )
 
@@ -140,7 +140,7 @@ def _create_hints_for_module(
         hints.append(
             Hint(
                 type=_Vocab.INLINE_SUBMODULE_CONTENTS.value[0],
-                patches=[
+                patches=(
                     Patch(
                         file=file_id,
                         left=mod.title_loc.begin,
@@ -151,7 +151,7 @@ def _create_hints_for_module(
                         left=mod.close_brace_loc.begin,
                         right=mod.close_brace_loc.end,
                     ),
-                ],
+                ),
             )
         )
 
@@ -161,39 +161,39 @@ def _create_hints_for_module(
             hints.append(
                 Hint(
                     type=_Vocab.FILEREF.value[0],
-                    patches=[
+                    patches=(
                         Patch(
                             file=file_id,
                             left=header.loc.begin,
                             right=header.loc.end,
-                        )
-                    ],
+                        ),
+                    ),
                     extra=header_file_id,
                 )
             )
         hints.append(
             Hint(
                 type=_Vocab.MAKE_HEADER_NON_MODULAR.value[0],
-                patches=[
+                patches=(
                     Patch(
                         file=file_id,
                         left=header.loc.begin,
                         right=header.loc.end,
-                    )
-                ],
+                    ),
+                ),
             )
         )
     for use in mod.uses:
         hints.append(
             Hint(
                 type=_Vocab.DELETE_USE_DECL.value[0],
-                patches=[
+                patches=(
                     Patch(
                         file=file_id,
                         left=use.loc.begin,
                         right=use.loc.end,
-                    )
-                ],
+                    ),
+                ),
             )
         )
     for submod in mod.submodules:
@@ -207,13 +207,13 @@ def _create_hints_for_unclassified_lines(unclassified_lines: List[_SourceLoc], f
         hints.append(
             Hint(
                 type=_Vocab.DELETE_LINE.value[0],
-                patches=[
+                patches=(
                     Patch(
                         file=file_id,
                         left=loc.begin,
                         right=loc.end,
-                    )
-                ],
+                    ),
+                ),
             )
         )
 

--- a/cvise/passes/clexhints.py
+++ b/cvise/passes/clexhints.py
@@ -60,10 +60,11 @@ class ClexHintsPass(HintBasedPass):
             if not line.isspace():
                 hint = hint_decoder.decode(line)
                 # Shift file identifiers according to their position in the vocabulary.
-                for patch in hint.patches:
-                    if patch.file is not None:
-                        patch.file += len(orig_vocab)
-                hints.append(hint)
+                new_patches = tuple(
+                    p.__replace__(file=p.file + len(orig_vocab) if p.file is not None else None) for p in hint.patches
+                )
+                new_hint = hint.__replace__(patches=new_patches)
+                hints.append(new_hint)
         return HintBundle(vocabulary=orig_vocab + files_vocab, hints=hints)
 
     def create_elementary_state(self, hint_count: int):

--- a/cvise/passes/comments.py
+++ b/cvise/passes/comments.py
@@ -46,16 +46,12 @@ class CommentsPass(HintBasedPass):
         # * then - any number of "*" that aren't followed by "/", or of any other characters;
         # * finally - "*/".
         for m in re.finditer(rb'/\*(?:\*(?!/)|[^*])*\*/', prog, flags=re.DOTALL):
-            patch = Patch(left=m.start(), right=m.end())
-            if file_id is not None:
-                patch.file = file_id
-            hints.append(Hint(type=self.MULTI_LINE_VOCAB_ID, patches=[patch]))
+            patch = Patch(left=m.start(), right=m.end(), file=file_id)
+            hints.append(Hint(type=self.MULTI_LINE_VOCAB_ID, patches=(patch,)))
 
         # Remove all single-line comments.
         for m in re.finditer(rb'//.*$', prog, flags=re.MULTILINE):
-            patch = Patch(left=m.start(), right=m.end())
-            if file_id is not None:
-                patch.file = file_id
-            hints.append(Hint(type=self.SINGLE_LINE_VOCAB_ID, patches=[patch]))
+            patch = Patch(left=m.start(), right=m.end(), file=file_id)
+            hints.append(Hint(type=self.SINGLE_LINE_VOCAB_ID, patches=(patch,)))
 
         return hints

--- a/cvise/passes/line_markers.py
+++ b/cvise/passes/line_markers.py
@@ -35,6 +35,6 @@ class LineMarkersPass(HintBasedPass):
             for line in in_file.readlines():
                 end_pos = file_pos + len(line)
                 if self.line_regex.search(line):
-                    hints.append(Hint(patches=[Patch(left=file_pos, right=end_pos)]))
+                    hints.append(Hint(patches=(Patch(left=file_pos, right=end_pos),)))
                 file_pos = end_pos
         return HintBundle(hints=hints)

--- a/cvise/passes/lines.py
+++ b/cvise/passes/lines.py
@@ -36,7 +36,7 @@ class LinesPass(HintBasedPass):
             file_pos = 0
             for line in in_file:
                 end_pos = file_pos + len(line)
-                hints.append(Hint(patches=[Patch(left=file_pos, right=end_pos, file=file_id)]))
+                hints.append(Hint(patches=(Patch(left=file_pos, right=end_pos, file=file_id),)))
                 file_pos = end_pos
 
     def _generate_topformflat_hints(

--- a/cvise/passes/makefile.py
+++ b/cvise/passes/makefile.py
@@ -60,7 +60,7 @@ def _create_hints_for_makefile(path: Path, file_id: int, hints: List[Hint]) -> N
     hints.append(
         Hint(
             type=_Vocab.FILEREF.value[0],
-            patches=[],
+            patches=(),
             extra=file_id,
         )
     )
@@ -76,7 +76,7 @@ def _create_hints_for_makefile(path: Path, file_id: int, hints: List[Hint]) -> N
         hints.append(
             Hint(
                 type=_Vocab.REMOVE_ARGUMENTS_ACROSS_ALL_COMMANDS.value[0],
-                patches=[Patch(left=loc.begin, right=loc.end, file=file_id) for loc in locs],
+                patches=tuple(Patch(left=loc.begin, right=loc.end, file=file_id) for loc in locs),
             )
         )
 

--- a/cvise/passes/rmunusedfiles.py
+++ b/cvise/passes/rmunusedfiles.py
@@ -51,14 +51,14 @@ class RmUnusedFilesPass(HintBasedPass):
             size = path.stat().st_size
             hints.append(
                 Hint(
-                    patches=[
+                    patches=(
                         Patch(
                             left=0,
                             right=size,
                             file=file_id,
                             operation=0,  # "rm"
-                        )
-                    ]
+                        ),
+                    )
                 )
             )
         return HintBundle(hints=hints, vocabulary=vocab)

--- a/cvise/tests/test_clangincludegraph.py
+++ b/cvise/tests/test_clangincludegraph.py
@@ -4,6 +4,7 @@ from typing import Any, Tuple
 
 from cvise.passes.clangincludegraph import ClangIncludeGraphPass
 from cvise.tests.testabstract import validate_stored_hints
+from cvise.passes.hint_based import HintBasedPass
 from cvise.utils.externalprograms import find_external_programs
 from cvise.utils.hint import load_hints
 from cvise.utils.process import ProcessEventNotifier
@@ -11,7 +12,24 @@ from cvise.utils.process import ProcessEventNotifier
 
 def init_pass(tmp_dir: Path, input_path: Path) -> Tuple[ClangIncludeGraphPass, Any]:
     pass_ = ClangIncludeGraphPass(external_programs=find_external_programs())
-    state = pass_.new(input_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[])
+
+    sub_passes = pass_.create_subordinate_passes()
+    sub_bundles = []
+    for p in sub_passes:
+        assert isinstance(p, HintBasedPass)
+        assert set(p.output_hint_types()) <= set(pass_.input_hint_types())
+        sub_state = p.new(
+            input_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+        )
+        validate_stored_hints(sub_state, p, input_path)
+        if sub_state is None:
+            continue
+        for path in sub_state.hint_bundle_paths().values():
+            sub_bundles.append(load_hints(path, begin_index=None, end_index=None))
+
+    state = pass_.new(
+        input_path, tmp_dir=tmp_dir, process_event_notifier=ProcessEventNotifier(None), dependee_hints=sub_bundles
+    )
     validate_stored_hints(state, pass_, input_path)
     return pass_, state
 

--- a/cvise/tests/test_hint.py
+++ b/cvise/tests/test_hint.py
@@ -23,7 +23,7 @@ def tmp_hints_file(tmp_path: Path) -> Path:
 
 def test_apply_hints_delete_prefix(tmp_test_case: Path, tmp_transformed_file: Path):
     tmp_test_case.write_text('Foo bar')
-    hint = Hint(patches=[Patch(left=0, right=4)])
+    hint = Hint(patches=(Patch(left=0, right=4),))
     bundle = HintBundle(hints=[hint])
     validate_hint_bundle(bundle, tmp_test_case)
 
@@ -34,7 +34,7 @@ def test_apply_hints_delete_prefix(tmp_test_case: Path, tmp_transformed_file: Pa
 
 def test_apply_hints_delete_suffix(tmp_test_case: Path, tmp_transformed_file: Path):
     tmp_test_case.write_text('Foo bar')
-    hint = Hint(patches=[Patch(left=3, right=7)])
+    hint = Hint(patches=(Patch(left=3, right=7),))
     bundle = HintBundle(hints=[hint])
     validate_hint_bundle(bundle, tmp_test_case)
 
@@ -45,7 +45,7 @@ def test_apply_hints_delete_suffix(tmp_test_case: Path, tmp_transformed_file: Pa
 
 def test_apply_hints_delete_middle(tmp_test_case: Path, tmp_transformed_file: Path):
     tmp_test_case.write_text('Foo bar baz')
-    hint = Hint(patches=[Patch(left=3, right=7)])
+    hint = Hint(patches=(Patch(left=3, right=7),))
     bundle = HintBundle(hints=[hint])
     validate_hint_bundle(bundle, tmp_test_case)
 
@@ -56,8 +56,8 @@ def test_apply_hints_delete_middle(tmp_test_case: Path, tmp_transformed_file: Pa
 
 def test_apply_hints_delete_middle_multiple(tmp_test_case: Path, tmp_transformed_file: Path):
     tmp_test_case.write_text('Foo bar baz')
-    hint1 = Hint(patches=[Patch(left=3, right=4)])
-    hint2 = Hint(patches=[Patch(left=7, right=8)])
+    hint1 = Hint(patches=(Patch(left=3, right=4),))
+    hint2 = Hint(patches=(Patch(left=7, right=8),))
     hints = [hint1, hint2]
     bundle = HintBundle(hints=hints)
     validate_hint_bundle(bundle, tmp_test_case)
@@ -69,7 +69,7 @@ def test_apply_hints_delete_middle_multiple(tmp_test_case: Path, tmp_transformed
 
 def test_apply_hints_delete_all(tmp_test_case: Path, tmp_transformed_file: Path):
     tmp_test_case.write_text('Foo bar')
-    hint = Hint(patches=[Patch(left=0, right=7)])
+    hint = Hint(patches=(Patch(left=0, right=7),))
     bundle = HintBundle(hints=[hint])
     validate_hint_bundle(bundle, tmp_test_case)
 
@@ -81,9 +81,14 @@ def test_apply_hints_delete_all(tmp_test_case: Path, tmp_transformed_file: Path)
 def test_apply_hints_delete_touching(tmp_test_case: Path, tmp_transformed_file: Path):
     tmp_test_case.write_text('Foo bar baz')
     # It's essentially the deletion of [3..7).
-    hint1 = Hint(patches=[Patch(left=3, right=4)])
-    hint2 = Hint(patches=[Patch(left=6, right=7)])
-    hint3 = Hint(patches=[Patch(left=5, right=6), Patch(left=4, right=5)])
+    hint1 = Hint(patches=(Patch(left=3, right=4),))
+    hint2 = Hint(patches=(Patch(left=6, right=7),))
+    hint3 = Hint(
+        patches=(
+            Patch(left=5, right=6),
+            Patch(left=4, right=5),
+        )
+    )
     hints = [hint1, hint2, hint3]
     bundle = HintBundle(hints=hints)
     validate_hint_bundle(bundle, tmp_test_case)
@@ -96,8 +101,8 @@ def test_apply_hints_delete_touching(tmp_test_case: Path, tmp_transformed_file: 
 def test_apply_hints_delete_overlapping(tmp_test_case: Path, tmp_transformed_file: Path):
     tmp_test_case.write_text('Foo bar baz')
     # It's essentially the deletion of [3..7).
-    hint1 = Hint(patches=[Patch(left=3, right=6)])
-    hint2 = Hint(patches=[Patch(left=4, right=7)])
+    hint1 = Hint(patches=(Patch(left=3, right=6),))
+    hint2 = Hint(patches=(Patch(left=4, right=7),))
     hints = [hint1, hint2]
     bundle = HintBundle(hints=hints)
     validate_hint_bundle(bundle, tmp_test_case)
@@ -109,8 +114,8 @@ def test_apply_hints_delete_overlapping(tmp_test_case: Path, tmp_transformed_fil
 
 def test_apply_hints_delete_nested(tmp_test_case: Path, tmp_transformed_file: Path):
     tmp_test_case.write_text('Foo bar baz')
-    hint1 = Hint(patches=[Patch(left=4, right=6)])
-    hint2 = Hint(patches=[Patch(left=3, right=7)])
+    hint1 = Hint(patches=(Patch(left=4, right=6),))
+    hint2 = Hint(patches=(Patch(left=3, right=7),))
     hints = [hint1, hint2]
     bundle = HintBundle(hints=hints)
     validate_hint_bundle(bundle, tmp_test_case)
@@ -124,7 +129,7 @@ def test_apply_hints_replace_with_shorter(tmp_test_case: Path, tmp_transformed_f
     """Test a hint replacing a fragment with a shorter value."""
     tmp_test_case.write_text('Foo foobarbaz baz')
     vocab = [b'xyz']
-    hint = Hint(patches=[Patch(left=4, right=13, value=0)])
+    hint = Hint(patches=(Patch(left=4, right=13, value=0),))
     bundle = HintBundle(vocabulary=vocab, hints=[hint])
     validate_hint_bundle(bundle, tmp_test_case)
 
@@ -137,7 +142,7 @@ def test_apply_hints_replace_with_longer(tmp_test_case: Path, tmp_transformed_fi
     """Test a hint replacing a fragment with a longer value."""
     tmp_test_case.write_text('Foo x baz')
     vocab = [b'z', b'abacaba']
-    hint = Hint(patches=[Patch(left=4, right=5, value=1)])
+    hint = Hint(patches=(Patch(left=4, right=5, value=1),))
     bundle = HintBundle(vocabulary=vocab, hints=[hint])
     validate_hint_bundle(bundle, tmp_test_case)
 
@@ -150,8 +155,8 @@ def test_apply_hints_replacement_inside_deletion(tmp_test_case: Path, tmp_transf
     """Test that a replacement is a no-op if happening inside a to-be-deleted fragment."""
     tmp_test_case.write_text('Foo bar baz')
     vocab = [b'x']
-    hint1 = Hint(patches=[Patch(left=5, right=6, value=0)])  # replaces "a" with "x" in "bar"
-    hint2 = Hint(patches=[Patch(left=4, right=7)])  # deletes "bar"
+    hint1 = Hint(patches=(Patch(left=5, right=6, value=0),))  # replaces "a" with "x" in "bar"
+    hint2 = Hint(patches=(Patch(left=4, right=7),))  # deletes "bar"
     hints = [hint1, hint2]
     bundle = HintBundle(vocabulary=vocab, hints=hints)
     validate_hint_bundle(bundle, tmp_test_case)
@@ -165,8 +170,8 @@ def test_apply_hints_deletion_inside_replacement(tmp_test_case: Path, tmp_transf
     """Test that a deletion is a no-op if happening inside a to-be-replaced fragment."""
     tmp_test_case.write_text('Foo bar baz')
     vocab = [b'some']
-    hint1 = Hint(patches=[Patch(left=5, right=6)])  # deletes "a" in "bar"
-    hint2 = Hint(patches=[Patch(left=4, right=7, value=0)])  # replaces "bar" with "some"
+    hint1 = Hint(patches=(Patch(left=5, right=6),))  # deletes "a" in "bar"
+    hint2 = Hint(patches=(Patch(left=4, right=7, value=0),))  # replaces "bar" with "some"
     hints = [hint1, hint2]
     bundle = HintBundle(vocabulary=vocab, hints=hints)
     validate_hint_bundle(bundle, tmp_test_case)
@@ -183,8 +188,8 @@ def test_apply_hints_replacement_of_deleted_prefix(tmp_test_case: Path, tmp_tran
     wins in a group of overlapping hints" that'd suffice for other tests."""
     tmp_test_case.write_text('Foo bar baz')
     vocab = [b'x']
-    hint1 = Hint(patches=[Patch(left=4, right=5, value=0)])  # replaces "b" with "x" in "bar"
-    hint2 = Hint(patches=[Patch(left=4, right=7)])  # deletes "bar"
+    hint1 = Hint(patches=(Patch(left=4, right=5, value=0),))  # replaces "b" with "x" in "bar"
+    hint2 = Hint(patches=(Patch(left=4, right=7),))  # deletes "bar"
     hints = [hint1, hint2]
     bundle = HintBundle(vocabulary=vocab, hints=hints)
     validate_hint_bundle(bundle, tmp_test_case)
@@ -198,9 +203,9 @@ def test_apply_hints_replacement_and_deletion_touching(tmp_test_case: Path, tmp_
     """Test that deletions and replacements in touching, but not overlapping, fragments are applied independently."""
     tmp_test_case.write_text('Foo bar baz')
     vocab = [b'some']
-    hint1 = Hint(patches=[Patch(left=5, right=7, value=0)])  # replaces "ar" with "some"
-    hint2 = Hint(patches=[Patch(left=4, right=5)])  # deletes "b" in "bar"
-    hint3 = Hint(patches=[Patch(left=7, right=8)])  # deletes " " after "bar"
+    hint1 = Hint(patches=(Patch(left=5, right=7, value=0),))  # replaces "ar" with "some"
+    hint2 = Hint(patches=(Patch(left=4, right=5),))  # deletes "b" in "bar"
+    hint3 = Hint(patches=(Patch(left=7, right=8),))  # deletes " " after "bar"
     hints = [hint1, hint2, hint3]
     bundle = HintBundle(vocabulary=vocab, hints=hints)
     validate_hint_bundle(bundle, tmp_test_case)
@@ -217,8 +222,8 @@ def test_apply_hints_overlapping_replacements(tmp_test_case: Path, tmp_transform
     break. At the moment, the leftwise patch wins in this case, but this is subject to change in the future."""
     tmp_test_case.write_text('abcd')
     vocab = [b'foo', b'x']
-    hint1 = Hint(patches=[Patch(left=1, right=3, value=0)])  # replaces "bc" with "foo"
-    hint2 = Hint(patches=[Patch(left=2, right=4, value=1)])  # replaces "cd" with "x"
+    hint1 = Hint(patches=(Patch(left=1, right=3, value=0),))  # replaces "bc" with "foo"
+    hint2 = Hint(patches=(Patch(left=2, right=4, value=1),))  # replaces "cd" with "x"
     hints = [hint1, hint2]
     bundle = HintBundle(vocabulary=vocab, hints=hints)
     validate_hint_bundle(bundle, tmp_test_case)
@@ -230,9 +235,9 @@ def test_apply_hints_overlapping_replacements(tmp_test_case: Path, tmp_transform
 
 def test_apply_hints_multiple_bundles(tmp_test_case: Path, tmp_transformed_file: Path):
     tmp_test_case.write_text('foobar')
-    hint02 = Hint(patches=[Patch(left=0, right=2)])
-    hint13 = Hint(patches=[Patch(left=1, right=3)])
-    hint24 = Hint(patches=[Patch(left=2, right=4)])
+    hint02 = Hint(patches=(Patch(left=0, right=2),))
+    hint13 = Hint(patches=(Patch(left=1, right=3),))
+    hint24 = Hint(patches=(Patch(left=2, right=4),))
     bundle1 = HintBundle(hints=[hint13])
     bundle2 = HintBundle(hints=[hint02, hint24])
     validate_hint_bundle(bundle1, tmp_test_case)
@@ -245,8 +250,13 @@ def test_apply_hints_multiple_bundles(tmp_test_case: Path, tmp_transformed_file:
 
 def test_apply_hints_utf8(tmp_test_case: Path, tmp_transformed_file: Path):
     tmp_test_case.write_text('Brötchen 🍴')
-    hint1 = Hint(patches=[Patch(left=0, right=1), Patch(left=5, right=7)])
-    hint2 = Hint(patches=[Patch(left=10, right=14)])
+    hint1 = Hint(
+        patches=(
+            Patch(left=0, right=1),
+            Patch(left=5, right=7),
+        )
+    )
+    hint2 = Hint(patches=(Patch(left=10, right=14),))
     bundle1 = HintBundle(hints=[hint1])
     bundle2 = HintBundle(hints=[hint2])
     validate_hint_bundle(bundle1, tmp_test_case)
@@ -260,7 +270,7 @@ def test_apply_hints_utf8(tmp_test_case: Path, tmp_transformed_file: Path):
 
 def test_apply_hints_non_unicode(tmp_test_case: Path, tmp_transformed_file: Path):
     tmp_test_case.write_bytes(b'\0F\xffoo')
-    hint = Hint(patches=[Patch(left=2, right=3)])
+    hint = Hint(patches=(Patch(left=2, right=3),))
     bundle = HintBundle(hints=[hint])
     validate_hint_bundle(bundle, tmp_test_case)
 
@@ -276,9 +286,9 @@ def test_apply_hints_dir(tmp_path: Path):
     (input_dir / 'foo.h').write_text('unsigned foo;')
     (input_dir / 'bar.cc').write_text('void bar();')
     vocab = [b'foo.h', b'bar.cc']
-    hint_oo = Hint(patches=[Patch(left=10, right=12, file=0)])
-    hint_un = Hint(patches=[Patch(left=0, right=2, file=0)])
-    hint_ar = Hint(patches=[Patch(left=6, right=8, file=1)])
+    hint_oo = Hint(patches=(Patch(left=10, right=12, file=0),))
+    hint_un = Hint(patches=(Patch(left=0, right=2, file=0),))
+    hint_ar = Hint(patches=(Patch(left=6, right=8, file=1),))
     bundle = HintBundle(hints=[hint_oo, hint_un, hint_ar], vocabulary=vocab)
     validate_hint_bundle(bundle, input_dir, allowed_hint_types=set())
 
@@ -310,9 +320,9 @@ def test_apply_hints_dir_nonexisting_parent(tmp_path: Path):
 
 def test_apply_hints_statistics(tmp_test_case: Path, tmp_transformed_file: Path):
     tmp_test_case.write_text('Foo bar baz')
-    hint03 = Hint(patches=[Patch(left=0, right=3)])
-    hint07 = Hint(patches=[Patch(left=0, right=7)])
-    hint89 = Hint(patches=[Patch(left=8, right=9)])
+    hint03 = Hint(patches=(Patch(left=0, right=3),))
+    hint07 = Hint(patches=(Patch(left=0, right=7),))
+    hint89 = Hint(patches=(Patch(left=8, right=9),))
     bundle1 = HintBundle(hints=[hint03, hint89], pass_name='pass1')
     bundle2 = HintBundle(hints=[hint07], pass_name='pass2')
     validate_hint_bundle(bundle1, tmp_test_case)
@@ -327,8 +337,8 @@ def test_apply_hints_statistics(tmp_test_case: Path, tmp_transformed_file: Path)
 
 def test_store_load_hints(tmp_hints_file):
     vocab = [b'new text']
-    hint1 = Hint(patches=[Patch(left=0, right=1)])
-    hint2 = Hint(patches=[Patch(left=2, right=3), Patch(left=4, right=5, value=0)])
+    hint1 = Hint(patches=(Patch(left=0, right=1),))
+    hint2 = Hint(patches=(Patch(left=2, right=3), Patch(left=4, right=5, value=0)))
     hints = HintBundle(vocabulary=vocab, hints=[hint1, hint2])
     store_hints(hints, tmp_hints_file)
 
@@ -339,7 +349,7 @@ def test_store_load_hints(tmp_hints_file):
 
 def test_hints_storage_compression(tmp_hints_file: Path):
     COUNT = 10000
-    hints = [Hint(patches=[Patch(left=i, right=i + 1)]) for i in range(COUNT)]
+    hints = [Hint(patches=(Patch(left=i, right=i + 1),)) for i in range(COUNT)]
     bundle = HintBundle(hints=hints)
     store_hints(bundle, tmp_hints_file)
 

--- a/cvise/tests/test_hint_based.py
+++ b/cvise/tests/test_hint_based.py
@@ -26,7 +26,7 @@ class StubHintBasedPass(HintBasedPass):
 
 def test_hint_based_first_char_once(tmp_path: Path):
     """Test the case of a single hint."""
-    hint = Hint(patches=[Patch(left=0, right=1)])
+    hint = Hint(patches=(Patch(left=0, right=1),))
     pass_ = StubHintBasedPass(
         {
             b'foo': [hint],
@@ -44,9 +44,9 @@ def test_hint_based_first_char_once(tmp_path: Path):
 
 def test_hint_based_last_char_repeatedly(tmp_path: Path):
     """Test the case of applying a single hint that's different every time."""
-    hint_byte0 = Hint(patches=[Patch(left=0, right=1)])
-    hint_byte1 = Hint(patches=[Patch(left=1, right=2)])
-    hint_byte2 = Hint(patches=[Patch(left=2, right=3)])
+    hint_byte0 = Hint(patches=(Patch(left=0, right=1),))
+    hint_byte1 = Hint(patches=(Patch(left=1, right=2),))
+    hint_byte2 = Hint(patches=(Patch(left=2, right=3),))
     pass_ = StubHintBasedPass(
         {
             b'foo': [hint_byte2],
@@ -70,9 +70,9 @@ def test_hint_based_all_chars_grouped(tmp_path: Path):
     The logic that chooses ranges of hints to be attempted (the binary search)
     is mostly irrelevant for the test - we only expect it to try *all* hints
     together."""
-    hint_byte0 = Hint(patches=[Patch(left=0, right=1)])
-    hint_byte1 = Hint(patches=[Patch(left=1, right=2)])
-    hint_byte2 = Hint(patches=[Patch(left=2, right=3)])
+    hint_byte0 = Hint(patches=(Patch(left=0, right=1),))
+    hint_byte1 = Hint(patches=(Patch(left=1, right=2),))
+    hint_byte2 = Hint(patches=(Patch(left=2, right=3),))
     pass_ = StubHintBasedPass(
         {
             b'foo': [hint_byte0, hint_byte1, hint_byte2],
@@ -94,10 +94,10 @@ def test_hint_based_state_iteration(tmp_path: Path):
     Unlike iterate_pass-based tests which pretend that any transformation leads
     to a successful interestingness test and proceed immediately, here we
     verify how different hints are attempted."""
-    hint_bytes01 = Hint(patches=[Patch(left=0, right=2)])
-    hint_bytes12 = Hint(patches=[Patch(left=1, right=3)])
-    hint_bytes45 = Hint(patches=[Patch(left=4, right=6)])
-    hint_bytes2345 = Hint(patches=[Patch(left=2, right=6)])
+    hint_bytes01 = Hint(patches=(Patch(left=0, right=2),))
+    hint_bytes12 = Hint(patches=(Patch(left=1, right=3),))
+    hint_bytes45 = Hint(patches=(Patch(left=4, right=6),))
+    hint_bytes2345 = Hint(patches=(Patch(left=2, right=6),))
     pass_ = StubHintBasedPass(
         {
             b'abc def': [hint_bytes01, hint_bytes12, hint_bytes45, hint_bytes2345],
@@ -119,10 +119,10 @@ def test_hint_based_state_iteration(tmp_path: Path):
 def test_hint_based_multiple_types(tmp_path: Path):
     """Test advancing through hints of multiple types."""
     vocab = [b'space_removal', b'b_removal']
-    hint_space1 = Hint(type=0, patches=[Patch(left=3, right=4)])
-    hint_space2 = Hint(type=0, patches=[Patch(left=7, right=8)])
-    hint_b1 = Hint(type=1, patches=[Patch(left=1, right=2)])
-    hint_b2 = Hint(type=1, patches=[Patch(left=6, right=7)])
+    hint_space1 = Hint(type=0, patches=(Patch(left=3, right=4),))
+    hint_space2 = Hint(type=0, patches=(Patch(left=7, right=8),))
+    hint_b1 = Hint(type=1, patches=(Patch(left=1, right=2),))
+    hint_b2 = Hint(type=1, patches=(Patch(left=6, right=7),))
     pass_ = StubHintBasedPass(
         {
             b'aba cab a': [hint_b1, hint_space1, hint_b2, hint_space2],
@@ -148,9 +148,9 @@ def test_hint_based_type1_fewer_than_type2(tmp_path: Path):
     Verify that subranges of same-typed hints are checked, but differently-typed hints aren't mixed.
     """
     vocab = [b'type0', b'type1']
-    hint1 = Hint(type=0, patches=[Patch(left=0, right=1)])
-    hint2 = Hint(type=1, patches=[Patch(left=1, right=2)])
-    hint3 = Hint(type=1, patches=[Patch(left=2, right=3)])
+    hint1 = Hint(type=0, patches=(Patch(left=0, right=1),))
+    hint2 = Hint(type=1, patches=(Patch(left=1, right=2),))
+    hint3 = Hint(type=1, patches=(Patch(left=2, right=3),))
     pass_ = StubHintBasedPass(
         {
             b'abc': [hint1, hint2, hint3],
@@ -174,9 +174,9 @@ def test_hint_based_type2_fewer_than_type1(tmp_path: Path):
     Verify that subranges of same-typed hints are checked, but differently-typed hints aren't mixed.
     """
     vocab = [b'type0', b'type1']
-    hint1 = Hint(type=0, patches=[Patch(left=0, right=1)])
-    hint2 = Hint(type=0, patches=[Patch(left=1, right=2)])
-    hint3 = Hint(type=1, patches=[Patch(left=2, right=3)])
+    hint1 = Hint(type=0, patches=(Patch(left=0, right=1),))
+    hint2 = Hint(type=0, patches=(Patch(left=1, right=2),))
+    hint3 = Hint(type=1, patches=(Patch(left=2, right=3),))
     pass_ = StubHintBasedPass(
         {
             b'abc': [hint1, hint2, hint3],
@@ -197,10 +197,10 @@ def test_hint_based_type2_fewer_than_type1(tmp_path: Path):
 def test_hint_based_non_utf8(tmp_path: Path):
     """Test the case of non UTF-8 inputs."""
     input = b'f\0o\xffo\xc3\x84'
-    hint12 = Hint(patches=[Patch(left=1, right=2)])
-    hint23 = Hint(patches=[Patch(left=2, right=3)])
-    hint34 = Hint(patches=[Patch(left=3, right=4)])
-    hint57 = Hint(patches=[Patch(left=5, right=7)])
+    hint12 = Hint(patches=(Patch(left=1, right=2),))
+    hint23 = Hint(patches=(Patch(left=2, right=3),))
+    hint34 = Hint(patches=(Patch(left=3, right=4),))
+    hint57 = Hint(patches=(Patch(left=5, right=7),))
     pass_ = StubHintBasedPass(
         {
             input: [hint12, hint23, hint34, hint57],
@@ -223,8 +223,8 @@ def test_hint_based_special_hints_not_attempted(tmp_path: Path):
     input = b'foo'
     test_case = tmp_path / 'input.txt'
     vocab = [b'sometype', b'@specialtype']
-    hint_regular = Hint(type=0, patches=[Patch(left=0, right=1)])
-    hint_special = Hint(type=1, patches=[Patch(left=1, right=2)])
+    hint_regular = Hint(type=0, patches=(Patch(left=0, right=1),))
+    hint_special = Hint(type=1, patches=(Patch(left=1, right=2),))
     pass_ = StubHintBasedPass(
         {
             input: [hint_regular, hint_special],
@@ -244,7 +244,7 @@ def test_hint_based_special_hints_stored(tmp_path: Path):
     input = b'foo'
     test_case = tmp_path / 'input.txt'
     hint_type = b'@specialtype'
-    hint = Hint(type=0, patches=[Patch(left=1, right=2)])
+    hint = Hint(type=0, patches=(Patch(left=1, right=2),))
     pass_ = StubHintBasedPass(
         {
             input: [hint],

--- a/cvise/tests/test_rmunusedfiles.py
+++ b/cvise/tests/test_rmunusedfiles.py
@@ -35,8 +35,8 @@ def test_unused_files_deleted(tmp_path: Path, test_case_path: Path):
     # Fake filerefs from a.c to foo.h and from unspecified location to a.c.
     filerefs_bundle = HintBundle(
         hints=[
-            Hint(type=0, patches=[Patch(left=0, right=1, file=1)], extra=2),
-            Hint(type=0, patches=[], extra=1),
+            Hint(type=0, patches=(Patch(left=0, right=1, file=1),), extra=2),
+            Hint(type=0, patches=(), extra=1),
         ],
         vocabulary=[b'@fileref', b'a.c', b'foo.h'],
     )

--- a/cvise/tests/test_test_manager.py
+++ b/cvise/tests/test_test_manager.py
@@ -137,7 +137,7 @@ class LetterRemovingHintPass(HintBasedPass):
 
     def generate_hints(self, test_case: Path, *args, **kwargs):
         sz = test_case.stat().st_size
-        hints = [Hint(patches=[Patch(left=i, right=i + 1)]) for i in range(sz)]
+        hints = [Hint(patches=(Patch(left=i, right=i + 1),)) for i in range(sz)]
         return HintBundle(hints=hints)
 
 
@@ -160,7 +160,7 @@ class BracketRemovingPass(HintBasedPass):
     def generate_hints(self, test_case: Path, *args, **kwargs):
         hints = []
         for m in re.finditer(r'\([^()]*\)', test_case.read_text()):
-            hints.append(Hint(type=0, patches=[Patch(left=m.start(), right=m.end())]))
+            hints.append(Hint(type=0, patches=(Patch(left=m.start(), right=m.end()),)))
         return HintBundle(hints=hints, vocabulary=[b'remove-brackets'])
 
 
@@ -183,7 +183,7 @@ class InsideBracketsRemovingPass(HintBasedPass):
                 input_patch = input_hint.patches[0]
                 if input_patch.right - input_patch.left == 1:
                     continue  # don't create empty hints
-                hints.append(Hint(patches=[Patch(left=input_patch.left + 1, right=input_patch.right - 1)]))
+                hints.append(Hint(patches=(Patch(left=input_patch.left + 1, right=input_patch.right - 1),)))
         return HintBundle(hints=hints)
 
 

--- a/cvise/tests/testabstract.py
+++ b/cvise/tests/testabstract.py
@@ -7,12 +7,11 @@ from typing import Optional, Set, Tuple, Union
 from cvise.passes.abstract import AbstractPass, PassResult
 from cvise.passes.hint_based import HintBasedPass, HintState
 from cvise.utils.fileutil import CloseableTemporaryFile
-from cvise.utils.hint import HINT_SCHEMA_STRICT, HintBundle, load_hints
+from cvise.utils.hint import HINT_SCHEMA_STRICT, HintBundle, is_special_hint_type, load_hints
 from cvise.utils.process import ProcessEventNotifier
 
 
 _TYPES_WITH_PATH_EXTRA = (b'@fileref',)
-_TYPES_ALLOWING_EMPTY_PATCHES = (b'@fileref',)
 _KNOWN_OPERATIONS = (b'rm',)
 
 
@@ -92,7 +91,7 @@ def validate_hint_bundle(bundle: HintBundle, test_case: Path, allowed_hint_types
             hint_type = bundle.vocabulary[hint.type]
             if allowed_hint_types is not None:
                 assert hint_type in allowed_hint_types
-        if hint.type is None or bundle.vocabulary[hint.type] not in _TYPES_ALLOWING_EMPTY_PATCHES:
+        if hint.type is None or not is_special_hint_type(bundle.vocabulary[hint.type]):
             assert len(hint.patches) > 0
         if hint.extra is not None:
             assert hint.extra < len(bundle.vocabulary)

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -869,6 +869,11 @@ class TestManager:
             self.release_all_jobs()
 
     def run_passes(self, passes: List[AbstractPass], interleaving: bool):
+        extra_passes = []
+        for p in passes:
+            extra_passes += p.create_subordinate_passes()
+        passes += extra_passes
+
         assert len(passes) == 1 or interleaving
 
         if self.start_with_pass:
@@ -887,7 +892,7 @@ class TestManager:
         self.interleaving = interleaving
         self.jobs = []
 
-        pass_titles = ', '.join(repr(c.pass_) for c in self.pass_contexts)
+        pass_titles = ', '.join(repr(c.pass_) for c in self.pass_contexts if c.pass_.user_visible())
         logging.info(f'===< {pass_titles} >===')
 
         if self.total_file_size == 0:


### PR DESCRIPTION
Change the Hint/Patch structs to be frozen and ordered, and consequently store patches in tuples instead of lists.

This should reduce RAM usage for passes that generate lots of hints. Additionally, it allows us to sort and remove duplicate hints easily.