### PR TITLE
multifile: Encode file paths in vocab in Python code

### DIFF
--- a/cvise/passes/treesitter.py
+++ b/cvise/passes/treesitter.py
@@ -35,6 +35,7 @@ class TreeSitterPass(HintBasedPass):
             cmd_arg = '--'
         else:
             work_dir = None
+            paths = []
             stdin = b''
             cmd_arg = str(test_case)
 
@@ -46,6 +47,7 @@ class TreeSitterPass(HintBasedPass):
         vocab_line = next(stdout, None)
         vocab_decoder = msgspec.json.Decoder(type=List[str])
         vocab = [s.encode() for s in vocab_decoder.decode(vocab_line)] if vocab_line else []
+        vocab += [str(p).encode() for p in paths]  # input paths aren't printed by the tool, due to escaping complexity
 
         hints = []
         hint_decoder = msgspec.json.Decoder(type=Hint)

--- a/treesitter_delta/Main.cpp
+++ b/treesitter_delta/Main.cpp
@@ -90,8 +90,6 @@ int main(int argc, char *argv[]) {
     return -1;
   }
   std::vector<std::string> Vocab = Transform->getVocabulary();
-  if (MultiFile)
-    Vocab.insert(Vocab.end(), InputPaths.begin(), InputPaths.end());
   printVocab(Vocab);
 
   // Prepare the common parsing state.
@@ -110,8 +108,7 @@ int main(int argc, char *argv[]) {
       std::cerr << "Failed to parse " << InputPath << "\n";
       continue;
     }
-    auto FileId = MultiFile ? std::make_optional<int>(
-                                  Vocab.size() - InputPaths.size() + InputIndex)
+    auto FileId = MultiFile ? std::make_optional<int>(Vocab.size() + InputIndex)
                             : std::nullopt;
     Transform->processFile(Contents, *Tree, FileId);
   }


### PR DESCRIPTION
Update TreeSitterPass to print the vocabulary's file paths on the Python side, instead of the C++ one. This makes sure we don't produce corrupted JSONs due to the lack of easy-to-use escaping functionality in C++.