### PR TITLE
multifile: MakefilePass removes targets

### DIFF
--- a/cvise/passes/makefile.py
+++ b/cvise/passes/makefile.py
@@ -93,7 +93,7 @@ def _add_target_removal_hints(mk: Makefile, file_id: int, hints: List[Hint]) -> 
     target_mentions: Dict[Path, List[SourceLoc]] = {}
     for rule in mk.rules:
         # Either delete a mention of a target from the rule, or the whole rule if it's the only target in it.
-        if len(set(t.value for t in rule.targets)) == 1:
+        if len({t.value for t in rule.targets}) == 1:
             target_mentions.setdefault(rule.targets[0].value, []).append(rule.loc)
         else:
             for target in rule.targets:
@@ -125,8 +125,8 @@ def _add_target_removal_hints(mk: Makefile, file_id: int, hints: List[Hint]) -> 
                     if prev_arg and _TWO_TOKEN_OPTIONS.fullmatch(prev_arg.value):
                         target_mentions[path].append(prev_arg.loc)
 
-    # Then generate a hint for each target with all references to it.
-    for target, locs in target_mentions.items():
+    # Then generate a hint for each target and all references to it.
+    for locs in target_mentions.values():
         hints.append(
             Hint(
                 type=_Vocab.REMOVE_TARGET.value[0],

--- a/cvise/tests/test_makefile.py
+++ b/cvise/tests/test_makefile.py
@@ -39,7 +39,7 @@ a.out:
             'Makefile',
             b"""
 a.out:
-\tgcc  foo.c
+\tgcc foo.c
         """,
         ),
     ) in all_transforms
@@ -73,7 +73,7 @@ b.o:
             'Makefile',
             b"""
 a.out:
-\tgcc   foo.c
+\tgcc foo.c
 b.o:
 \tgcc -ob.o bar.c
         """,
@@ -85,7 +85,7 @@ b.o:
             'Makefile',
             b"""
 a.out:
-\tgcc  a.o foo.c
+\tgcc a.o foo.c
 b.o:
 \tgcc -ob.o bar.c
         """,
@@ -97,7 +97,7 @@ b.o:
             'Makefile',
             b"""
 a.out:
-\tgcc -o  foo.c
+\tgcc -o foo.c
 b.o:
 \tgcc -ob.o bar.c
         """,
@@ -111,7 +111,7 @@ b.o:
 a.o:
 \tgcc -o a.o foo.c
 b.o:
-\tgcc  bar.c
+\tgcc bar.c
         """,
         ),
     ) not in all_transforms
@@ -133,7 +133,7 @@ a.o:
             'Makefile',
             b"""
 a.o:
-\tgcc  foo.c
+\tgcc foo.c
         """,
         ),
     ) not in all_transforms
@@ -157,9 +157,9 @@ b.out:
             'makefile',
             b"""
 a.out:
-\tgcc  foo.c
+\tgcc foo.c
 b.out:
-\tgcc -fsigned-char  -o b.out bar.c
+\tgcc -fsigned-char -o b.out bar.c
         """,
         ),
     ) in all_transforms
@@ -170,11 +170,11 @@ def test_continuation(tmp_path: Path, test_case_path: Path):
         """
 a.out:
 \tgcc -ansi foo.c
-b.out: \
+b.out: \\
     a.out
-\tgcc \
-\t    -fsigned-char \
-\t    -ansi \
+\tgcc \\
+\t    -fsigned-char \\
+\t    -ansi \\
 \t    -o b.out bar.c
         """,
     )
@@ -187,12 +187,11 @@ b.out: \
             'makefile',
             b"""
 a.out:
-\tgcc  foo.c
-b.out: \
+\tgcc foo.c
+b.out: \\
     a.out
-\tgcc \
-\t    -fsigned-char \
-\t     \
+\tgcc \\
+\t    -fsigned-char \\
 \t    -o b.out bar.c
         """,
         ),
@@ -215,7 +214,7 @@ a.o:
             'Makefile',
             b"""
 a.o:
-\tgcc  foo.c
+\tgcc foo.c
         """,
         ),
     ) in all_transforms
@@ -256,7 +255,7 @@ a.o:
             'Makefile',
             b"""
 a.o:
-\tgcc  foo.c
+\tgcc foo.c
         """,
         ),
     ) in all_transforms
@@ -266,7 +265,7 @@ a.o:
             'Makefile',
             b"""
 a.o:
-\tgcc '-Dfoo="x  foo.c
+\tgcc '-Dfoo="x foo.c
         """,
         ),
     ) not in all_transforms
@@ -275,7 +274,7 @@ a.o:
             'Makefile',
             b"""
 a.o:
-\tgcc  y"' foo.c
+\tgcc y"' foo.c
         """,
         ),
     ) not in all_transforms
@@ -308,8 +307,8 @@ b.o:
         (
             'Makefile',
             b"""
-prog:  b.o
-\tgcc -o prog  b.o
+prog: b.o
+\tgcc -o prog b.o
 b.o:
 \tgcc -o b.o b.c""",
         ),
@@ -319,7 +318,9 @@ b.o:
         (
             'Makefile',
             b"""
-prog: a.o \n\tgcc -o prog a.o \na.o:
+prog: a.o
+\tgcc -o prog a.o
+a.o:
 \tgcc -o a.o a.c\n""",
         ),
     ) in all_transforms
@@ -342,6 +343,7 @@ mod.pcm:
         (
             'Makefile',
             b"""
-a.out: \n\tclang -fmodules  main.cc\n""",
+a.out:
+\tclang -fmodules main.cc\n""",
         ),
     ) in all_transforms

--- a/cvise/tests/test_makefile.py
+++ b/cvise/tests/test_makefile.py
@@ -288,3 +288,43 @@ a.o:
         """,
         ),
     ) not in all_transforms
+
+
+def test_remove_target(tmp_path: Path, test_case_path: Path):
+    (test_case_path / 'Makefile').write_text(
+        """
+prog:
+\tgcc -o prog a.o b.o
+a.o:
+\tgcc -o a.o a.c
+b.o:
+\tgcc -o b.o b.c
+        """,
+    )
+    p, state = init_pass(tmp_path, test_case_path)
+    all_transforms = collect_all_transforms_dir(p, state, test_case_path)
+
+    # "a.o" removed
+    assert (
+        (
+            'Makefile',
+            b"""
+prog:
+\tgcc -o prog  b.o
+b.o:
+\tgcc -o b.o b.c
+        """,
+        ),
+    ) in all_transforms
+    # "b.o" removed
+    assert (
+        (
+            'Makefile',
+            b"""
+prog:
+\tgcc -o prog  b.o
+a.o:
+\tgcc -o a.o a.c
+        """,
+        ),
+    ) in all_transforms

--- a/cvise/tests/test_makefile.py
+++ b/cvise/tests/test_makefile.py
@@ -298,8 +298,7 @@ prog:
 a.o:
 \tgcc -o a.o a.c
 b.o:
-\tgcc -o b.o b.c
-        """,
+\tgcc -o b.o b.c""",
     )
     p, state = init_pass(tmp_path, test_case_path)
     all_transforms = collect_all_transforms_dir(p, state, test_case_path)
@@ -312,8 +311,7 @@ b.o:
 prog:
 \tgcc -o prog  b.o
 b.o:
-\tgcc -o b.o b.c
-        """,
+\tgcc -o b.o b.c""",
         ),
     ) in all_transforms
     # "b.o" removed
@@ -322,9 +320,7 @@ b.o:
             'Makefile',
             b"""
 prog:
-\tgcc -o prog  b.o
-a.o:
-\tgcc -o a.o a.c
-        """,
+\tgcc -o prog a.o \na.o:
+\tgcc -o a.o a.c\n""",
         ),
     ) in all_transforms

--- a/cvise/tests/test_makefile.py
+++ b/cvise/tests/test_makefile.py
@@ -351,7 +351,7 @@ a.out:
 
 def test_dont_remove_phony_target(tmp_path: Path, test_case_path: Path):
     (test_case_path / 'Makefile').write_text(
-            """
+        """
 .PHONY: all clean
 all: a.out
 a.out:
@@ -372,7 +372,7 @@ clean:
 all:
 clean:
 \trm -f
-            """
+            """,
         ),
     ) in all_transforms
     # "all" not removed
@@ -385,7 +385,7 @@ a.out:
 \tgcc main.c
 clean:
 \trm -f a.out
-            """
+            """,
         ),
     ) not in all_transforms
     # "clean" not removed
@@ -397,6 +397,6 @@ clean:
 all: a.out
 a.out:
 \tgcc main.c
-            """
+            """,
         ),
     ) not in all_transforms

--- a/cvise/utils/makefileparser.py
+++ b/cvise/utils/makefileparser.py
@@ -35,6 +35,7 @@ class SourceLoc:
 class TextWithLoc:
     loc: SourceLoc
     value: bytes
+    preceding_spaces_loc: Optional[SourceLoc] = None
 
     def substr(self, begin: int, end: Optional[int] = None) -> TextWithLoc:
         assert self.loc.begin + begin <= self.loc.end
@@ -50,6 +51,7 @@ class TextWithLoc:
 class PathWithLoc:
     loc: SourceLoc
     value: Path
+    preceding_spaces_loc: Optional[SourceLoc] = None
 
 
 @dataclass
@@ -160,7 +162,10 @@ def _split_by_spaces(text: TextWithLoc) -> List[TextWithLoc]:
         # Determine the token's position - split() doesn't return how many whitespaces were skipped.
         pos = text.value.find(tok, start_pos)
         assert pos != -1
-        tok_locs.append(text.substr(pos, pos + len(tok)))
+        tok_loc = text.substr(pos, pos + len(tok))
+        if pos > start_pos:
+            tok_loc.preceding_spaces_loc = SourceLoc(text.loc.begin + start_pos, text.loc.begin + pos)
+        tok_locs.append(tok_loc)
         start_pos = pos + len(tok)
     return tok_locs
 
@@ -173,10 +178,12 @@ def _split_shell_cmd_line(text: TextWithLoc) -> List[TextWithLoc]:
     n = len(text.value)
     while i < n:
         # Skip spaces before the next token.
+        start = i
         while i < n and chr(text.value[i]).isspace():
             i += 1
         if i == n:
             break
+        preceding_spaces_loc = SourceLoc(text.loc.begin + start, text.loc.begin + i) if start < i else None
 
         begin = i
         tok = bytearray()
@@ -207,10 +214,10 @@ def _split_shell_cmd_line(text: TextWithLoc) -> List[TextWithLoc]:
             i += 1
 
         loc = SourceLoc(begin=text.loc.begin + begin, end=text.loc.begin + i)
-        tok_locs.append(TextWithLoc(loc, tok))
+        tok_locs.append(TextWithLoc(loc, tok, preceding_spaces_loc))
 
     return tok_locs
 
 
 def _to_paths(toks: List[TextWithLoc]) -> List[PathWithLoc]:
-    return [PathWithLoc(tok.loc, Path(tok.value.decode())) for tok in toks]
+    return [PathWithLoc(tok.loc, Path(tok.value.decode()), tok.preceding_spaces_loc) for tok in toks]


### PR DESCRIPTION
Implement a new heuristic that removes a makefile target together with all references to it (in prerequisites and command lines).

Also improve the "remove-arguments-across-all-commands" heuristic in the same pass to not leave extraneous spaces around the deleted arguments.