### PR TITLE
multifile: Print file&dir count in logs

### DIFF
--- a/cvise/utils/fileutil.py
+++ b/cvise/utils/fileutil.py
@@ -71,6 +71,18 @@ def get_line_count(test_case: Path) -> int:
     return lines
 
 
+def get_file_count(test_case: Path) -> int:
+    if not test_case.is_dir():
+        return 1
+    return sum(1 for p in test_case.rglob('*') if not p.is_dir())
+
+
+def get_dir_count(test_case: Path) -> int:
+    if not test_case.is_dir():
+        return 0
+    return 1 + sum(1 for p in test_case.rglob('*') if p.is_dir())
+
+
 def copy_test_case(source: Path, destination_parent: Path) -> None:
     assert not source.is_absolute()
     mkdir_up_to(destination_parent / source.parent, destination_parent)

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -540,6 +540,14 @@ class TestManager:
     def total_line_count(self) -> int:
         return sum(fileutil.get_line_count(p) for p in self.test_cases)
 
+    @property
+    def total_file_count(self) -> int:
+        return sum(fileutil.get_file_count(p) for p in self.test_cases)
+
+    @property
+    def total_dir_count(self) -> int:
+        return sum(fileutil.get_dir_count(p) for p in self.test_cases)
+
     def backup_test_cases(self):
         for f in self.test_cases:
             orig_file = Path(f'{f}.orig')
@@ -1041,6 +1049,10 @@ class TestManager:
             notes.append(f'{self.total_line_count} lines')
         if len(self.test_cases) > 1:
             notes.append(str(new_test_case.name))
+        if self.current_test_case.is_dir():
+            files = self.total_file_count
+            dirs = self.total_dir_count
+            notes.append(f'{files} file{"s" if files > 1 else ""} in {dirs} dir{"s" if dirs > 1 else ""}')
         if len(self.pass_contexts) > 1:
             if isinstance(self.success_candidate.pass_state, FoldingStateOut):
                 pass_name = ' + '.join(self.success_candidate.pass_state.statistics.get_passes_ordered_by_delta())


### PR DESCRIPTION
Logs for directory (multi-file) test cases will look like:

`00:30:26 INFO (58.7%, 9998801 bytes, 149447 lines, 2481 files in 675 dirs, ...)`