### PR TITLE
cli: Stats sort passes by duration too

### DIFF
--- a/cvise/utils/statistics.py
+++ b/cvise/utils/statistics.py
@@ -1,5 +1,5 @@
 import time
-from typing import Union
+from typing import Dict, Optional, Tuple
 
 from cvise.passes.abstract import AbstractPass
 
@@ -16,60 +16,60 @@ class SinglePassStatistic:
 
 class PassStatistic:
     def __init__(self):
-        self.stats = {}
-        self.folding_stats = SinglePassStatistic('Folding')
+        self._stats: Dict[str, SinglePassStatistic] = {}
+        self._folding_stats = SinglePassStatistic('Folding')
 
     def add_initialized(self, pass_: AbstractPass, start_time: float) -> None:
         """Record a completion of a new() method for a pass."""
         pass_name = repr(pass_)
-        if pass_name not in self.stats:
-            self.stats[pass_name] = SinglePassStatistic(pass_name)
-        self.stats[pass_name].total_seconds += time.monotonic() - start_time
+        if pass_name not in self._stats:
+            self._stats[pass_name] = SinglePassStatistic(pass_name)
+        self._stats[pass_name].total_seconds += time.monotonic() - start_time
 
-    def add_executed(self, pass_: Union[AbstractPass, None], start_time: float, parallel_workers: int) -> None:
+    def add_executed(self, pass_: Optional[AbstractPass], start_time: float, parallel_workers: int) -> None:
         """Record a completion of a transformation and checking task for a pass.
 
         If pass_ is None, it was a folding execution.
         """
-        stat = self.get_stats(pass_)
+        stat = self._get_stats(pass_)
         stat.totally_executed += 1
         # Account for parallelism when adding up durations.
         stat.total_seconds += (time.monotonic() - start_time) / parallel_workers
 
-    def add_success(self, pass_: Union[AbstractPass, None]):
+    def add_success(self, pass_: Optional[AbstractPass]):
         """Record that a transformation by the pass passes the interestingness test.
 
         If pass_ is None, it was a folding execution.
         """
-        stat = self.get_stats(pass_)
+        stat = self._get_stats(pass_)
         stat.worked += 1
 
-    def add_failure(self, pass_: Union[AbstractPass, None]):
+    def add_failure(self, pass_: Optional[AbstractPass]):
         """Record that a transformation by the pass failed or didn't pass the interestingness test.
 
         If pass_ is None, it was a folding execution.
         """
-        stat = self.get_stats(pass_)
+        stat = self._get_stats(pass_)
         stat.failed += 1
 
-    def add_committed_success(self, pass_name: Union[str, None], size_delta: int):
-        stat = self.stats[pass_name] if pass_name is not None else self.folding_stats
+    def add_committed_success(self, pass_name: Optional[str], size_delta: int):
+        stat = self._stats[pass_name] if pass_name is not None else self._folding_stats
         stat.total_size_delta += size_delta
 
     @property
     def sorted_results(self):
-        def sort_statistics(item):
+        def sort_statistics(item: Tuple[str, SinglePassStatistic]) -> Tuple:
             pass_name, pass_data = item
-            return (pass_data.total_size_delta, pass_name)
+            return (pass_data.total_size_delta, pass_data.total_seconds, pass_name)
 
-        regular_results = sorted(self.stats.items(), key=sort_statistics)
+        regular_results = sorted(self._stats.items(), key=sort_statistics)
         folding_results = []
-        if self.folding_stats.worked > 0:
-            folding_results.append(('Folding (merging transformations from other passes)', self.folding_stats))
+        if self._folding_stats.worked > 0:
+            folding_results.append(('Folding (merging transformations from other passes)', self._folding_stats))
         return regular_results + folding_results
 
-    def get_stats(self, pass_: Union[AbstractPass, None]) -> SinglePassStatistic:
+    def _get_stats(self, pass_: Optional[AbstractPass]) -> SinglePassStatistic:
         if pass_ is None:
-            return self.folding_stats
+            return self._folding_stats
         pass_name = repr(pass_)
-        return self.stats[pass_name]
+        return self._stats[pass_name]


### PR DESCRIPTION
When multiple passes have the same improvement, sort them by increasing of total duration. This makes the stats table a bit more intuitive.