### PR TITLE
tests: Add another possible output into test_cvise

### DIFF
--- a/tests/test_cvise.py
+++ b/tests/test_cvise.py
@@ -63,7 +63,7 @@ def test_simple_reduction(tmp_path: Path, overridden_subprocess_tmpdir: Path):
     check_cvise(
         'blocksort-part.c',
         ['-c', r"gcc -c blocksort-part.c && grep '\<nextHi\>' blocksort-part.c"],
-        ['#define nextHi', '#define nextHi\n'],
+        ['#define nextHi', '#define nextHi\n', '#undef nextHi', '#undef nextHi\n'],
         tmp_path,
         overridden_subprocess_tmpdir,
     )
@@ -73,7 +73,7 @@ def test_simple_reduction_no_interleaving_config(tmp_path: Path, overridden_subp
     check_cvise(
         'blocksort-part.c',
         ['-c', r"gcc -c blocksort-part.c && grep '\<nextHi\>' blocksort-part.c", '--pass-group', 'no-interleaving'],
-        ['#define nextHi', '#define nextHi\n'],
+        ['#define nextHi', '#define nextHi\n', '#undef nextHi', '#undef nextHi\n'],
         tmp_path,
         overridden_subprocess_tmpdir,
     )
@@ -221,7 +221,7 @@ def test_non_ascii_interestingness_test(tmp_path: Path, overridden_subprocess_tm
     check_cvise(
         'blocksort-part.c',
         ['-c', r"printf '\xc3\xa4\xff'; gcc -c blocksort-part.c && grep '\<nextHi\>' blocksort-part.c"],
-        ['#define nextHi', '#define nextHi\n'],
+        ['#define nextHi', '#define nextHi\n', '#undef nextHi', '#undef nextHi\n'],
         tmp_path,
         overridden_subprocess_tmpdir,
     )


### PR DESCRIPTION
The semi-integration test of reducing blocksort-part.c can sometimes end up with yet another result: "#undef nextHi". This was causing occasional flakiness of the test.