### PR TITLE
hints, test_manager: Sanitize and randomize file names

### DIFF
--- a/cvise/passes/abstract.py
+++ b/cvise/passes/abstract.py
@@ -206,6 +206,7 @@ class AbstractPass:
         self,
         test_case: Path,
         state,
+        new_tmp_dir: Path,
         succeeded_state,
         job_timeout,
         process_event_notifier: ProcessEventNotifier,

--- a/cvise/passes/clanghints.py
+++ b/cvise/passes/clanghints.py
@@ -94,7 +94,14 @@ class ClangHintsPass(HintBasedPass):
         return ClangState.wrap(new_state, state.clang_std)
 
     def advance_on_success(
-        self, test_case: Path, state, job_timeout: int, process_event_notifier: ProcessEventNotifier, *args, **kwargs
+        self,
+        test_case: Path,
+        state,
+        new_tmp_dir: Path,
+        job_timeout: int,
+        process_event_notifier: ProcessEventNotifier,
+        *args,
+        **kwargs,
     ):
         # Keep using the same standard as the one chosen in new() - repeating the choose procedure on every successful
         # reduction would be too costly.
@@ -103,7 +110,7 @@ class ClangHintsPass(HintBasedPass):
         except ClangDeltaError as e:
             logging.warning('%s', e)
             return None
-        new_state = self.advance_on_success_from_hints(hints, state)
+        new_state = self.advance_on_success_from_hints(hints, state, new_tmp_dir)
         return ClangState.wrap(new_state, state.clang_std)
 
     def _generate_hints_for_standard(

--- a/cvise/tests/test_balanced.py
+++ b/cvise/tests/test_balanced.py
@@ -149,7 +149,11 @@ class BalancedParensOnlyTestCase(unittest.TestCase):
 
         while result == PassResult.OK:
             state = self.pass_.advance_on_success(
-                self.input_path, state, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+                self.input_path,
+                state,
+                new_tmp_dir=self.tmp_dir,
+                process_event_notifier=ProcessEventNotifier(None),
+                dependee_hints=[],
             )
             if state is None:
                 break

--- a/cvise/tests/test_comments.py
+++ b/cvise/tests/test_comments.py
@@ -65,7 +65,11 @@ class CommentsTestCase(unittest.TestCase):
 
         while result == PassResult.OK and state is not None:
             state = self.pass_.advance_on_success(
-                self.input_path, state, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+                self.input_path,
+                state,
+                new_tmp_dir=self.tmp_dir,
+                process_event_notifier=ProcessEventNotifier(None),
+                dependee_hints=[],
             )
             if state is None:
                 break

--- a/cvise/tests/test_fileutil.py
+++ b/cvise/tests/test_fileutil.py
@@ -19,6 +19,7 @@ from cvise.utils.fileutil import (
     hash_test_case,
     mkdir_up_to,
     replace_test_case_atomically,
+    sanitize_for_file_name,
 )
 
 
@@ -45,6 +46,16 @@ def test_mkdir_failure(tmp_path: Path):
     p = parent / 'path'
     with pytest.raises(FileNotFoundError):
         mkdir_up_to(p, parent)
+
+
+def test_sanitize():
+    assert sanitize_for_file_name('Foo123') == 'Foo123'
+    assert sanitize_for_file_name('foo bar') == 'foo_bar'
+    assert sanitize_for_file_name('foo bar') == 'foo_bar'
+    assert sanitize_for_file_name('example.txt') == 'example.txt'
+    assert sanitize_for_file_name('@something') == '_something'
+    assert sanitize_for_file_name('a-b') == 'a-b'
+    assert sanitize_for_file_name('a_b') == 'a_b'
 
 
 def test_get_file_size(tmp_path: Path):

--- a/cvise/tests/test_lines.py
+++ b/cvise/tests/test_lines.py
@@ -698,11 +698,15 @@ def test_advance_on_success(tmp_path: Path, input_path: Path):
     # Cut 'foo' first, pretending that all previous transforms (e.g., deletion of the whole text) didn't pass the
     # interestingness test.
     state = advance_until(p, state, input_path, lambda s: b'bar' in s and b'baz' in s)
-    p.advance_on_success(input_path, state, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[])
+    p.advance_on_success(
+        input_path, state, new_tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+    )
     # Cut 'baz' now, pretending that all transforms in between (e.g, deletion of "bar;") didn't pass the
     # interestingness test.
     state = advance_until(p, state, input_path, lambda s: b'bar' in s)
-    p.advance_on_success(input_path, state, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[])
+    p.advance_on_success(
+        input_path, state, new_tmp_dir=tmp_path, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+    )
 
     assert (
         input_path.read_bytes()

--- a/cvise/tests/testabstract.py
+++ b/cvise/tests/testabstract.py
@@ -23,7 +23,11 @@ def iterate_pass(current_pass: AbstractPass, path: Path, **kwargs) -> None:
         )
         if result == PassResult.OK:
             state = current_pass.advance_on_success(
-                path, state, process_event_notifier=ProcessEventNotifier(None), dependee_hints=[]
+                path,
+                state,
+                new_tmp_dir=kwargs.get('tmp_dir'),
+                process_event_notifier=ProcessEventNotifier(None),
+                dependee_hints=[],
             )
         else:
             state = current_pass.advance(path, state)

--- a/cvise/utils/fileutil.py
+++ b/cvise/utils/fileutil.py
@@ -4,6 +4,7 @@ import io
 import os
 from pathlib import Path
 import random
+import re
 import shutil
 import string
 import tempfile
@@ -57,6 +58,11 @@ def mkdir_up_to(dir_to_create: Path, last_parent_dir: Path) -> None:
         return
     mkdir_up_to(dir_to_create.parent, last_parent_dir)
     dir_to_create.mkdir(exist_ok=True)
+
+
+def sanitize_for_file_name(text: str) -> str:
+    """Replaces characters which might be invalid or error-prone (e.g., spaces) when used in file names."""
+    return re.sub(r'[^a-zA-Z0-9_.-]', '_', text)
 
 
 def get_file_size(test_case: Path) -> int:

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -1153,7 +1153,7 @@ class TestManager:
                 ]
 
         sanitized_name = fileutil.sanitize_for_file_name(str(ctx.pass_))
-        tmp_dir = tempfile.mkdtemp(prefix=f'{TestManager.TEMP_PREFIX}{sanitized_name}-')
+        tmp_dir = Path(tempfile.mkdtemp(prefix=f'{TestManager.TEMP_PREFIX}{sanitized_name}-'))
         logging.debug(f'Creating pass root folder: {tmp_dir}')
 
         # Either initialize the pass from scratch, or advance from the previous state.


### PR DESCRIPTION
Only allow regular characters (a-zA-Z0-9_.-) in file names that C-Vise creates for internal needs.

First, this fixes an annoying problem that the interestingness script could be executed in a folder with spaces in the names - and it's pretty hard for the user of C-Vise to discover if their Shell script doesn't support this. Second, it makes sure we don't use hint types - which can be arbitrary strings - to form malformed file names.

As a bonus, this commit simplifies implementing a better folding mechanism in the future, with reusing successful discoveries from a previous batch of jobs that didn't make it into the best folding attempt.