### PR TITLE
Revert "hints: Sort hints in all passes"

### DIFF
--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -527,7 +527,7 @@ def do_reduce(args):
                 is_dir = test_case.is_dir()
                 fs.write(f'--- {test_case} ---\n'.encode())
                 paths = (
-                    sorted(p for p in test_case.rglob('*') if not p.is_dir() and not p.is_symlink())
+                    [p for p in test_case.rglob('*') if not p.is_dir() and not p.is_symlink()]
                     if is_dir
                     else [test_case]
                 )

--- a/cvise/passes/clangincludegraph.py
+++ b/cvise/passes/clangincludegraph.py
@@ -55,20 +55,25 @@ class ClangIncludeGraphPass(HintBasedPass):
 
     def generate_hints(self, test_case: Path, dependee_hints: List[HintBundle], *args, **kwargs):
         # Simply merge received hints - the actual work has been done by _ClangIncludeGraphMultiplexPass instances.
-        merged_vocab = []
+        vocab: List[bytes] = list(_HINT_VOCAB)
+        path_to_vocab: Dict[Path, int] = {}
+        hints = set()
         for bundle in dependee_hints:
-            merged_vocab.extend(bundle.vocabulary)
-        vocab: List[bytes] = list(_HINT_VOCAB) + sorted(set(merged_vocab))
-        text_to_vocab: Dict[bytes, int] = {s: i for i, s in enumerate(vocab)}
-        hints = [_remap_file_ids(h, b, text_to_vocab) for b in dependee_hints for h in b.hints]
-        return HintBundle(hints=list(set(hints)), vocabulary=vocab)
+            for hint in bundle.hints:
+                new_hint = _remap_file_ids(hint, bundle, test_case, vocab, path_to_vocab)
+                hints.add(new_hint)
+        return HintBundle(hints=sorted(hints), vocabulary=vocab)
 
 
-def _remap_file_ids(hint: Hint, bundle: HintBundle, text_to_vocab: Dict[bytes, int]) -> Hint:
-    patches = tuple(
-        Patch(left=p.left, right=p.right, file=text_to_vocab[bundle.vocabulary[p.file]]) for p in hint.patches
-    )
-    return Hint(type=0, patches=patches, extra=text_to_vocab[bundle.vocabulary[hint.extra]])
+def _remap_file_ids(
+    hint: Hint, bundle: HintBundle, test_case: Path, vocab: List[bytes], path_to_vocab: Dict[Path, int]
+) -> Hint:
+    patches = []
+    for p in hint.patches:
+        file_id = _get_vocab_id(Path(bundle.vocabulary[p.file].decode()), test_case, vocab, path_to_vocab)
+        patches.append(Patch(left=p.left, right=p.right, file=file_id))
+    extra = _get_vocab_id(Path(bundle.vocabulary[hint.extra].decode()), test_case, vocab, path_to_vocab)
+    return Hint(type=0, patches=tuple(patches), extra=extra)
 
 
 class _ClangIncludeGraphMultiplexPass(HintBasedPass):

--- a/cvise/passes/clangmodulemap.py
+++ b/cvise/passes/clangmodulemap.py
@@ -42,7 +42,7 @@ class ClangModuleMapPass(HintBasedPass):
 
     def generate_hints(self, test_case: Path, *args, **kwargs):
         paths = list(test_case.rglob('*')) if test_case.is_dir() else [test_case]
-        interesting_paths = sorted(p for p in paths if _interesting_file(p))
+        interesting_paths = [p for p in paths if _interesting_file(p)]
 
         vocab: List[bytes] = [v.value[1] for v in _Vocab]  # collect all strings used in hints
         path_to_vocab: Dict[Path, int] = {}

--- a/cvise/passes/clexhints.py
+++ b/cvise/passes/clexhints.py
@@ -33,7 +33,7 @@ class ClexHintsPass(HintBasedPass):
         # limit).
         if test_case.is_dir():
             work_dir = test_case
-            paths = sorted(p.relative_to(test_case) for p in test_case.rglob('*') if not p.is_dir())
+            paths = [p.relative_to(test_case) for p in test_case.rglob('*') if not p.is_dir()]
             stdin = b'\0'.join(bytes(p) for p in paths)
             files_vocab = [str(p).encode() for p in paths]
             cmd_arg = '--'

--- a/cvise/passes/hint_based.py
+++ b/cvise/passes/hint_based.py
@@ -304,7 +304,6 @@ class HintBasedPass(AbstractPass):
         sub_states: List[PerTypeHintState] = []
         special_states: List[SpecialHintState] = []
         for type, sub_bundle in type_to_bundle.items():
-            sub_bundle.hints.sort()
             if is_special_hint_type(type):
                 # "Special" hints aren't attempted in transform() jobs - only store them to be consumed by other passes.
                 special_states.append(
@@ -331,8 +330,6 @@ class HintBasedPass(AbstractPass):
         if not bundle.hints:
             return None
         type_to_bundle = group_hints_by_type(bundle)
-        for sub_bundle in type_to_bundle.values():
-            sub_bundle.hints.sort()
         self.backfill_pass_names(type_to_bundle)
         store_hints_per_type(state.tmp_dir, type_to_bundle)
         return state.advance_on_success(type_to_bundle)

--- a/cvise/passes/lines.py
+++ b/cvise/passes/lines.py
@@ -17,9 +17,7 @@ class LinesPass(HintBasedPass):
 
     def generate_hints(self, test_case: Path, process_event_notifier: ProcessEventNotifier, *args, **kwargs):
         is_dir = test_case.is_dir()
-        paths = (
-            sorted(p for p in test_case.rglob('*') if not p.is_dir() and not p.is_symlink()) if is_dir else [test_case]
-        )
+        paths = [p for p in test_case.rglob('*') if not p.is_dir() and not p.is_symlink()] if is_dir else [test_case]
         vocab = [str(p.relative_to(test_case)).encode() for p in paths] if is_dir else []
 
         hints = []

--- a/cvise/passes/makefile.py
+++ b/cvise/passes/makefile.py
@@ -42,7 +42,7 @@ class MakefilePass(HintBasedPass):
 
     def generate_hints(self, test_case: Path, *args, **kwargs):
         paths = list(test_case.rglob('*')) if test_case.is_dir() else [test_case]
-        makefiles = sorted(p for p in paths if p.name in makefileparser.FILE_NAMES)
+        makefiles = [p for p in paths if p.name in makefileparser.FILE_NAMES]
 
         vocab: List[bytes] = [v.value[1] for v in _Vocab]  # collect all strings used in hints
         hints: List[Hint] = []

--- a/cvise/passes/treesitter.py
+++ b/cvise/passes/treesitter.py
@@ -30,7 +30,7 @@ class TreeSitterPass(HintBasedPass):
         # limit).
         if test_case.is_dir():
             work_dir = test_case
-            paths = sorted(p.relative_to(test_case) for p in test_case.rglob('*') if not p.is_dir())
+            paths = [p.relative_to(test_case) for p in test_case.rglob('*') if not p.is_dir()]
             stdin = b'\0'.join(bytes(p) for p in paths)
             files_vocab = [str(p).encode() for p in paths]  # avoid the complexity of escaping paths in C++ code
             cmd_arg = '--'

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -37,14 +37,14 @@ class Patch(msgspec.Struct, omit_defaults=True, gc=False, frozen=True, order=Tru
     value: Optional[int] = msgspec.field(default=None, name='v')
 
 
-class Hint(msgspec.Struct, omit_defaults=True, gc=False, frozen=True, order=True, kw_only=True):
+class Hint(msgspec.Struct, omit_defaults=True, gc=False, frozen=True, order=True):
     """Describes a single hint.
 
     See HINT_SCHEMA.
     """
 
-    type: Optional[int] = msgspec.field(default=None, name='t')
     patches: Tuple[Patch, ...] = msgspec.field(name='p')
+    type: Optional[int] = msgspec.field(default=None, name='t')
     extra: Optional[int] = msgspec.field(default=None, name='e')
 
 


### PR DESCRIPTION
Reverts marxin/cvise#378 due to errors observed in manual testing:

`'<' not supported between instances of 'int' and 'NoneType'`