### PR TITLE
hints: Reland "Sort hints in all passes"

### DIFF
--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -527,7 +527,7 @@ def do_reduce(args):
                 is_dir = test_case.is_dir()
                 fs.write(f'--- {test_case} ---\n'.encode())
                 paths = (
-                    [p for p in test_case.rglob('*') if not p.is_dir() and not p.is_symlink()]
+                    sorted(p for p in test_case.rglob('*') if not p.is_dir() and not p.is_symlink())
                     if is_dir
                     else [test_case]
                 )

--- a/cvise/passes/clangmodulemap.py
+++ b/cvise/passes/clangmodulemap.py
@@ -42,7 +42,7 @@ class ClangModuleMapPass(HintBasedPass):
 
     def generate_hints(self, test_case: Path, *args, **kwargs):
         paths = list(test_case.rglob('*')) if test_case.is_dir() else [test_case]
-        interesting_paths = [p for p in paths if _interesting_file(p)]
+        interesting_paths = sorted(p for p in paths if _interesting_file(p))
 
         vocab: List[bytes] = [v.value[1] for v in _Vocab]  # collect all strings used in hints
         path_to_vocab: Dict[Path, int] = {}

--- a/cvise/passes/clexhints.py
+++ b/cvise/passes/clexhints.py
@@ -33,7 +33,7 @@ class ClexHintsPass(HintBasedPass):
         # limit).
         if test_case.is_dir():
             work_dir = test_case
-            paths = [p.relative_to(test_case) for p in test_case.rglob('*') if not p.is_dir()]
+            paths = sorted(p.relative_to(test_case) for p in test_case.rglob('*') if not p.is_dir())
             stdin = b'\0'.join(bytes(p) for p in paths)
             files_vocab = [str(p).encode() for p in paths]
             cmd_arg = '--'

--- a/cvise/passes/hint_based.py
+++ b/cvise/passes/hint_based.py
@@ -14,6 +14,7 @@ from cvise.utils.hint import (
     HintBundle,
     HintApplicationStats,
     load_hints,
+    sort_hints,
     store_hints,
 )
 
@@ -308,11 +309,12 @@ class HintBasedPass(AbstractPass):
             return None
         type_to_bundle = group_hints_by_type(bundle)
         self.backfill_pass_names(type_to_bundle)
+        for sub_bundle in type_to_bundle.values():
+            sort_hints(sub_bundle)
         type_to_file_name = _store_hints_per_type(tmp_dir, type_to_bundle)
         sub_states: List[PerTypeHintState] = []
         special_states: List[SpecialHintState] = []
         for type, sub_bundle in type_to_bundle.items():
-            sub_bundle.hints.sort()
             if is_special_hint_type(type):
                 # "Special" hints aren't attempted in transform() jobs - only store them to be consumed by other passes.
                 special_states.append(
@@ -342,7 +344,7 @@ class HintBasedPass(AbstractPass):
             return None
         type_to_bundle = group_hints_by_type(bundle)
         for sub_bundle in type_to_bundle.values():
-            sub_bundle.hints.sort()
+            sort_hints(sub_bundle)
         self.backfill_pass_names(type_to_bundle)
         type_to_file_name = _store_hints_per_type(new_tmp_dir, type_to_bundle)
         return state.advance_on_success(type_to_bundle, type_to_file_name, new_tmp_dir)

--- a/cvise/passes/hint_based.py
+++ b/cvise/passes/hint_based.py
@@ -312,6 +312,7 @@ class HintBasedPass(AbstractPass):
         sub_states: List[PerTypeHintState] = []
         special_states: List[SpecialHintState] = []
         for type, sub_bundle in type_to_bundle.items():
+            sub_bundle.hints.sort()
             if is_special_hint_type(type):
                 # "Special" hints aren't attempted in transform() jobs - only store them to be consumed by other passes.
                 special_states.append(
@@ -340,6 +341,8 @@ class HintBasedPass(AbstractPass):
         if not bundle.hints:
             return None
         type_to_bundle = group_hints_by_type(bundle)
+        for sub_bundle in type_to_bundle.values():
+            sub_bundle.hints.sort()
         self.backfill_pass_names(type_to_bundle)
         type_to_file_name = _store_hints_per_type(new_tmp_dir, type_to_bundle)
         return state.advance_on_success(type_to_bundle, type_to_file_name, new_tmp_dir)

--- a/cvise/passes/lines.py
+++ b/cvise/passes/lines.py
@@ -17,7 +17,9 @@ class LinesPass(HintBasedPass):
 
     def generate_hints(self, test_case: Path, process_event_notifier: ProcessEventNotifier, *args, **kwargs):
         is_dir = test_case.is_dir()
-        paths = [p for p in test_case.rglob('*') if not p.is_dir() and not p.is_symlink()] if is_dir else [test_case]
+        paths = (
+            sorted(p for p in test_case.rglob('*') if not p.is_dir() and not p.is_symlink()) if is_dir else [test_case]
+        )
         vocab = [str(p.relative_to(test_case)).encode() for p in paths] if is_dir else []
 
         hints = []

--- a/cvise/passes/makefile.py
+++ b/cvise/passes/makefile.py
@@ -42,7 +42,7 @@ class MakefilePass(HintBasedPass):
 
     def generate_hints(self, test_case: Path, *args, **kwargs):
         paths = list(test_case.rglob('*')) if test_case.is_dir() else [test_case]
-        makefiles = [p for p in paths if p.name in makefileparser.FILE_NAMES]
+        makefiles = sorted(p for p in paths if p.name in makefileparser.FILE_NAMES)
 
         vocab: List[bytes] = [v.value[1] for v in _Vocab]  # collect all strings used in hints
         hints: List[Hint] = []

--- a/cvise/passes/treesitter.py
+++ b/cvise/passes/treesitter.py
@@ -30,7 +30,7 @@ class TreeSitterPass(HintBasedPass):
         # limit).
         if test_case.is_dir():
             work_dir = test_case
-            paths = [p.relative_to(test_case) for p in test_case.rglob('*') if not p.is_dir()]
+            paths = sorted(p.relative_to(test_case) for p in test_case.rglob('*') if not p.is_dir())
             stdin = b'\0'.join(bytes(p) for p in paths)
             files_vocab = [str(p).encode() for p in paths]  # avoid the complexity of escaping paths in C++ code
             cmd_arg = '--'

--- a/cvise/tests/test_balanced.py
+++ b/cvise/tests/test_balanced.py
@@ -53,7 +53,8 @@ class BalancedParensTestCase(unittest.TestCase):
         self.input_path.write_text('This (is a (simple) test)!\n')
 
         state = self._pass_new()
-        # Transform failed
+        # Simulate that transforms failed until we get to the inner parenthesis.
+        state = self.pass_.advance(self.input_path, state)
         state = self.pass_.advance(self.input_path, state)
         (_, state) = self.pass_.transform(
             self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
@@ -115,7 +116,8 @@ class BalancedParensOnlyTestCase(unittest.TestCase):
         self.input_path.write_text('This (is a (simple) test)!\n')
 
         state = self._pass_new()
-        # Transform failed
+        # Simulate that transforms failed until we get to the inner parenthesis.
+        state = self.pass_.advance(self.input_path, state)
         state = self.pass_.advance(self.input_path, state)
         (_, state) = self.pass_.transform(
             self.input_path, state, process_event_notifier=None, original_test_case=self.input_path
@@ -224,7 +226,8 @@ class BalancedParensInsideTestCase(unittest.TestCase):
         self.input_path.write_text('This (is a (simple) test)!\n')
 
         state = self._pass_new()
-        # Transform failed
+        # Simulate that transforms failed until we get to the inner parenthesis.
+        state = self.pass_.advance(self.input_path, state)
         state = self.pass_.advance(self.input_path, state)
         (_, state) = self.pass_.transform(
             self.input_path, state, process_event_notifier=None, original_test_case=self.input_path

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -451,7 +451,7 @@ def sort_hints(bundle: HintBundle) -> None:
         prev_key = hint.patches[0].comparison_key()
         for p in hint.patches[1:]:
             key = p.comparison_key()
-            if key > prev_key:
+            if prev_key > key:
                 need_sort = True
                 break
             prev_key = key

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -37,7 +37,7 @@ class Patch(msgspec.Struct, omit_defaults=True, gc=False, frozen=True, order=Tru
     value: Optional[int] = msgspec.field(default=None, name='v')
 
 
-class Hint(msgspec.Struct, omit_defaults=True, gc=False, frozen=True, order=True):
+class Hint(msgspec.Struct, omit_defaults=True, gc=False, frozen=True, order=True, kw_only=True):
     """Describes a single hint.
 
     See HINT_SCHEMA.

--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -57,7 +57,11 @@ class Hint(msgspec.Struct, omit_defaults=True, gc=False, frozen=True):
     extra: Optional[int] = msgspec.field(default=None, name='e')
 
     def comparison_key(self) -> Tuple:
-        return (self.type, tuple(p.comparison_key() for p in self.patches), -1 if self.extra is None else self.extra)
+        return (
+            -1 if self.type is None else self.type,
+            tuple(p.comparison_key() for p in self.patches),
+            -1 if self.extra is None else self.extra,
+        )
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Compared to the original patch (#378), we now properly support comparing Nones with non-Nones in fields. Original patch description:

Make sure hints are sorted lexicographically: by file, type, 'l'/'r' indices within the same file, etc.

This makes sure passes enumerate reduction possibilities in a stable and well-defined order.