### PR TITLE
Clang passes: Pass params directly to constructor

### DIFF
--- a/cvise/cvise.py
+++ b/cvise/cvise.py
@@ -155,7 +155,8 @@ class CVise:
 
             pass_group[category.name] = []
 
-            for pass_dict in pass_group_dict[category.name]:
+            pass_dict_list = pass_group_dict[category.name]
+            for pass_dict in pass_dict_list:
                 if not include_pass(pass_dict, pass_options):
                     continue
 
@@ -167,7 +168,12 @@ class CVise:
                 except KeyError:
                     raise CViseError('Unknown pass {}'.format(pass_dict['pass'])) from None
 
-                pass_instance = pass_class(pass_dict.get('arg'), external_programs)
+                pass_instance = pass_class(
+                    pass_dict.get('arg'),
+                    external_programs=external_programs,
+                    user_clang_delta_std=clang_delta_std,
+                    clang_delta_preserve_routine=clang_delta_preserve_routine,
+                )
                 if str(pass_instance) in removed_passes:
                     continue
 
@@ -181,8 +187,6 @@ class CVise:
                         raise CViseError('max-transforms not available for passes in interleaving categories')
                     pass_instance.max_transforms = int(pass_dict['max-transforms'])
 
-                pass_instance.user_clang_delta_std = clang_delta_std
-                pass_instance.clang_delta_preserve_routine = clang_delta_preserve_routine
                 pass_group[category.name].append(pass_instance)
 
         if not pass_group:

--- a/cvise/passes/abstract.py
+++ b/cvise/passes/abstract.py
@@ -5,7 +5,7 @@ import logging
 from pathlib import Path
 import random
 import shutil
-from typing import List, Self, Union
+from typing import List, Optional, Self, Union
 
 from cvise.utils.process import ProcessEventNotifier
 
@@ -149,7 +149,15 @@ class AbstractPass:
         slow = 'slow'
         windows = 'windows'
 
-    def __init__(self, arg=None, external_programs=None):
+    def __init__(
+        self,
+        arg=None,
+        external_programs=None,
+        claim_files: Optional[List[str]] = None,
+        claimed_by_others_files: Optional[List[str]] = None,
+        *args,
+        **kwargs,
+    ):
         self.external_programs = external_programs
         self.arg = arg
         self.max_transforms = None

--- a/cvise/passes/clang.py
+++ b/cvise/passes/clang.py
@@ -1,14 +1,14 @@
 import logging
 from pathlib import Path
+from typing import Optional
 
 from cvise.passes.abstract import AbstractPass, PassResult
 
 
 class ClangPass(AbstractPass):
-    def __init__(self, arg=None, external_programs=None):
-        super().__init__(arg, external_programs)
-        # The actual value is set by the caller in cvise.py.
-        self.user_clang_delta_std = None
+    def __init__(self, arg: str, user_clang_delta_std: Optional[str] = None, *args, **kwargs):
+        super().__init__(arg, *args, user_clang_delta_std=user_clang_delta_std, **kwargs)
+        self._user_clang_delta_std = user_clang_delta_std
 
     def check_prerequisites(self):
         return self.check_external_program('clang_delta')
@@ -28,8 +28,8 @@ class ClangPass(AbstractPass):
             f'--transformation={self.arg}',
             f'--counter={state}',
         ]
-        if self.user_clang_delta_std:
-            args.append(f'--std={self.user_clang_delta_std}')
+        if self._user_clang_delta_std:
+            args.append(f'--std={self._user_clang_delta_std}')
         cmd = args + [str(test_case)]
 
         logging.debug(' '.join(cmd))

--- a/cvise/passes/clangbinarysearch.py
+++ b/cvise/passes/clangbinarysearch.py
@@ -3,16 +3,29 @@ from pathlib import Path
 import re
 import subprocess
 import time
+from typing import Optional
 
 from cvise.passes.abstract import AbstractPass, BinaryState, PassResult
 
 
 class ClangBinarySearchPass(AbstractPass):
-    def __init__(self, arg=None, external_programs=None):
-        super().__init__(arg, external_programs)
-        # The actual values are set by the caller in cvise.py.
-        self.user_clang_delta_std = None
-        self.clang_delta_preserve_routine = None
+    def __init__(
+        self,
+        arg: str,
+        user_clang_delta_std: Optional[str] = None,
+        clang_delta_preserve_routine: Optional[str] = None,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(
+            arg,
+            *args,
+            user_clang_delta_std=user_clang_delta_std,
+            clang_delta_preserve_routine=clang_delta_preserve_routine,
+            **kwargs,
+        )
+        self._user_clang_delta_std = user_clang_delta_std
+        self._clang_delta_preserve_routine = clang_delta_preserve_routine
 
     def check_prerequisites(self):
         return self.check_external_program('clang_delta')
@@ -35,10 +48,10 @@ class ClangBinarySearchPass(AbstractPass):
         return best
 
     def new(self, test_case: Path, job_timeout, *args, **kwargs):
-        if not self.user_clang_delta_std:
+        if not self._user_clang_delta_std:
             std = self.detect_best_standard(test_case, job_timeout)
         else:
-            std = self.user_clang_delta_std
+            std = self._user_clang_delta_std
         state = BinaryState.create(self.count_instances(test_case, std, job_timeout))
         return attach_clang_delta_std(state, std)
 
@@ -59,8 +72,8 @@ class ClangBinarySearchPass(AbstractPass):
             f'--query-instances={self.arg}',
             f'--std={std}',
         ]
-        if self.clang_delta_preserve_routine:
-            args.append(f'--preserve-routine="{self.clang_delta_preserve_routine}"')
+        if self._clang_delta_preserve_routine:
+            args.append(f'--preserve-routine="{self._clang_delta_preserve_routine}"')
         cmd = args + [str(test_case)]
 
         try:
@@ -104,8 +117,8 @@ class ClangBinarySearchPass(AbstractPass):
             '--report-instances-count',
         ]
         args.append(f'--std={state.clang_delta_std}')
-        if self.clang_delta_preserve_routine:
-            args.append(f'--preserve-routine="{self.clang_delta_preserve_routine}"')
+        if self._clang_delta_preserve_routine:
+            args.append(f'--preserve-routine="{self._clang_delta_preserve_routine}"')
         cmd = [self.external_programs['clang_delta']] + args + [str(test_case)]
         logging.debug(' '.join(cmd))
 

--- a/cvise/passes/clanghints.py
+++ b/cvise/passes/clanghints.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import shlex
 import subprocess
 import time
-from typing import List, Union
+from typing import List, Optional, Union
 
 from cvise.passes.hint_based import HintBasedPass, HintState
 from cvise.utils.hint import Hint, HintBundle
@@ -42,10 +42,9 @@ class ClangHintsPass(HintBasedPass):
     advance() calls.
     """
 
-    def __init__(self, arg=None, external_programs=None):
-        super().__init__(arg, external_programs)
-        # The actual value is set by the caller in cvise.py.
-        self.user_clang_delta_std: Union[str, None] = None
+    def __init__(self, arg: str, user_clang_delta_std: Optional[str] = None, *args, **kwargs):
+        super().__init__(arg, *args, user_clang_delta_std=user_clang_delta_std, **kwargs)
+        self._user_clang_delta_std = user_clang_delta_std
 
     def check_prerequisites(self):
         return self.check_external_program('clang_delta')
@@ -54,7 +53,7 @@ class ClangHintsPass(HintBasedPass):
         self, test_case: Path, tmp_dir: Path, job_timeout, process_event_notifier: ProcessEventNotifier, *args, **kwargs
     ):
         # Choose the best standard unless the user provided one.
-        std_choices = [self.user_clang_delta_std] if self.user_clang_delta_std else CLANG_STD_CHOICES
+        std_choices = [self._user_clang_delta_std] if self._user_clang_delta_std else CLANG_STD_CHOICES
         best_std = None
         best_bundle: Union[HintBundle, None] = None
         last_error: Union[ClangDeltaError, None] = None

--- a/cvise/tests/test_clanghints.py
+++ b/cvise/tests/test_clanghints.py
@@ -18,7 +18,7 @@ def get_data_path(testcase: str) -> Path:
 
 
 def init_pass(transformation: str, tmp_dir: Path, input_path: Path) -> Tuple[ClangHintsPass, Any]:
-    pass_ = ClangHintsPass(transformation, find_external_programs())
+    pass_ = ClangHintsPass(transformation, external_programs=find_external_programs())
     pass_.user_clang_delta_std = None
     state = pass_.new(
         input_path,


### PR DESCRIPTION
This is a small refactoring to explicitly pass
ClangPass/ClangHintsPass/ClangBinarySearchPass parameters directly as constructor arguments, instead of the caller setting them as fields afterwards.

This makes the contract more explicit, and also prepares us for introducing more pass-specific construction parameters in follow-up commits.