### PR TITLE
tests: Enforce the multiprocessing forkserver method

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,4 +10,5 @@ def mp_start_method():
 
     The "forkserver" mode is the same as the one used by the C-Vise CLI.
     """
-    multiprocessing.set_start_method('forkserver')
+    # Enforce the method selection, in case the test framework previously set a different one.
+    multiprocessing.set_start_method('forkserver', force=True)


### PR DESCRIPTION
In downstream projects it's possible that the test framework preconfigures a different multiprocessing start method - so use "force=True" to avoid the "RuntimeError: context has already been set" error.