### PR TITLE
makefile: Fix arg incorrectly removed after "-osomething"

### DIFF
--- a/cvise/passes/makefile.py
+++ b/cvise/passes/makefile.py
@@ -172,14 +172,14 @@ def _get_removable_arg_groups(args: List[TextWithLoc]) -> List[List[TextWithLoc]
     removable = []
     for arg in args:
         if two_token_option:
-            if not _TWO_TOKEN_OPTIONS_REMOVAL_BLOCKLIST.match(two_token_option.value + b' ' + arg.value):
+            if not _TWO_TOKEN_OPTIONS_REMOVAL_BLOCKLIST.fullmatch(two_token_option.value + b' ' + arg.value):
                 removable.append([two_token_option, arg])
             two_token_option = None
             continue
-        if _TWO_TOKEN_OPTIONS.match(arg.value):
+        if _TWO_TOKEN_OPTIONS.fullmatch(arg.value):
             two_token_option = arg
             continue
-        if _REMOVAL_BLOCKLIST.match(arg.value):
+        if _REMOVAL_BLOCKLIST.fullmatch(arg.value):
             continue
         removable.append([arg])
     return removable

--- a/cvise/tests/test_makefile.py
+++ b/cvise/tests/test_makefile.py
@@ -121,19 +121,79 @@ def test_dont_remove_blocklisted_argument(tmp_path: Path, test_case_path: Path):
     (test_case_path / 'Makefile').write_text(
         """
 a.o:
-\tgcc -Wall foo.c
+\tgcc -Wall a.c
+b.o:
+\tgcc -ob.o -Wall b.c
+c.o:
+\tgcc -o c.o -Wall c.c
         """,
     )
     p, state = init_pass(tmp_path, test_case_path)
     all_transforms = collect_all_transforms_dir(p, state, test_case_path)
 
-    # "-Wall" not removed
+    # "-Wall" not removed from any of the commands
     assert (
         (
             'Makefile',
             b"""
 a.o:
-\tgcc foo.c
+\tgcc a.c
+b.o:
+\tgcc -ob.o -Wall b.c
+c.o:
+\tgcc -o c.o -Wall c.c
+        """,
+        ),
+    ) not in all_transforms
+    assert (
+        (
+            'Makefile',
+            b"""
+a.o:
+\tgcc -Wall a.c
+b.o:
+\tgcc -ob.o b.c
+c.o:
+\tgcc -o c.o -Wall c.c
+        """,
+        ),
+    ) not in all_transforms
+    assert (
+        (
+            'Makefile',
+            b"""
+a.o:
+\tgcc -Wall a.c
+b.o:
+\tgcc b.c
+c.o:
+\tgcc -o c.o -Wall c.c
+        """,
+        ),
+    ) not in all_transforms
+    assert (
+        (
+            'Makefile',
+            b"""
+a.o:
+\tgcc -Wall a.c
+b.o:
+\tgcc -ob.o -Wall b.c
+c.o:
+\tgcc -o c.o c.c
+        """,
+        ),
+    ) not in all_transforms
+    assert (
+        (
+            'Makefile',
+            b"""
+a.o:
+\tgcc -Wall a.c
+b.o:
+\tgcc -ob.o -Wall b.c
+c.o:
+\tgcc c.c
         """,
         ),
     ) not in all_transforms


### PR DESCRIPTION
Fix the arg removal blocklist being ignored when the argument follows a single-token option with a parameter, like "-ofoo.o -Wall".