### PR TITLE
ci: Use ubuntu:25.04 instead of rolling for Nightly job

### DIFF
--- a/.github/workflows/build-llvm-nightly.yml
+++ b/.github/workflows/build-llvm-nightly.yml
@@ -19,7 +19,7 @@ jobs:
   CI-LLVM-nightly:
     runs-on: ubuntu-22.04
     container:
-      image: ubuntu:latest
+      image: ubuntu:25.04
 
     steps:
       - run: apt-get update


### PR DESCRIPTION
The llvm.sh script doesn't support the freshest Ubuntu yet, causing failures in the "Build LLVM nightly" job:

```
  Distribution 'ubuntu' in version '25.10 (Questing Quokka)' is not
  supported by this script.
```