### PR TITLE
ci: Add Python version compatibility tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
       with:
         python-version: "${{ matrix.python }}"
         cache: 'pip'
-    - run: pip install --user chardet jsonschema msgspec pebble psutil pytest pytest-mock pytest-subprocess pytest-xdist pytype zstandard
+    - run: pip install chardet jsonschema msgspec pebble psutil pytest pytest-mock pytest-subprocess pytest-xdist pytype zstandard
     - run: wget https://apt.llvm.org/llvm.sh
     - run: chmod +x llvm.sh
     - run: ./llvm.sh all


### PR DESCRIPTION
These ensure C-Vise works correctly on a range of Python releases - currently 3.9 - 3.13.