### PR TITLE
ci: Fix typo in LLVM RelWithDebInfo jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
             build-type: ASAN
           - llvm: 21
             build-type: UBSAN
-          - llmv: 21
+          - llvm: 21
             build-type: RelWithDebInfo
             extra-flags: -flto=auto
-          - llmv: 21
+          - llvm: 21
             build-type: RelWithDebInfo
             env: CC=clang CXX=clang++
       fail-fast: false


### PR DESCRIPTION
The "llvm" constant was misspelled on two CI matrix jobs, which resulted in them using the system-default LLVM version instead of the one specified in the CI config.