### PR TITLE
hints: Fix test_hint flakiness due to file ordering

### DIFF
--- a/cvise/tests/test_hint.py
+++ b/cvise/tests/test_hint.py
@@ -295,7 +295,7 @@ def test_apply_hints_dir(tmp_path: Path):
     output_dir = tmp_path / 'output'
     apply_hints([bundle], input_dir, output_dir)
 
-    assert list(output_dir.glob('*')) == [output_dir / 'foo.h', output_dir / 'bar.cc']
+    assert set(output_dir.glob('*')) == {output_dir / 'foo.h', output_dir / 'bar.cc'}
     assert (output_dir / 'foo.h').read_text() == 'signed f;'
     assert (output_dir / 'bar.cc').read_text() == 'void b();'
 


### PR DESCRIPTION
The assertion in test_apply_hints_dir could fail depending on the order of file enumeration.