### PR TITLE
Python 3.9+ compatibility fixes

### DIFF
--- a/clang_delta/tests/test_clang_delta.py
+++ b/clang_delta/tests/test_clang_delta.py
@@ -64,11 +64,10 @@ class TestClangDelta(unittest.TestCase):
     @classmethod
     def check_clang_delta_hints(cls, testcase, arguments, begin_index, end_index, output_file=None):
         hints = run_clang_delta(testcase, arguments + ' --generate-hints')
-        with tempfile.NamedTemporaryFile(delete_on_close=False, mode='wt', suffix='.jsonl') as hints_file:
-            hints_file.write('{"format": "cvise_hints_v0"}\n')
-            hints_file.write(hints)
-            hints_file.close()
-            output = run_apply_hints(Path(hints_file.name), begin_index, end_index, testcase)
+        with tempfile.TemporaryDirectory() as dir:
+            hints_path = Path(dir) / 'hints.jsonl'
+            hints_path.write_text('{"format": "cvise_hints_v0"}\n' + hints)
+            output = run_apply_hints(hints_path, begin_index, end_index, testcase)
 
         expected = get_expected_output_path(testcase, output_file).read_text()
         assert output == expected

--- a/cvise/passes/abstract.py
+++ b/cvise/passes/abstract.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import copy
 from dataclasses import dataclass
 from enum import auto, Enum, unique
@@ -5,7 +6,7 @@ import logging
 from pathlib import Path
 import random
 import shutil
-from typing import Dict, List, Optional, Self, Union
+from typing import Dict, List, Optional, Union
 
 from cvise.utils.process import ProcessEventNotifier
 
@@ -53,7 +54,7 @@ class SubsegmentState:
     def real_chunk(self) -> int:
         return self.chunk
 
-    def advance(self) -> Union[Self, None]:
+    def advance(self) -> Union[SubsegmentState, None]:
         to_start = self.index + 1 == self.start
         to_wrapover = self.index + 1 + self.chunk > self.instances
         if to_start or (to_wrapover and self.start == 0):
@@ -66,7 +67,7 @@ class SubsegmentState:
             start=self.start,
         )
 
-    def advance_on_success(self, instances) -> Union[Self, None]:
+    def advance_on_success(self, instances) -> Union[SubsegmentState, None]:
         if self.chunk > instances:
             return None
         if wrapover := self.index + self.chunk > instances:
@@ -201,7 +202,7 @@ class AbstractPass:
         """
         return False
 
-    def create_subordinate_passes(self) -> List[Self]:
+    def create_subordinate_passes(self) -> List[AbstractPass]:
         """Additional passes that perform the work needed for this pass.
 
         By default empty; useful for implementing parallelization of pass initialization.

--- a/cvise/tests/test_balanced.py
+++ b/cvise/tests/test_balanced.py
@@ -12,9 +12,14 @@ from cvise.utils.process import ProcessEventNotifier
 
 class BalancedParensTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        # TODO: use enterContext() once Python 3.11 is the oldest supported release
+        self.tmp_dir_obj = tempfile.TemporaryDirectory()
+        self.tmp_dir: Path = Path(self.tmp_dir_obj.name)
         self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = BalancedPass('parens')
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
 
     def _pass_new(self) -> Union[HintState, None]:
         return self.pass_.new(
@@ -76,9 +81,14 @@ class BalancedParensTestCase(unittest.TestCase):
 
 class BalancedParensOnlyTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        # TODO: use enterContext() once Python 3.11 is the oldest supported release
+        self.tmp_dir_obj = tempfile.TemporaryDirectory()
+        self.tmp_dir: Path = Path(self.tmp_dir_obj.name)
         self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = BalancedPass('parens-only')
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
 
     def _pass_new(self) -> Union[HintState, None]:
         return self.pass_.new(
@@ -185,9 +195,14 @@ class BalancedParensOnlyTestCase(unittest.TestCase):
 
 class BalancedParensInsideTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        # TODO: use enterContext() once Python 3.11 is the oldest supported release
+        self.tmp_dir_obj = tempfile.TemporaryDirectory()
+        self.tmp_dir: Path = Path(self.tmp_dir_obj.name)
         self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = BalancedPass('parens-inside')
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
 
     def _pass_new(self) -> Union[HintState, None]:
         return self.pass_.new(
@@ -274,9 +289,14 @@ class BalancedParensInsideTestCase(unittest.TestCase):
 
 class BalancedParensToZeroTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        # TODO: use enterContext() once Python 3.11 is the oldest supported release
+        self.tmp_dir_obj = tempfile.TemporaryDirectory()
+        self.tmp_dir: Path = Path(self.tmp_dir_obj.name)
         self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = BalancedPass('parens-to-zero')
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
 
     def _pass_new(self) -> Union[HintState, None]:
         return self.pass_.new(
@@ -303,9 +323,14 @@ class BalancedParensToZeroTestCase(unittest.TestCase):
 
 class BalancedCurly3TestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        # TODO: use enterContext() once Python 3.11 is the oldest supported release
+        self.tmp_dir_obj = tempfile.TemporaryDirectory()
+        self.tmp_dir: Path = Path(self.tmp_dir_obj.name)
         self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = BalancedPass('curly3')
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
 
     def _pass_new(self) -> Union[HintState, None]:
         return self.pass_.new(

--- a/cvise/tests/test_comments.py
+++ b/cvise/tests/test_comments.py
@@ -12,9 +12,14 @@ from cvise.utils.process import ProcessEventNotifier
 
 class CommentsTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        # TODO: use enterContext() once Python 3.11 is the oldest supported release
+        self.tmp_dir_obj = tempfile.TemporaryDirectory()
+        self.tmp_dir: Path = Path(self.tmp_dir_obj.name)
         self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = CommentsPass()
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
 
     def _pass_new(self) -> Union[HintState, None]:
         return self.pass_.new(

--- a/cvise/tests/test_fileutil.py
+++ b/cvise/tests/test_fileutil.py
@@ -431,7 +431,7 @@ def test_filter_files(tmp_path: Path):
         p / 'foo.cc',
         p / 'foo.h',
     ]
-    assert filter_files_by_patterns(p, include_globs=['**'], default_exclude_globs=[]) == [
+    assert filter_files_by_patterns(p, include_globs=['**/*'], default_exclude_globs=[]) == [
         p / 'Makefile',
         p / 'bar.c',
         p / 'dir' / 'a.c',

--- a/cvise/tests/test_ifs.py
+++ b/cvise/tests/test_ifs.py
@@ -9,10 +9,15 @@ from cvise.passes.ifs import IfPass
 
 class LineMarkersTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        # TODO: use enterContext() once Python 3.11 is the oldest supported release
+        self.tmp_dir_obj = tempfile.TemporaryDirectory()
+        self.tmp_dir: Path = Path(self.tmp_dir_obj.name)
         self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = IfPass(external_programs={'unifdef': 'unifdef'})
         self.process_event_notifier = ProcessEventNotifier(None)
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
 
     def test_all(self):
         self.input_path.write_text('#if FOO\nint a = 2;\n#endif')

--- a/cvise/tests/test_peep.py
+++ b/cvise/tests/test_peep.py
@@ -8,9 +8,14 @@ from cvise.tests.testabstract import iterate_pass
 
 class PeepATestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        # TODO: use enterContext() once Python 3.11 is the oldest supported release
+        self.tmp_dir_obj = tempfile.TemporaryDirectory()
+        self.tmp_dir: Path = Path(self.tmp_dir_obj.name)
         self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = PeepPass('a')
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
 
     def test_a_1(self):
         self.input_path.write_text("<That's a small test> whether the transformation works!\n")
@@ -66,9 +71,14 @@ class PeepATestCase(unittest.TestCase):
 
 class PeepBTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        # TODO: use enterContext() once Python 3.11 is the oldest supported release
+        self.tmp_dir_obj = tempfile.TemporaryDirectory()
+        self.tmp_dir: Path = Path(self.tmp_dir_obj.name)
         self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = PeepPass('b')
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
 
     def test_b_1(self):
         self.input_path.write_text('struct test_t {} test;\n')
@@ -103,9 +113,14 @@ class PeepBTestCase(unittest.TestCase):
 
 class PeepCTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        # TODO: use enterContext() once Python 3.11 is the oldest supported release
+        self.tmp_dir_obj = tempfile.TemporaryDirectory()
+        self.tmp_dir: Path = Path(self.tmp_dir_obj.name)
         self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = PeepPass('c')
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
 
     def test_c_1(self):
         self.input_path.write_text(

--- a/cvise/tests/test_special.py
+++ b/cvise/tests/test_special.py
@@ -8,9 +8,14 @@ from cvise.tests.testabstract import iterate_pass
 
 class SpecialATestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        # TODO: use enterContext() once Python 3.11 is the oldest supported release
+        self.tmp_dir_obj = tempfile.TemporaryDirectory()
+        self.tmp_dir: Path = Path(self.tmp_dir_obj.name)
         self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = SpecialPass('a')
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
 
     def test_a(self):
         self.input_path.write_text(
@@ -44,9 +49,14 @@ class SpecialATestCase(unittest.TestCase):
 
 class SpecialBTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        # TODO: use enterContext() once Python 3.11 is the oldest supported release
+        self.tmp_dir_obj = tempfile.TemporaryDirectory()
+        self.tmp_dir: Path = Path(self.tmp_dir_obj.name)
         self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = SpecialPass('b')
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
 
     def test_b(self):
         self.input_path.write_text("void foo(){} extern 'C' {int a;}; a = 9;\n")
@@ -60,9 +70,14 @@ class SpecialBTestCase(unittest.TestCase):
 
 class SpecialCTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        # TODO: use enterContext() once Python 3.11 is the oldest supported release
+        self.tmp_dir_obj = tempfile.TemporaryDirectory()
+        self.tmp_dir: Path = Path(self.tmp_dir_obj.name)
         self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = SpecialPass('c')
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
 
     def test_c(self):
         self.input_path.write_text("void foo(){} extern 'C++' {int a;}; a = 9;\n")

--- a/cvise/tests/test_ternary.py
+++ b/cvise/tests/test_ternary.py
@@ -8,9 +8,14 @@ from cvise.passes.ternary import TernaryPass
 
 class TernaryBTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        # TODO: use enterContext() once Python 3.11 is the oldest supported release
+        self.tmp_dir_obj = tempfile.TemporaryDirectory()
+        self.tmp_dir: Path = Path(self.tmp_dir_obj.name)
         self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = TernaryPass('b')
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
 
     def test_b(self):
         self.input_path.write_text('int res = a ? b : c;\n')
@@ -79,9 +84,14 @@ class TernaryBTestCase(unittest.TestCase):
 
 class TernaryCTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir: Path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        # TODO: use enterContext() once Python 3.11 is the oldest supported release
+        self.tmp_dir_obj = tempfile.TemporaryDirectory()
+        self.tmp_dir: Path = Path(self.tmp_dir_obj.name)
         self.input_path: Path = self.tmp_dir / 'test_case'
         self.pass_ = TernaryPass('c')
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
 
     def test_c(self):
         self.input_path.write_text('int res = a ? b : c;\n')

--- a/cvise/utils/fileutil.py
+++ b/cvise/utils/fileutil.py
@@ -154,7 +154,7 @@ def filter_files_by_patterns(test_case: Path, include_globs: List[str], default_
     if include_globs:
         paths = _find_files_matching(test_case, include_globs)
     else:
-        all = _find_files_matching(test_case, ['**'])
+        all = _find_files_matching(test_case, ['**/*'])
         exclude = _find_files_matching(test_case, default_exclude_globs)
         paths = all - exclude
     return sorted(paths)
@@ -279,8 +279,12 @@ def _find_files_matching(test_case: Path, globs: List[str]) -> Set[Path]:
         return set()
 
     if not test_case.is_dir():
-        matches = any(fnmatch.fnmatch(str(test_case), pat) for pat in globs)
-        return {test_case} if matches else set()
+        for pattern in globs:
+            if pattern.startswith('**/'):
+                pattern = pattern[3:]  # use removeprefix() once Python 3.9 is the lowest supported version
+            if fnmatch.fnmatch(str(test_case), pattern):
+                return {test_case}
+        return set()
 
     paths = set()
     for pattern in globs:


### PR DESCRIPTION
This fixes failures of C-Vise and its tests on Python 3.9 - 3.12.

We don't aim 3.8 anymore since it's been end-of-life since more than a year.