### PR TITLE
docs,pyproject: Document Python 3.9+ as requirement

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,7 +82,7 @@ manager:
 
   Tested LLVM versions: ``9.0.0`` - ``15.0.0``
 
-* [Python 3.8+](https://www.python.org/downloads/)
+* [Python 3.9+](https://www.python.org/downloads/)
 
 * [Pebble](https://pypi.org/project/Pebble/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ maintainers = [{ name = "Martin Liška", email = "marxin.liska@gmail.com" }]
 description = "C-Vise is a super-parallel Python port of the C-Reduce."
 readme = "README.md"
 license = { file = "COPYING" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [tool.ruff]
 exclude = ["objdir", "tree-sitter", "tree-sitter-cpp"]


### PR DESCRIPTION
Stop declaring 3.8 as a minimum supported version. Python 3.8 has already been end-of-life since more than a year, and maintaining shims/workarounds for it in C-Vise is becoming increasingly cumbersome.