### PR TITLE
pyright: Add CI job

### DIFF
--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -126,7 +126,7 @@ class TestEnvironment:
         test_script,
         folder: Path,
         test_case: Path,
-        all_test_cases: set[str],
+        all_test_cases: set[Path],
         should_copy_test_cases: bool,
         transform,
         pid_queue: queue.Queue | None = None,


### PR DESCRIPTION
Automatically run pyright static type checker as a CI job.

This might be a more future-proof solution, unlike pytype which is already deprecated and never supported Python 3.13+.