### PR TITLE
hints: Preserve empty dirs in the test case

### DIFF
--- a/cvise/tests/test_fileutil.py
+++ b/cvise/tests/test_fileutil.py
@@ -19,7 +19,6 @@ from cvise.utils.fileutil import (
     get_file_size,
     get_line_count,
     hash_test_case,
-    mkdir_up_to,
     replace_test_case_atomically,
     sanitize_for_file_name,
 )
@@ -35,19 +34,6 @@ def input_in_source_dir():
     current = Path(__file__).parent.resolve()
     with tempfile.TemporaryDirectory(dir=current) as tmp_dir:
         yield Path(tmp_dir)
-
-
-def test_mkdir(tmp_path: Path):
-    p = tmp_path / 'some' / 'path'
-    mkdir_up_to(p, tmp_path)
-    assert p.is_dir()
-
-
-def test_mkdir_failure(tmp_path: Path):
-    parent = tmp_path / 'some'
-    p = parent / 'path'
-    with pytest.raises(FileNotFoundError):
-        mkdir_up_to(p, parent)
 
 
 def test_sanitize():

--- a/cvise/tests/test_hint.py
+++ b/cvise/tests/test_hint.py
@@ -300,6 +300,22 @@ def test_apply_hints_dir(tmp_path: Path):
     assert (output_dir / 'bar.cc').read_text() == 'void b();'
 
 
+def test_apply_hints_empty_dir(tmp_path: Path, tmp_test_case: Path):
+    """Test that an empty directory is preserved (in case of multi-file inputs)."""
+    input_dir = tmp_path / 'input'
+    input_dir.mkdir()
+    (input_dir / 'foo').mkdir()
+    (input_dir / 'foo' / 'bar').mkdir()
+    bundle = HintBundle(hints=[])
+    validate_hint_bundle(bundle, tmp_test_case)
+
+    output_dir = tmp_path / 'output'
+    apply_hints([bundle], input_dir, output_dir)
+
+    assert set(output_dir.rglob('*')) == {output_dir / 'foo', output_dir / 'foo' / 'bar'}
+    assert (output_dir / 'foo' / 'bar').is_dir()
+
+
 def test_apply_hints_dir_nonexisting_parent(tmp_path: Path, tmp_test_case: Path):
     """Test that an exception occurs when the destination path is in a non-existing directory.
 

--- a/cvise/utils/fileutil.py
+++ b/cvise/utils/fileutil.py
@@ -51,18 +51,6 @@ def rmfolder(name):
         pass
 
 
-def mkdir_up_to(dir_to_create: Path, last_parent_dir: Path) -> None:
-    """Similar to Path.mkdir(parents=True), but stops at the given ancestor directory which must exist.
-
-    We use it to avoid canceled-but-not-killed-yet C-Vise jobs recreating temporary work directories that the C-Vise
-    main process has deleted.
-    """
-    if dir_to_create == last_parent_dir or not dir_to_create.is_relative_to(last_parent_dir):
-        return
-    mkdir_up_to(dir_to_create.parent, last_parent_dir)
-    dir_to_create.mkdir(exist_ok=True)
-
-
 def sanitize_for_file_name(text: str) -> str:
     """Replaces characters which might be invalid or error-prone (e.g., spaces) when used in file names."""
     return re.sub(r'[^a-zA-Z0-9_.-]', '_', text)
@@ -94,7 +82,6 @@ def get_dir_count(test_case: Path) -> int:
 
 def copy_test_case(source: Path, destination_parent: Path) -> None:
     assert not source.is_absolute()
-    mkdir_up_to(destination_parent / source.parent, destination_parent)
     if source.is_dir():
         shutil.copytree(source, destination_parent / source)
     else:


### PR DESCRIPTION
This replicates empty directories from the input test case when creating a working copy of a multi-file input (transformed according to hints from pass(es)).

Before this commit, directories were only created when there's at least one file in them, which prevented some reduction possibilities. While we do want to be able to clean up empty directories, we should do this properly, as separate reduction attempts and only for directories that aren't referenced by any command line - this will be added in a follow-up.