### PR TITLE
clanghints: Validate all hints in tests

### DIFF
--- a/clang_delta/tests/test_clang_delta.py
+++ b/clang_delta/tests/test_clang_delta.py
@@ -15,6 +15,7 @@ if importlib.util.find_spec('cvise') is None:
 
 from cvise.passes.clanghints import parse_clang_delta_hints  # noqa: E402
 from cvise.utils.hint import apply_hints  # noqa: E402
+from cvise.tests.testabstract import validate_hint_bundle  # noqa: E402
 
 
 def get_clang_version():
@@ -64,6 +65,7 @@ class TestClangDelta(unittest.TestCase):
         cmd = [get_clang_delta_path(), str(testcase_path)] + arguments.split() + ['--generate-hints']
         hints = subprocess.check_output(cmd)
         bundle = parse_clang_delta_hints(hints)
+        validate_hint_bundle(bundle, testcase_path)
         if begin_index is not None and end_index is not None:
             bundle.hints = bundle.hints[begin_index:end_index]
         with tempfile.TemporaryDirectory() as dir:

--- a/cvise/tests/testabstract.py
+++ b/cvise/tests/testabstract.py
@@ -134,9 +134,8 @@ def _validate_hint(hint: Hint, bundle: HintBundle, test_case: Path, allowed_hint
             assert patch.operation < len(bundle.vocabulary)
             assert bundle.vocabulary[patch.operation] in _KNOWN_OPERATIONS
         else:
-            # only special operations can use zero-size patches
             assert patch.left is not None
             assert patch.right is not None
-            assert patch.left < patch.right
+            assert patch.left <= patch.right
         if patch.value is not None:
             assert patch.value < len(bundle.vocabulary)


### PR DESCRIPTION
Run schema and format assertions on hints generated by clang_delta. Also fix the assertions to reflect recent schema changes: left can be equal to right.