### PR TITLE
test_manager: Fix wait when missing timeout workaround is due 

### DIFF
--- a/tests/test_cvise.py
+++ b/tests/test_cvise.py
@@ -84,7 +84,7 @@ def test_simple_reduction_no_interleaving_config(tmp_path: Path, overridden_subp
 
 @pytest.mark.skipif(os.name != 'posix', reason='requires POSIX for command-line tools')
 @pytest.mark.parametrize('signum', [signal.SIGINT, signal.SIGTERM], ids=['sigint', 'sigterm'])
-@pytest.mark.parametrize('additional_delay', [1, 10])
+@pytest.mark.parametrize('additional_delay', [0, 1, 10])
 def test_kill(tmp_path: Path, overridden_subprocess_tmpdir: Path, signum: int, additional_delay: int):
     """Test that Control-C is handled quickly, without waiting for jobs to finish."""
     MAX_SHUTDOWN = 60  # in seconds; tolerance to prevent flakiness (normally it's a fraction of a second)


### PR DESCRIPTION
Fix hanging the C-Vise process when a Pebble job never reports its
timeout: the logic to force-stop the job didn't actually take place
if no other job was executed, since we never returned from a wait()
call.

Now we'll exit from wait() when it comes to the time when a job is
considered as a hung.