### PR TITLE
logs: Fix orphan comma for single-pass stat messages

### DIFF
--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -1107,7 +1107,7 @@ class TestManager:
                 pass_name = self.success_candidate.pass_.user_visible_name()
             log_note = f'via {pass_name}'
         else:
-            log_note = ''
+            log_note = None
 
         self.success_candidate.release()
         self.success_candidate = None


### PR DESCRIPTION
We should print:

  "33.3%, 8 bytes, 2 lines"

instead of:

  "33.3%, 8 bytes, 2 lines, "