### PR TITLE
IndentPass: Get rid of no-op jobs

### DIFF
--- a/cvise/passes/indent.py
+++ b/cvise/passes/indent.py
@@ -16,14 +16,13 @@ class IndentPass(AbstractPass):
         return 0
 
     def advance(self, test_case: Path, state):
-        return state + 1
+        return None
 
     def advance_on_success(self, test_case: Path, state, *args, **kwargs):
-        return state + 1
+        return None
 
     def transform(self, test_case: Path, state, process_event_notifier, *args, **kwargs):
-        if state != 0:
-            return (PassResult.STOP, state)
+        assert state == 0
 
         old = test_case.read_text()
         cmd = [self.external_programs['clang-format'], '-i']


### PR DESCRIPTION
The pass used to spawn jobs for each state=0,1,2,... despite that only state=0 was really doing any work.

While the performance impact was negligible, the job counts in the resulting stats looked weird (numbers like "192" despite the pass being executed 3 times according to the logs), so this commit prevents these excessive jobs.