### PR TITLE
hints: Refactor out patch sorting key function

### DIFF
--- a/cvise/utils/hint.py
+++ b/cvise/utils/hint.py
@@ -586,7 +586,7 @@ def _merge_overlapping_patches(patches: Sequence[_PatchWithBundleRef]) -> Sequen
     return merged
 
 
-def _patch_merge_sorting_key(ref: _PatchWithBundleRef):
+def _patch_merge_sorting_key(ref: _PatchWithBundleRef) -> tuple:
     """Sorting key used for merging overlapping patches."""
     p = ref.patch
     is_replacement = p.value is not None


### PR DESCRIPTION
Move the helper function out of another function, to potentially improve performance a little for test cases with many files.

Function-wise, this should be a no-op commit.