### PR TITLE
clang_delta: Downgrade instance count logs to debug-only

### DIFF
--- a/cvise/passes/clanghints.py
+++ b/cvise/passes/clanghints.py
@@ -99,11 +99,11 @@ class ClangHintsPass(HintBasedPass):
             )
 
         if best_bundle is None:
-            logging.warning('%s', last_error)
+            logging.debug('%s', last_error)
             return None
 
         if best_std:
-            logging.info(
+            logging.debug(
                 'clang_delta %s using C++ standard: %s with %d transformation opportunities',
                 self.arg,
                 best_std,


### PR DESCRIPTION
The logs "clang_delta %s using C++ standard: %s with %d transformation opportunities" have become quite noisy, given the number of clang-based passes that are executed in the interleaving mode currently, and additionally given that they're restarted by C-Vise occasionally.

Downgrade these logs to be only visible under "--debug".