### PR TITLE
docs,pyproject: Document Python 3.10+ is requirement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,9 +71,6 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-        include:
-          - python: "3.9"
-            extra-deps: ["eval_type_backport"]
       fail-fast: false
 
     steps:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,7 +82,7 @@ manager:
 
   Tested LLVM versions: ``18.0.0`` - ``22.0.0``
 
-* [Python 3.9+](https://www.python.org/downloads/)
+* [Python 3.10+](https://www.python.org/downloads/)
 
 * [Pebble](https://pypi.org/project/Pebble/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ maintainers = [{ name = "Martin Liška", email = "marxin.liska@gmail.com" }]
 description = "C-Vise is a super-parallel Python port of the C-Reduce."
 readme = "README.md"
 license = { file = "COPYING" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [tool.ruff]
 exclude = ["objdir", "tree-sitter", "tree-sitter-cpp"]
@@ -25,7 +25,7 @@ quote-style="single"
 
 [tool.pyright]
 exclude = ["objdir", "tree-sitter", "tree-sitter-cpp"]
-pythonVersion = "3.9"
+pythonVersion = "3.10"
 reportOptionalCall = false
 reportOptionalMemberAccess = false
 reportOptionalOperand = false


### PR DESCRIPTION
Stop advertising Python 3.9 as the minimal support version - this Python version has reached its "end of life", and maintaining compatibility shims causes extra burden and makes some optimizations hard to enable.

Starting from this commit, C-Vise code base assumes Python 3.10+.