### PR TITLE
test_manager: Only calc size diff for successful transforms

### DIFF
--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -127,7 +127,6 @@ class TestEnvironment:
     ):
         self.state = state
         self.folder: Path = folder
-        self.original_size = None
         self.test_script = test_script
         self.exitcode = None
         self.result = None
@@ -137,9 +136,11 @@ class TestEnvironment:
         self.test_case: Path = test_case
         self.should_copy_test_cases = should_copy_test_cases
         self.all_test_cases: set[Path] = all_test_cases
+        self.original_size: int | None = None
+        self.new_size: int | None = None
 
     @property
-    def size_improvement(self):
+    def size_improvement(self) -> int:
         assert self.success
         assert self.original_size is not None
         assert self.new_size is not None


### PR DESCRIPTION
Postpone calculating the original test case size until we know it's actually needed - i.e., the transformation passed the interestingness test. Also cache the new file size, so that accessing the "size_improvement" property (which happens twice or thrice) doesn't lead to recalculating it again.

This optimization helps big multi-file inputs, where calculating the total size takes a non-neglibile time (due to the need to traverse the directory tree).