### PR TITLE
test_manager: Specify cwd instead of doing chdir

### DIFF
--- a/cvise/tests/test_cache.py
+++ b/cvise/tests/test_cache.py
@@ -1,6 +1,7 @@
 import tempfile
 import uuid
 from collections.abc import Iterator
+import os
 from pathlib import Path
 
 import pytest
@@ -12,8 +13,12 @@ from cvise.utils.cache import Cache
 
 @pytest.fixture(autouse=True)
 def cd_to_tmp_path(tmp_path: Path) -> Iterator[None]:
-    with fileutil.chdir(tmp_path):
+    original_workdir = os.getcwd()
+    os.chdir(tmp_path)
+    try:
         yield
+    finally:
+        os.chdir(original_workdir)
 
 
 @pytest.fixture

--- a/cvise/utils/fileutil.py
+++ b/cvise/utils/fileutil.py
@@ -34,17 +34,6 @@ def CloseableTemporaryFile(mode='w+b', dir: Path | None = None):
             yield f
 
 
-# TODO: use contextlib.chdir once Python 3.11 is the oldest supported release
-@contextlib.contextmanager
-def chdir(path: Path) -> Iterator[None]:
-    original_workdir = os.getcwd()
-    os.chdir(path)
-    try:
-        yield
-    finally:
-        os.chdir(original_workdir)
-
-
 class TmpDirManager:
     TEMP_PREFIX = 'cvise-'
     JANITOR_INTERVAL = 10  # seconds

--- a/cvise/utils/testing.py
+++ b/cvise/utils/testing.py
@@ -198,19 +198,18 @@ class TestEnvironment:
             return self
 
     def run_test(self, verbose):
-        with fileutil.chdir(self.folder):
-            # Make the job use our custom temp dir instead of the standard one, so that the standard location doesn't
-            # get cluttered with files it might leave undeleted (the process might do this because of an oversight in
-            # the interestingness test, or because C-Vise abruptly kills our job without a chance for a proper cleanup).
-            with tempfile.TemporaryDirectory(dir=self.folder, prefix='overridetmp') as tmp_override:
-                env = override_tmpdir_env(os.environ.copy(), Path(tmp_override))
-                stdout, stderr, returncode = ProcessEventNotifier(self.pid_queue).run_process(
-                    str(self.test_script), shell=True, env=env
-                )
-            if verbose and returncode != 0:
-                # Drop invalid UTF sequences.
-                logging.debug('stdout:\n%s', stdout.decode('utf-8', 'ignore'))
-                logging.debug('stderr:\n%s', stderr.decode('utf-8', 'ignore'))
+        # Make the job use our custom temp dir instead of the standard one, so that the standard location doesn't get
+        # cluttered with files it might leave undeleted (the process might do this because of an oversight in the
+        # interestingness test, or because C-Vise abruptly kills our job without a chance for a proper cleanup).
+        with tempfile.TemporaryDirectory(dir=self.folder, prefix='overridetmp') as tmp_override:
+            env = override_tmpdir_env(os.environ.copy(), Path(tmp_override))
+            stdout, stderr, returncode = ProcessEventNotifier(self.pid_queue).run_process(
+                str(self.test_script), shell=True, env=env, cwd=self.folder
+            )
+        if verbose and returncode != 0:
+            # Drop invalid UTF sequences.
+            logging.debug('stdout:\n%s', stdout.decode('utf-8', 'ignore'))
+            logging.debug('stderr:\n%s', stderr.decode('utf-8', 'ignore'))
         return returncode
 
 


### PR DESCRIPTION
When launching the interestingness test, run it with the custom cwd instead of doing chdir in the C-Vise process.

This fixes a race condition, when a worker process could've been launched in the middle of check_sanity() and inherit a wrong cwd, resulting in all future jobs in that worker not being able to read the input file.