### PR TITLE
[ci] Add testing on Python 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
       fail-fast: false
 
     steps:


### PR DESCRIPTION
The only blocker - the msgspec library - has gotten an update 0.20.0. C-Vise is expected to be fully compatible with Python 3.14 now.