### PR TITLE
docs: Recommend Pebble 5.1.1+

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,7 +84,7 @@ manager:
 
 * [Python 3.10+](https://www.python.org/downloads/)
 
-* [Pebble](https://pypi.org/project/Pebble/)
+* [Pebble (5.1.1+ recommended)](https://pypi.org/project/Pebble/)
 
 * [chardet](https://pypi.org/project/chardet/)
 


### PR DESCRIPTION
Before this version, that library had an issue that was causing a significant slowdown of C-Vise.