### PR TITLE
[help] Mention that input can be a directory

### DIFF
--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -307,7 +307,7 @@ def main():
         nargs='?',
         help='Executable to check interestingness of test cases',
     )
-    parser.add_argument('test_cases', metavar='TEST_CASE', nargs='+', help='Test cases')
+    parser.add_argument('test_cases', metavar='TEST_CASE', nargs='+', help='Test cases (files or directories)')
     parser.add_argument(
         '--stopping-threshold',
         default=1.0,


### PR DESCRIPTION
The support of reducing test cases that are directories was implemented
as part of #221.