### PR TITLE
clex: Fix macOS build with system Flex

### DIFF
--- a/clex/CMakeLists.txt
+++ b/clex/CMakeLists.txt
@@ -18,6 +18,12 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
 endif()
 
+# Some versions of Flex (e.g., the macOS-provided one) define "yyleng" as being
+# of the "yy_size_t" type, which is size_t by default; override it to int to be
+# compatible with other versions.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Dyy_size_t=int -DYY_TYPEDEF_YY_SIZE_T")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Dyy_size_t=int -DYY_TYPEDEF_YY_SIZE_T")
+
 ###############################################################################
 
 project(clex)


### PR DESCRIPTION
This fixes the error:

```
  defs.h:22:12: error: redeclaration of 'yyleng' with a different
                type: 'int' vs 'yy_size_t' (aka 'unsigned long')
   22 | extern int yyleng;
      |            ^
  strlex.c:271:11: note: previous definition is here
  271 | yy_size_t yyleng;
```

The system-provided version of Flex defines yyleng differently than on majority of other platforms, using yy_size_t == size_t instead of int. To avoid the compilation error in the particular environment, this commit overrides the type to unconditionally be "int" (even if size_t might in theory be a better choice for huge files).