### PR TITLE
[tests] Fix tests for macOS

### DIFF
--- a/cvise/tests/test_makefile.py
+++ b/cvise/tests/test_makefile.py
@@ -201,7 +201,7 @@ c.o:
 
 
 def test_remove_argument_from_all_commands(tmp_path: Path, test_case_path: Path):
-    (test_case_path / 'makefile').write_text(
+    (test_case_path / 'Makefile').write_text(
         """
 a.out:
 \tgcc -ansi foo.c
@@ -215,7 +215,7 @@ b.out:
     # "-ansi" removed from all commands
     assert (
         (
-            'makefile',
+            'Makefile',
             b"""
 a.out:
 \tgcc foo.c
@@ -227,7 +227,7 @@ b.out:
 
 
 def test_continuation(tmp_path: Path, test_case_path: Path):
-    (test_case_path / 'makefile').write_text(
+    (test_case_path / 'Makefile').write_text(
         """
 a.out:
 \tgcc -ansi foo.c
@@ -245,7 +245,7 @@ b.out: \\
     # "-ansi" removed from all commands
     assert (
         (
-            'makefile',
+            'Makefile',
             b"""
 a.out:
 \tgcc foo.c

--- a/cvise/tests/test_test_manager.py
+++ b/cvise/tests/test_test_manager.py
@@ -590,7 +590,7 @@ def test_subprocess_termination(manager: testing.TestManager):
 def _find_processes_by_cmd_line(needle: str) -> list[psutil.Process]:
     processes = []
     for proc in psutil.process_iter():
-        with contextlib.suppress(psutil.NoSuchProcess, psutil.ZombieProcess):
+        with contextlib.suppress(psutil.NoSuchProcess, psutil.ZombieProcess, psutil.AccessDenied):
             if needle in proc.cmdline():
                 processes.append(proc)
     return processes


### PR DESCRIPTION
* Fix makefile-related code for case-insensitive file systems (don't think "makefile" and "Makefile" are two different files if there's only one, and deterministically choose one spelling for hints).
* Ignore AccessDenied error in the subprocess termination tests when enumerating system processes.
* Run subprocesses with the same Python interpreter as the test itself, fixing import errors in integration-like tests.
* Account for a different linker behavior on macOS in the test with duplicate symbols (variables need to be used and not just declared, and main() remains in the output since omitting it prevents the duplicate symbols error).