### PR TITLE
cli: Don't require arguments for --list-passes

### DIFF
--- a/cvise-cli.py
+++ b/cvise-cli.py
@@ -307,7 +307,7 @@ def main():
         nargs='?',
         help='Executable to check interestingness of test cases',
     )
-    parser.add_argument('test_cases', metavar='TEST_CASE', nargs='+', help='Test cases (files or directories)')
+    parser.add_argument('test_cases', metavar='TEST_CASE', nargs='*', help='Test cases (files or directories)')
     parser.add_argument(
         '--stopping-threshold',
         default=1.0,
@@ -329,6 +329,15 @@ def main():
     )
 
     args = parser.parse_args()
+
+    # Shift interestingness_test to test_cases if --commands is used,
+    # or if it's the only positional argument (to match argparse nargs='+' behavior)
+    if args.interestingness_test is not None and (args.commands is not None or not args.test_cases):
+        args.test_cases.insert(0, args.interestingness_test)
+        args.interestingness_test = None
+
+    if not args.list_passes and not args.test_cases:
+        parser.error('the following arguments are required: TEST_CASE')
 
     log_config = {}
 
@@ -420,11 +429,6 @@ def do_reduce(args):
     if not args.interestingness_test and not args.commands:
         print('Either INTERESTINGNESS_TEST or --commands must be used!')
         sys.exit(1)
-
-    # shift interestingness_test if --commands is used
-    if args.interestingness_test and args.commands:
-        args.test_cases.insert(0, args.interestingness_test)
-        args.interestingness_test = None
 
     test_cases = [Path(s) for s in args.test_cases]
 

--- a/tests/test_cvise.py
+++ b/tests/test_cvise.py
@@ -567,5 +567,20 @@ def test_failing_interestingness_test(tmp_path: Path, overridden_subprocess_tmpd
     assert 'interestingness test does not return' in stdout
 
 
+def test_list_passes(tmp_path: Path, overridden_subprocess_tmpdir: Path):
+    """Test that --list-passes works without providing an interestingness test or test cases."""
+    proc = start_cvise(
+        ['--list-passes'],
+        tmp_path,
+        overridden_subprocess_tmpdir,
+    )
+    stdout, stderr = proc.communicate()
+    assert proc.returncode == 0, (
+        f'Process failed with exit code {proc.returncode}; stderr:\n{stderr}\nstdout:\n{stdout}'
+    )
+    assert 'Available passes:' in stdout
+    assert_subprocess_tmpdir_empty(overridden_subprocess_tmpdir)
+
+
 def _read_files_in_dir(dir: Path) -> dict[str, str]:
     return {str(p.relative_to(dir)): p.read_text() for p in dir.rglob('*') if not p.is_dir()}


### PR DESCRIPTION
Fix the issue that "--list-passes" didn't work alone and required passing a dummy (unused) argument.

Fixes #488.