### PR TITLE
ci: Bump checkout action version

### DIFF
--- a/.github/workflows/build-llvm-nightly.yml
+++ b/.github/workflows/build-llvm-nightly.yml
@@ -33,7 +33,7 @@ jobs:
       - run: apt-get install -y bolt-22 clang-22 libclang-common-22-dev libclang-22-dev mlir-22-tools llvm-22-tools libclang-common-22-dev libclang-22-dev libclang1-22 clang-format-22 python3-clang-22 clangd-22 clang-tidy-22 libomp-22-dev
       # TODO: remove in the future
       - run: touch /usr/lib/llvm-22/lib/libLibcTableGenUtil.a
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: mkdir objdir
       - run: cmake ..
         working-directory: objdir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
     - uses: rui314/setup-mold@v1
     - run: ld --version
     - run: nproc
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: build
       run: |
             mkdir objdir
@@ -94,7 +94,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - run: apt-get update
     - run: apt-get -qq install -y gcc g++ wget lsb-release wget software-properties-common gnupg git cmake flex vim unifdef sudo
     - run: chown -R $(whoami) /github/home  # workaround for "directory ... pip ... is not owned or is not writable by the current user"
@@ -122,7 +122,7 @@ jobs:
 
     steps:
     - run: zypper -n install python3-pip
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - run: pip install --break-system-packages ruff
     - run: ruff check
     - run: ruff format --diff
@@ -134,7 +134,7 @@ jobs:
 
     steps:
     - run: zypper -n install binutils clang-devel cmake flex gcc-c++ llvm-devel python312
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: prepare venv
       # Pytype currently only supports Python <=3.12
       run: |
@@ -164,7 +164,7 @@ jobs:
         python3-Pebble python3-pytest python3-pytest-mock python3-pytest-subprocess
         unifdef python3-psutil curl git python3-chardet findutils sudo wget python3-jsonschema
         python3-msgspec python3-zstandard
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - run: mkdir objdir
     - run: cmake ..
       working-directory: objdir


### PR DESCRIPTION
This fixes the following warning on Github Actions bots: "Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4."