### PR TITLE
tests: Add output variant for blocksort-part.c reduction

### DIFF
--- a/tests/test_cvise.py
+++ b/tests/test_cvise.py
@@ -67,7 +67,7 @@ def test_simple_reduction(tmp_path: Path, overridden_subprocess_tmpdir: Path):
     check_cvise(
         'blocksort-part.c',
         ['-c', r"gcc -c blocksort-part.c && grep '\<nextHi\>' blocksort-part.c"],
-        ['#define nextHi', '#define nextHi\n', '#undef nextHi', '#undef nextHi\n'],
+        ['#define nextHi', '#define nextHi\n', '#undef nextHi', '#undef nextHi\n', 'nextHi;'],
         tmp_path,
         overridden_subprocess_tmpdir,
     )
@@ -77,7 +77,7 @@ def test_simple_reduction_no_interleaving_config(tmp_path: Path, overridden_subp
     check_cvise(
         'blocksort-part.c',
         ['-c', r"gcc -c blocksort-part.c && grep '\<nextHi\>' blocksort-part.c", '--pass-group', 'no-interleaving'],
-        ['#define nextHi', '#define nextHi\n', '#undef nextHi', '#undef nextHi\n'],
+        ['#define nextHi', '#define nextHi\n', '#undef nextHi', '#undef nextHi\n', 'nextHi;'],
         tmp_path,
         overridden_subprocess_tmpdir,
     )
@@ -253,7 +253,7 @@ def test_non_ascii_interestingness_test(tmp_path: Path, overridden_subprocess_tm
     check_cvise(
         'blocksort-part.c',
         ['-c', r"printf '\xc3\xa4\xff'; gcc -c blocksort-part.c && grep '\<nextHi\>' blocksort-part.c"],
-        ['#define nextHi', '#define nextHi\n', '#undef nextHi', '#undef nextHi\n'],
+        ['#define nextHi', '#define nextHi\n', '#undef nextHi', '#undef nextHi\n', 'nextHi;'],
         tmp_path,
         overridden_subprocess_tmpdir,
     )


### PR DESCRIPTION
Resolve a flakiness reason in the tests that reduce blocksort-part.c: there's one more output variant possible (the reduction is non-deterministic).