### PR TITLE
clex: Don't trim last newline in files

### DIFF
--- a/clex/driver.c
+++ b/clex/driver.c
@@ -15,6 +15,7 @@
 
 #include <assert.h>
 #include <limits.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -302,7 +303,13 @@ static void rm_toks(int idx) {
       }
       which++;
     }
-    if (!started || (which > (idx + n_toks)))
+    bool should_print = !started || (which > (idx + n_toks));
+    // Do not consume the file-terminating newline.
+    if (!should_print && tok_list[i].kind == TOK_NEWLINE &&
+        (i + 1 == toks || tok_list[i + 1].path_id != tok_list[i].path_id)) {
+      should_print = true;
+    }
+    if (should_print)
       printf("%s", tok_list[i].str);
   }
   if (matched) {
@@ -326,6 +333,11 @@ static void hints_toks(void) {
            (tok_list[i + 1].kind == TOK_WS ||
             tok_list[i + 1].kind == TOK_NEWLINE) &&
            tok_list[i + 1].path_id == tok_list[i].path_id) {
+      // Do not consume the file-terminating newline.
+      if (tok_list[i + 1].kind == TOK_NEWLINE &&
+          (i + 2 == toks || tok_list[i + 2].path_id != tok_list[i].path_id)) {
+        break;
+      }
       ++i;
     }
     int cut_end = tok_list[i].start_pos + tok_list[i].len;

--- a/cvise/tests/test_clexhints.py
+++ b/cvise/tests/test_clexhints.py
@@ -61,6 +61,7 @@ void f() {
     b"""
 void f() {
     char x;
+
 """,
 ]
 
@@ -99,11 +100,12 @@ void f() {
 """,
     b"""
 void f() {
-    char x""",
+    char x
+""",
 ]
 
 TOKENS_REMOVED_8 = [
-    b'\n',
+    b'\n\n',
 ]
 
 
@@ -244,8 +246,8 @@ def test_directory_input_leading_trailing_spaces(tmp_path: Path):
     p, state = init_pass('rm-toks-1-to-1', tmp_path, test_case)
     all_transforms = collect_all_transforms_dir(p, state, test_case)
 
-    assert (('a.txt', b'\n'), ('b.txt', b'\nchar\n')) in all_transforms
-    assert (('a.txt', b'\nint\n'), ('b.txt', b'\n')) in all_transforms
+    assert (('a.txt', b'\n\n'), ('b.txt', b'\nchar\n')) in all_transforms
+    assert (('a.txt', b'\nint\n'), ('b.txt', b'\n\n')) in all_transforms
 
 
 def test_directory_unclosed_c_comment(tmp_path: Path):


### PR DESCRIPTION
Change the clex-based heuristics to avoid truncating the terminating line break character.

This is intended to be a mostly cosmetic change (by a common convention, text files end with a newline), but will also help reduce nondeterminism in tests.