### PR TITLE
ci: Set timeouts on jobs

### DIFF
--- a/.github/workflows/build-llvm-nightly.yml
+++ b/.github/workflows/build-llvm-nightly.yml
@@ -18,6 +18,7 @@ jobs:
 
   CI-LLVM-nightly:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     container:
       image: ubuntu:25.04
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   CI:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     strategy:
       matrix:
@@ -61,6 +62,7 @@ jobs:
 
   CI-macos:
     runs-on: macos-latest
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v6
@@ -79,6 +81,7 @@ jobs:
 
   CI-python:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
       image: ubuntu:latest
 
@@ -117,6 +120,7 @@ jobs:
 
   ruff:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
       image: opensuse/tumbleweed
 
@@ -129,6 +133,7 @@ jobs:
 
   pytype:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
       image: opensuse/tumbleweed
 
@@ -155,6 +160,7 @@ jobs:
 
   pyright:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
       image: opensuse/tumbleweed
 


### PR DESCRIPTION
If a test gets hung, the timeouts will let the developer be notified faster rather than waiting for the default github actions timeout (which currently is 6 hours).

The manual timeouts are set at 1.5-4x of the typical execution times that have been observed in practice.