### PR TITLE
tests: Initialize sigmonitor where needed

### DIFF
--- a/cvise/tests/test_clangincludegraph.py
+++ b/cvise/tests/test_clangincludegraph.py
@@ -9,6 +9,12 @@ from cvise.tests.testabstract import load_ref_hints, validate_stored_hints
 from cvise.utils.externalprograms import find_external_programs
 from cvise.utils.hint import Hint, HintBundle, load_hints
 from cvise.utils.process import ProcessEventNotifier
+from cvise.utils import sigmonitor
+
+
+@pytest.fixture(autouse=True)
+def signal_monitor():
+    sigmonitor.init()
 
 
 def init_pass(tmp_dir: Path, input_path: Path) -> tuple[ClangIncludeGraphPass, Any]:

--- a/cvise/tests/test_clexhints.py
+++ b/cvise/tests/test_clexhints.py
@@ -9,6 +9,13 @@ from cvise.passes.clexhints import ClexHintsPass
 from cvise.tests.testabstract import collect_all_transforms, collect_all_transforms_dir, validate_stored_hints
 from cvise.utils.externalprograms import find_external_programs
 from cvise.utils.process import ProcessEventNotifier
+from cvise.utils import sigmonitor
+
+
+@pytest.fixture(autouse=True)
+def signal_monitor():
+    sigmonitor.init()
+
 
 # How many times to repeat each test that involves randomness (for extra reassurance).
 RANDOM_TEST_REPETITIONS = 10

--- a/cvise/tests/test_ifs.py
+++ b/cvise/tests/test_ifs.py
@@ -5,6 +5,13 @@ from typing import Any
 
 from cvise.passes.abstract import ProcessEventNotifier
 from cvise.passes.ifs import IfPass
+from cvise.utils import sigmonitor
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def signal_monitor():
+    sigmonitor.init()
 
 
 class LineMarkersTestCase(unittest.TestCase):

--- a/cvise/tests/test_treesitter.py
+++ b/cvise/tests/test_treesitter.py
@@ -7,6 +7,13 @@ from cvise.passes.treesitter import TreeSitterPass
 from cvise.tests.testabstract import collect_all_transforms, collect_all_transforms_dir, validate_stored_hints
 from cvise.utils.externalprograms import find_external_programs
 from cvise.utils.process import ProcessEventNotifier
+from cvise.utils import sigmonitor
+
+
+@pytest.fixture(autouse=True)
+def signal_monitor():
+    sigmonitor.init()
+
 
 REPLACE_FUNC_DEF = 'replace-function-def-with-decl'
 ERASE_NAMESPACE = 'erase-namespace'


### PR DESCRIPTION
Don't rely on other test files to do the initialization - this doesn't work when a particular test is executed.

The sigmonitor is used, e.g., for using the utility for child process launching.