### PR TITLE
[clex] Treat double-angle-bracket as two tokens

### DIFF
--- a/clex/clex.l
+++ b/clex/clex.l
@@ -94,8 +94,6 @@ L?\"(\\.|[^\\"])*\"	{ process_token(TOK_STRING); }
 "&="			{ process_token(TOK_OP); }
 "^="			{ process_token(TOK_OP); }
 "|="			{ process_token(TOK_OP); }
-">>"			{ process_token(TOK_OP); }
-"<<"			{ process_token(TOK_OP); }
 "++"			{ process_token(TOK_OP); }
 "--"			{ process_token(TOK_OP); }
 "->"			{ process_token(TOK_OP); }

--- a/cvise/CMakeLists.txt
+++ b/cvise/CMakeLists.txt
@@ -107,6 +107,7 @@ set(SOURCE_FILES
   "tests/test_clanghints.py"
   "tests/test_clangincludegraph.py"
   "tests/test_clangmodulemap.py"
+  "tests/test_clex.py"
   "tests/test_clexhints.py"
   "tests/test_comments.py"
   "tests/test_fileutil.py"

--- a/cvise/tests/test_clex.py
+++ b/cvise/tests/test_clex.py
@@ -1,0 +1,46 @@
+import shutil
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cvise.passes.abstract import PassResult
+from cvise.passes.clex import ClexPass
+from cvise.utils.externalprograms import find_external_programs
+from cvise.utils.process import ProcessEventNotifier
+from cvise.utils import sigmonitor
+
+
+@pytest.fixture(autouse=True)
+def signal_monitor():
+    sigmonitor.init()
+
+
+@pytest.fixture
+def input_path(tmp_path: Path) -> Path:
+    return tmp_path / 'input.cc'
+
+
+def init_clex_pass(arg: str, input_path: Path) -> tuple[ClexPass, Any]:
+    pass_ = ClexPass(arg, find_external_programs())
+    state = pass_.new(input_path)
+    return pass_, state
+
+
+def test_clex_pattern_nested_brackets(tmp_path: Path, input_path: Path):
+    """Test the scenario of "flattening" a generic; it's crucial that >> is treated as two tokens."""
+    input_path.write_text('Foo<Bar<Baz>>')
+    pass_, state = init_clex_pass('rm-tok-pattern-4', input_path)
+    all_transforms = set()
+
+    while state is not None:
+        test_case = tmp_path / 'test.cc'
+        shutil.copy(input_path, test_case)
+        result, _new_state = pass_.transform(test_case, state, process_event_notifier=ProcessEventNotifier(None))
+        if result == PassResult.OK:
+            all_transforms.add(test_case.read_bytes())
+        elif result == PassResult.STOP:
+            break
+        state = pass_.advance(input_path, state)
+
+    assert b'Foo<Baz>' in all_transforms

--- a/cvise/tests/test_clexhints.py
+++ b/cvise/tests/test_clexhints.py
@@ -293,3 +293,12 @@ def test_directory_file_reading_failure(tmp_path: Path):
     all_transforms = collect_all_transforms_dir(p, state, test_case)
 
     assert all_transforms == set()
+
+
+def test_nested_brackets(tmp_path: Path, input_path: Path):
+    """Test that clex does not treat >> or << as a single token, allowing reduction of nested generics."""
+    input_path.write_text('Foo<Bar<Baz>>')
+    p, state = init_pass('rm-toks-1-to-1', tmp_path, input_path)
+    all_transforms = collect_all_transforms(p, state, input_path)
+
+    assert b'Foo<Bar<Baz>' in all_transforms


### PR DESCRIPTION
Do not combine two brackets in "<<" or ">>" into a single token in Clex. This is not always the case in modern C++, and may also inhibit the reduction of programs in other languages (e.g., generics in Rust).

Note that for the cases where "<<"/">>" does indeed need to be removed as a whole, the passes that remove at least 2 consecutive clex tokens will do the job.