### PR TITLE
CMakeLists.txt: embed unabbreviated git hash to release tarball

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ endif()
 # `git archive' inserts the abbreviated hash of the archive's commit into this
 # file.  (See the `.gitattributes' file.)
 #
-set(GIT_HASH "$Format:%h$")
+set(GIT_HASH "$Format:%H$")
 if(GIT_HASH MATCHES "^\\$")
   ## METHOD 2: The source tree is a git repository.
   get_git_head_revision(GIT_REFSPEC GIT_HASH)


### PR DESCRIPTION
Due to use of abbreviated hash `cvise` release tarball drifts occasionally when re-fetched from github. My recent diff against `2.12.0`:

```diff
$ diffoscope before/ after/
--- before/
+++ after/
│   --- before/CMakeLists.txt
├── +++ after/CMakeLists.txt
│ @@ -84,15 +84,15 @@
│
│  # Determine the short git hash for the source tree.
│  #
│  ## METHOD 1: The source tree is the result of `git archive'.
│  # `git archive' inserts the abbreviated hash of the archive's commit into this
│  # file.  (See the `.gitattributes' file.)
│  #
│ -set(GIT_HASH "2d0889e7")
│ +set(GIT_HASH "2d0889e73")
```

The change uses full unabbreviated hash which should depend less on `git` version to construct archives.