### PR TITLE
Fix test_dir_linker_duplicate_var_error on non-english locales

### DIFF
--- a/tests/test_cvise.py
+++ b/tests/test_cvise.py
@@ -317,7 +317,7 @@ clean:
     proc = start_cvise(
         [
             '-c',
-            f"(make -C repro 2>&1 || true) | awk '{{ print }} /{ERROR_REGEX}/ {{ y=1 }} END {{ exit !y }}'",
+            f"(LC_ALL=C make -C repro 2>&1 || true) | awk '{{ print }} /{ERROR_REGEX}/ {{ y=1 }} END {{ exit !y }}'",
             'repro',
             '--tidy',
         ],


### PR DESCRIPTION
If the host machine is running another locale language other than english, the test `test_dir_linker_duplicate_var_error` fails because the searched string is not found.  Fix this by enforcing that make is called with `LC_ALL=C`.