### PR TITLE
subprocesses: Exit job on orphan i/o streams

### DIFF
--- a/cvise/utils/process.py
+++ b/cvise/utils/process.py
@@ -358,6 +358,13 @@ class ProcessEventNotifier:
             except subprocess.TimeoutExpired:
                 if step_timeout == 0:
                     raise  # we reached the original timeout, so bail out
+
+                # If the child process has already exited but orphaned descendants keep the pipes open, communicate()
+                # will wait for EOF forever. In this case, we close the pipes and bail out.
+                if proc.poll() is not None:
+                    _close_pipes(proc)
+                    return proc.communicate(input=b'')  # type: ignore[arg-type]
+
                 input = b''  # the input has been written in the first communicate() call
 
 
@@ -448,15 +455,20 @@ def _auto_kill_on_timeout(proc: subprocess.Popen) -> Iterator[None]:
         raise
 
 
-def _kill(proc: subprocess.Popen) -> None:
-    # First, close i/o streams opened for PIPE. This allows us to simply use wait() to wait for the process completion.
-    # Additionally, it acts as another indication (SIGPIPE on *nix) for the process and its grandchildren to exit.
+def _close_pipes(proc: subprocess.Popen) -> None:
+    """Closes all i/o streams opened for PIPE."""
     if proc.stdin is not None:
         proc.stdin.close()
     if proc.stdout is not None:
         proc.stdout.close()
     if proc.stderr is not None:
         proc.stderr.close()
+
+
+def _kill(proc: subprocess.Popen) -> None:
+    # First, close i/o streams. This allows us to simply use wait() to wait for the process completion.
+    # Additionally, it acts as another indication (SIGPIPE on *nix) for the process and its grandchildren to exit.
+    _close_pipes(proc)
 
     # Second, attempt graceful termination (SIGTERM on *nix). We wait for some timeout that's less than Pebble's
     # term_timeout, so that we (hopefully) have time to try hard termination before C-Vise main process kills us.

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,0 +1,33 @@
+import os
+import time
+
+import pytest
+
+from cvise.utils import sigmonitor
+from cvise.utils.process import ProcessEventNotifier
+
+
+@pytest.mark.skipif(os.name != 'posix', reason='requires POSIX for command-line tools')
+def test_run_process_orphaned_pipes_no_hang():
+    """
+    Regression test: Ensure that an orphaned background process keeping the stdout/stderr pipes open does not cause
+    run_process to hang indefinitely when timeout=None.
+    """
+    sigmonitor.init()
+    notifier = ProcessEventNotifier(pid_queue=None)
+
+    # We use a subshell that launches a background sleep. The background process inherits the stdout/stderr pipes.
+    # The main shell process will exit immediately, but without the fix, C-Vise would hang waiting for the pipes to
+    # close.
+    script = 'sleep 100 & exit 0'
+
+    start_time = time.monotonic()
+
+    stdout, stderr, returncode = notifier.run_process(['sh', '-c', script], timeout=None)
+
+    elapsed = time.monotonic() - start_time
+
+    # The process should exit almost immediately. If it hangs for 100 seconds, or times out via an external mechanism,
+    # this will fail.
+    assert elapsed < 10.0, f'run_process took {elapsed}s, likely hung on orphaned pipes!'
+    assert returncode == 0


### PR DESCRIPTION
Prevent hanging a job until reaching the timeout in case the interestingness test's process exits, however its stdout/stderr streams remain open (e.g., due to child processes).

Fixes #508