### PR TITLE
ci: Fix mold error in tests

### DIFF
--- a/.github/workflows/build-llvm-nightly.yml
+++ b/.github/workflows/build-llvm-nightly.yml
@@ -29,6 +29,8 @@ jobs:
       - run: ${{ env.RETRY }} apt-get update
       - run: ${{ env.RETRY }} apt-get -qq install -y gcc g++ wget lsb-release wget software-properties-common gnupg git cmake flex mawk python3-pebble python3-psutil python3-chardet python3-msgspec python3-pytest python3-pytest-mock python3-pytest-subprocess python3-jsonschema python3-zstandard vim unifdef sudo
       - uses: rui314/setup-mold@v1
+        with:
+          make-default: false
       - run: ld --version
       - run: nproc
       - run: ${{ env.RETRY }} wget https://apt.llvm.org/llvm.sh
@@ -39,7 +41,7 @@ jobs:
       - run: touch /usr/lib/llvm-22/lib/libLibcTableGenUtil.a
       - uses: actions/checkout@v6
       - run: mkdir objdir
-      - run: cmake ..
+      - run: cmake .. -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=mold" -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=mold"
         working-directory: objdir
       - run: make -j`nproc` VERBOSE=1
         working-directory: objdir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,8 @@ jobs:
     - run: ${{ env.RETRY }} zypper -n install sqlite-devel python3
     - run: ${{ env.RETRY }} pip install --break-system-packages pytest-cov
     - uses: rui314/setup-mold@v1
+      with:
+        make-default: false
     - run: ld --version
     - run: nproc
     - uses: actions/checkout@v6
@@ -58,7 +60,7 @@ jobs:
       run: |
             mkdir objdir
             cd objdir
-            ${{ matrix.env }} cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_FLAGS=${{ matrix.extra-flags }}
+            ${{ matrix.env }} cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_FLAGS="${{ matrix.extra-flags }}" -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=mold" -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=mold"
             make -j`nproc` VERBOSE=1
     - name: test
       run: pytest


### PR DESCRIPTION
Fix the incompatibility of setting Mold as the system-level default linker with Clang's recent probing logic for linkers: this was causing "mold: fatal: -m option is missing" errors in tests on Github actions.

Instead, we only specify Mold to CMake for build steps, while keeping the system-wide linker at its default.