### PR TITLE
tests: make test_interleaving_lines_passes reduction unique

### DIFF
--- a/tests/test_cvise.py
+++ b/tests/test_cvise.py
@@ -168,7 +168,18 @@ def test_interleaving_lines_passes(tmp_path: Path, overridden_subprocess_tmpdir:
         """)
 
     proc = start_cvise(
-        ['-c', 'gcc -c test.c && grep foo test.c', '--pass-group-file', str(config_path), testcase_path.name],
+        [
+            '-c',
+            # -Werror=implicit-function-declaration makes the reduction below unique. Without it, GCC <= 13 also
+            # accepts "int main() { return foo(); }" (an implicit declaration is merely a warning there), so which
+            # of the two results we end up with depends on which interleaved pass happens to win the race.
+            # Plain -Werror is not usable: it would reject the expected result too, whose non-void foo() falls off
+            # the end and trips -Wreturn-type.
+            'gcc -c -Werror=implicit-function-declaration test.c && grep foo test.c',
+            '--pass-group-file',
+            str(config_path),
+            testcase_path.name,
+        ],
         tmp_path,
         overridden_subprocess_tmpdir,
     )


### PR DESCRIPTION
`test_interleaving_lines_passes` asserts one exact reduced output:

```c
int foo() {
}
```

but its interestingness test is `gcc -c test.c && grep foo test.c`, which on GCC <= 13 also accepts

```c
int main() {
  return foo();
}
```

because an implicit declaration of `foo()` is merely a warning there. GCC 14 turned `-Wimplicit-function-declaration` into an error by default, so on a newer compiler only the expected form survives.

With two admissible reductions the outcome is decided by which of the three interleaved `lines` passes happens to win the race, so the test fails intermittently on any distribution still shipping GCC 13. openSUSE Leap 16.0 and 16.1 both ship gcc 13.4 and both fail this test, while Tumbleweed (GCC 16) passes. CI runs on openSUSE Tumbleweed, which is why this is not visible upstream.

This pins the interestingness test to the stricter behaviour so the reduction is unique on every compiler.

Note that `-Wall -Werror` (as used by the neighbouring tests, e.g. `test_non_ascii`) is **not** usable here: it would also reject the expected result, whose non-void `foo()` falls off the end and trips `-Wreturn-type`.

Verified against both compilers:

| testcase | gcc 13 | gcc 15 |
| --- | --- | --- |
| `int foo() { }` (expected) | compiles | compiles |
| `int main() { return foo(); }` | rejected | rejected |

With the patch applied, the full suite passes on openSUSE Leap 16.0 aarch64, where it previously failed with:

```
FAILED tests/test_cvise.py::test_interleaving_lines_passes - AssertionError:
assert "\n int main() {\n return foo();\n }\n " == "\n int foo() {\n }\n "
```

`ruff check` and `ruff format --diff` are both clean.